### PR TITLE
ci: correct gh api client_payload syntax for repository dispatch (fix)

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -63,8 +63,9 @@ jobs:
       - name: Trigger release build
         run: |
           gh api repos/${{ github.repository }}/dispatches \
-            -f event_type=release-build \
-            -f client_payload='{"version":"${{ inputs.version }}","draft":${{ inputs.draft }}}'
+            --raw-field event_type=release-build \
+            --field client_payload[version]="${{ inputs.version }}" \
+            --field client_payload[draft]=${{ inputs.draft }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Fix the `repository_dispatch` API call in `release-tag.yml` that was failing with:

```
gh: Invalid request.
For 'properties/client_payload', "{\"version\":\"0.1.1\",\"draft\":true}" is not an object.
```

## Changes

Changed from passing JSON string (incorrect):
```bash
-f client_payload='{"version":"0.1.1","draft":true}'
```

To using `--field` with nested object syntax (correct):
```bash
--raw-field event_type=release-build \
--field client_payload[version]="${{ inputs.version }}" \
--field client_payload[draft]=${{ inputs.draft }}
```

## Testing

After merging, you can test by:
1. Deleting the existing tag: `git push origin :refs/tags/v0.1.1`
2. Running "Release - Tag & Build" workflow with version `0.1.1`