### PR TITLE
docs: link signed-commits guide in README and clarify CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,9 +201,11 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) t
 
 ## Signed Commits
 
-We prefer signed commits so GitHub can verify contributions. Follow the setup guide:
+We prefer signed commits so GitHub can verify contributions and display the "Verified" badge on your commits. Follow the setup guide:
 
 - docs/signed-commits.md
+
+If you cannot sign commits for a specific contribution, please mention it in your pull request so maintainers have the right context.
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ See [AGENTS.md](AGENTS.md) for detailed architecture documentation.
 
 ## Contributing
 
-We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines. This project prefers signed commits; see [docs/signed-commits.md](docs/signed-commits.md) for setup instructions.
 
 ## Security
 


### PR DESCRIPTION
### Motivation

- Make the signed-commit setup instructions more discoverable from the main repository `README.md` so contributors can easily enable commit signing.
- Clarify the expectations around signed commits in `CONTRIBUTING.md` and surface the purpose of the `Verified` badge.
- Provide a simple fallback guidance for contributors who cannot sign commits for a particular contribution.

### Description

- Add a short note and a link to `docs/signed-commits.md` in the `README.md` contributing section.
- Update `CONTRIBUTING.md` to state that signed commits display the GitHub `Verified` badge and to ask contributors to mention exceptions in their PRs.
- Changes are documentation-only (no code paths or behavior modified).

### Testing

- No automated tests were run because this is a documentation-only change.
- There were no code changes that would affect build or runtime tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696445cd255c832f9b2f99b2374c0708)