### PR TITLE
feat(core): implement KDBX3 file reading for backward compatibility

### DIFF
--- a/src-tauri/src/models/database.rs
+++ b/src-tauri/src/models/database.rs
@@ -10,6 +10,7 @@ pub struct DatabaseInfo {
     pub is_modified: bool,
     pub is_locked: bool,
     pub root_group_id: String,
+    pub version: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ export const DatabaseInfoSchema = z.object({
   path: z.string(),
   isModified: z.boolean(),
   rootGroupId: z.string(),
+  version: z.string(),
 });
 export type DatabaseInfo = z.infer<typeof DatabaseInfoSchema>;
 


### PR DESCRIPTION
## Summary

- Add `version` field to `DatabaseInfo` to expose database format version (e.g., "KDBX 3.1", "KDBX 4.0")
- Add `format_database_version()` helper to convert `keepass-rs` `DatabaseVersion` enum to user-friendly strings
- Update `open()`, `open_with_keyfile()`, `get_info()`, and `create()` methods to track and return version
- Add 8 new integration tests for KDBX3 functionality and version reporting

## Test plan

- [x] All 27 KDBX integration tests pass
- [x] All 23 command tests pass
- [x] All 4 unit tests pass
- [x] Rust linting (clippy) passes
- [x] Rust formatting passes
- [x] Frontend linting passes
- [x] Frontend formatting passes

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)