### PR TITLE
feat(core): implement group/folder CRUD operations

### DIFF
--- a/src-tauri/src/commands/groups.rs
+++ b/src-tauri/src/commands/groups.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::dto::error::AppError;
-use crate::dto::group::{CreateGroupData, Group, UpdateGroupData};
+use crate::dto::group::{Group, UpdateGroupData};
 use crate::services::kdbx::KdbxService;
 use std::sync::Arc;
 use tauri::State;
@@ -18,30 +18,61 @@ pub async fn get_group(id: String, state: State<'_, Arc<KdbxService>>) -> Result
     state.get_group(&id)
 }
 
-/// TODO: Creates a new group (not yet implemented).
+/// Creates a new group.
+/// `parent_id` is the parent group ID (uses root if None).
+/// Frontend sends `parentId` which Tauri converts to `parent_id`.
 #[tauri::command]
-pub async fn create_group(data: CreateGroupData) -> Result<Group, AppError> {
-    let _ = data;
-    Err(AppError::NotImplemented("create_group".into()))
+pub async fn create_group(
+    parent_id: String,
+    name: String,
+    state: State<'_, Arc<KdbxService>>,
+) -> Result<Group, AppError> {
+    state.create_group(Some(&parent_id), &name, None)
 }
 
-/// TODO: Updates a group (not yet implemented).
+/// Updates a group.
 #[tauri::command]
-pub async fn update_group(id: String, data: UpdateGroupData) -> Result<Group, AppError> {
-    let _ = (id, data);
-    Err(AppError::NotImplemented("update_group".into()))
+pub async fn update_group(
+    id: String,
+    data: UpdateGroupData,
+    state: State<'_, Arc<KdbxService>>,
+) -> Result<Group, AppError> {
+    state.update_group(&id, data)
 }
 
-/// TODO: Deletes a group (not yet implemented).
+/// Deletes a group (moves to recycle bin).
+/// Frontend sends just `id`, so `recursive` defaults to false.
 #[tauri::command]
-pub async fn delete_group(id: String, recursive: bool) -> Result<(), AppError> {
-    let _ = (id, recursive);
-    Err(AppError::NotImplemented("delete_group".into()))
+pub async fn delete_group(
+    id: String,
+    recursive: Option<bool>,
+    state: State<'_, Arc<KdbxService>>,
+) -> Result<(), AppError> {
+    state.delete_group(&id, recursive.unwrap_or(false), false)
 }
 
-/// TODO: Moves a group (not yet implemented).
+/// Moves a group to a new parent.
 #[tauri::command]
-pub async fn move_group(id: String, target_parent_id: Option<String>) -> Result<Group, AppError> {
-    let _ = (id, target_parent_id);
-    Err(AppError::NotImplemented("move_group".into()))
+pub async fn move_group(
+    id: String,
+    target_parent_id: Option<String>,
+    state: State<'_, Arc<KdbxService>>,
+) -> Result<Group, AppError> {
+    state.move_group(&id, target_parent_id.as_deref())
+}
+
+/// Renames a group (convenience wrapper around `update_group`).
+#[tauri::command]
+pub async fn rename_group(
+    id: String,
+    name: String,
+    state: State<'_, Arc<KdbxService>>,
+) -> Result<Group, AppError> {
+    state.update_group(
+        &id,
+        UpdateGroupData {
+            name: Some(name),
+            icon: None,
+        },
+    )
 }

--- a/src-tauri/src/dto/error.rs
+++ b/src-tauri/src/dto/error.rs
@@ -26,6 +26,18 @@ pub enum AppError {
     #[error("Group not found: {0}")]
     GroupNotFound(String),
 
+    #[error("Cannot delete root group")]
+    CannotDeleteRootGroup,
+
+    #[error("Cannot move root group")]
+    CannotMoveRootGroup,
+
+    #[error("Cannot move group into itself or its descendants")]
+    CircularReference,
+
+    #[error("Group is not empty and recursive delete not requested")]
+    GroupNotEmpty(String),
+
     #[error("Invalid path: {0}")]
     InvalidPath(String),
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,8 +12,8 @@ use commands::{
     generate_passphrase, generate_password, get_entry, get_entry_password,
     get_entry_protected_custom_field, get_group, get_settings, has_session_key, list_entries,
     list_groups, lock_database, move_entry, move_group, open_database, open_database_with_keyfile,
-    open_database_with_keyfile_only, remove_recent_database, save_database, store_session_key,
-    unlock_database, update_entry, update_group, update_settings,
+    open_database_with_keyfile_only, remove_recent_database, rename_group, save_database,
+    store_session_key, unlock_database, update_entry, update_group, update_settings,
 };
 use services::kdbx::KdbxService;
 use services::secure_storage::SecureStorageService;
@@ -57,6 +57,7 @@ pub fn run() {
             update_group,
             delete_group,
             move_group,
+            rename_group,
             generate_password,
             generate_passphrase,
             calculate_password_strength,

--- a/src-tauri/src/services/kdbx/groups.rs
+++ b/src-tauri/src/services/kdbx/groups.rs
@@ -1,7 +1,11 @@
 use crate::dto::error::AppError;
-use crate::dto::group::Group;
+use crate::dto::group::{Group, UpdateGroupData};
+use keepass::db::{Group as KeepassGroup, Times};
 
-use super::mapping::{convert_group, find_group_by_id};
+use super::mapping::{
+    convert_group, ensure_recycle_bin, find_group_by_id, find_group_by_id_mut,
+    find_parent_group_id, group_has_children, is_ancestor_of, remove_group_by_id,
+};
 use super::KdbxService;
 
 impl KdbxService {
@@ -22,5 +26,158 @@ impl KdbxService {
         find_group_by_id(&open_db.db.root, id)
             .map(|g| convert_group(g, None))
             .ok_or_else(|| AppError::GroupNotFound(id.to_string()))
+    }
+
+    /// Creates a new group.
+    pub fn create_group(
+        &self,
+        parent_id: Option<&str>,
+        name: &str,
+        icon: Option<u32>,
+    ) -> Result<Group, AppError> {
+        let mut db_lock = self.database.lock().map_err(|_| AppError::Lock)?;
+        let open_db = db_lock.as_mut().ok_or(AppError::DatabaseNotOpen)?;
+
+        // Find the parent group (root if parent_id is None)
+        let (parent, parent_uuid) = if let Some(pid) = parent_id {
+            let parent = find_group_by_id_mut(&mut open_db.db.root, pid)
+                .ok_or_else(|| AppError::GroupNotFound(pid.to_string()))?;
+            let uuid = parent.uuid.to_string();
+            (parent, Some(uuid))
+        } else {
+            let uuid = open_db.db.root.uuid.to_string();
+            (&mut open_db.db.root, Some(uuid))
+        };
+
+        // Create the new group
+        let mut new_group = KeepassGroup::new(name);
+        if let Some(icon_id) = icon {
+            new_group.icon_id = Some(icon_id as usize);
+        }
+
+        let group_model = convert_group(&new_group, parent_uuid.as_deref());
+        parent.add_child(new_group);
+        open_db.is_modified = true;
+
+        Ok(group_model)
+    }
+
+    /// Updates an existing group.
+    pub fn update_group(&self, id: &str, data: UpdateGroupData) -> Result<Group, AppError> {
+        let mut db_lock = self.database.lock().map_err(|_| AppError::Lock)?;
+        let open_db = db_lock.as_mut().ok_or(AppError::DatabaseNotOpen)?;
+
+        // Find parent ID before mutating (for return value)
+        let parent_id = find_parent_group_id(&open_db.db.root, id);
+
+        let group = find_group_by_id_mut(&mut open_db.db.root, id)
+            .ok_or_else(|| AppError::GroupNotFound(id.to_string()))?;
+
+        if let Some(name) = data.name {
+            group.name = name;
+        }
+        if let Some(icon) = data.icon {
+            group.icon_id = icon.parse().ok().map(|i: u32| i as usize);
+        }
+
+        group.times.set_last_modification(Times::now());
+        open_db.is_modified = true;
+
+        Ok(convert_group(group, parent_id.as_deref()))
+    }
+
+    /// Deletes a group.
+    /// If `recursive` is false and the group has children, returns an error.
+    /// If `permanent` is true, the group is permanently deleted; otherwise moved to recycle bin.
+    pub fn delete_group(&self, id: &str, recursive: bool, permanent: bool) -> Result<(), AppError> {
+        let mut db_lock = self.database.lock().map_err(|_| AppError::Lock)?;
+        let open_db = db_lock.as_mut().ok_or(AppError::DatabaseNotOpen)?;
+
+        // Cannot delete root group
+        if open_db.db.root.uuid.to_string() == id {
+            return Err(AppError::CannotDeleteRootGroup);
+        }
+
+        // Check if group exists and whether it has children
+        {
+            let group = find_group_by_id(&open_db.db.root, id)
+                .ok_or_else(|| AppError::GroupNotFound(id.to_string()))?;
+
+            if !recursive && group_has_children(group) {
+                return Err(AppError::GroupNotEmpty(id.to_string()));
+            }
+        }
+
+        // Remove the group from its parent
+        let mut removed_group = remove_group_by_id(&mut open_db.db.root, id)
+            .ok_or_else(|| AppError::GroupNotFound(id.to_string()))?;
+
+        if permanent {
+            // Permanently deleted, nothing more to do
+        } else {
+            // Move to recycle bin
+            let recycle_bin_id = ensure_recycle_bin(&mut open_db.db);
+            let recycle_bin = find_group_by_id_mut(&mut open_db.db.root, &recycle_bin_id)
+                .ok_or_else(|| AppError::GroupNotFound(recycle_bin_id.clone()))?;
+
+            let now = Times::now();
+            removed_group.times.set_last_modification(now);
+            removed_group.times.set_location_changed(now);
+            recycle_bin.add_child(removed_group);
+        }
+
+        open_db.is_modified = true;
+        Ok(())
+    }
+
+    /// Moves a group to a new parent.
+    /// If `target_parent_id` is None, moves to root.
+    pub fn move_group(&self, id: &str, target_parent_id: Option<&str>) -> Result<Group, AppError> {
+        let mut db_lock = self.database.lock().map_err(|_| AppError::Lock)?;
+        let open_db = db_lock.as_mut().ok_or(AppError::DatabaseNotOpen)?;
+
+        let root_id = open_db.db.root.uuid.to_string();
+
+        // Cannot move root group
+        if root_id == id {
+            return Err(AppError::CannotMoveRootGroup);
+        }
+
+        // Verify the group exists
+        if find_group_by_id(&open_db.db.root, id).is_none() {
+            return Err(AppError::GroupNotFound(id.to_string()));
+        }
+
+        // Determine target parent ID (root if None)
+        let target_id = target_parent_id.unwrap_or(&root_id);
+
+        // Check for circular reference (cannot move a group into itself or its descendants)
+        if is_ancestor_of(&open_db.db.root, id, target_id) {
+            return Err(AppError::CircularReference);
+        }
+
+        // Verify target parent exists
+        if find_group_by_id(&open_db.db.root, target_id).is_none() {
+            return Err(AppError::GroupNotFound(target_id.to_string()));
+        }
+
+        // Remove the group from its current parent
+        let mut group = remove_group_by_id(&mut open_db.db.root, id)
+            .ok_or_else(|| AppError::GroupNotFound(id.to_string()))?;
+
+        // Update timestamps
+        let now = Times::now();
+        group.times.set_last_modification(now);
+        group.times.set_location_changed(now);
+
+        // Add to new parent
+        let target_parent = find_group_by_id_mut(&mut open_db.db.root, target_id)
+            .ok_or_else(|| AppError::GroupNotFound(target_id.to_string()))?;
+
+        let group_model = convert_group(&group, Some(target_id));
+        target_parent.add_child(group);
+        open_db.is_modified = true;
+
+        Ok(group_model)
     }
 }

--- a/src-tauri/src/services/kdbx/mapping.rs
+++ b/src-tauri/src/services/kdbx/mapping.rs
@@ -1,6 +1,7 @@
 use crate::dto::entry::{CustomFieldMeta, Entry};
 use crate::dto::group::Group;
-use keepass::db::{Entry as KeepassEntry, Node, Value};
+use keepass::db::{Entry as KeepassEntry, Group as KeepassGroup, Node, Times, Value};
+use keepass::Database;
 use secstr::SecStr;
 use std::collections::BTreeMap;
 
@@ -166,4 +167,135 @@ pub(crate) fn collect_custom_fields(
     }
 
     (custom_fields, custom_field_meta)
+}
+
+/// Finds a group by ID (mutable version).
+pub(crate) fn find_group_by_id_mut<'a>(
+    group: &'a mut KeepassGroup,
+    id: &str,
+) -> Option<&'a mut KeepassGroup> {
+    if group.uuid.to_string() == id {
+        return Some(group);
+    }
+
+    for node in &mut group.children {
+        if let Node::Group(child) = node {
+            if let Some(found) = find_group_by_id_mut(child, id) {
+                return Some(found);
+            }
+        }
+    }
+
+    None
+}
+
+/// Finds the parent group of a group by ID.
+/// Returns None if the target is the root or not found.
+pub(crate) fn find_parent_group_id(group: &KeepassGroup, target_id: &str) -> Option<String> {
+    let parent_id = group.uuid.to_string();
+
+    for node in &group.children {
+        if let Node::Group(child) = node {
+            if child.uuid.to_string() == target_id {
+                return Some(parent_id);
+            }
+            if let Some(found) = find_parent_group_id(child, target_id) {
+                return Some(found);
+            }
+        }
+    }
+
+    None
+}
+
+/// Removes a group from its parent and returns it.
+pub(crate) fn remove_group_by_id(group: &mut KeepassGroup, id: &str) -> Option<KeepassGroup> {
+    let mut index = 0;
+    while index < group.children.len() {
+        match &group.children[index] {
+            Node::Group(child) => {
+                if child.uuid.to_string() == id {
+                    return match group.children.remove(index) {
+                        Node::Group(removed) => Some(removed),
+                        Node::Entry(_) => None,
+                    };
+                }
+            }
+            Node::Entry(_) => {}
+        }
+        index += 1;
+    }
+
+    // Recursively search in child groups
+    for node in &mut group.children {
+        if let Node::Group(child) = node {
+            if let Some(found) = remove_group_by_id(child, id) {
+                return Some(found);
+            }
+        }
+    }
+
+    None
+}
+
+/// Checks if `ancestor_id` is an ancestor of (or equal to) `descendant_id`.
+pub(crate) fn is_ancestor_of(group: &KeepassGroup, ancestor_id: &str, descendant_id: &str) -> bool {
+    if ancestor_id == descendant_id {
+        return true;
+    }
+
+    // Find the ancestor group first
+    if let Some(ancestor) = find_group_by_id(group, ancestor_id) {
+        return contains_descendant(ancestor, descendant_id);
+    }
+
+    false
+}
+
+/// Helper to check if a group contains a descendant with the given ID.
+fn contains_descendant(group: &KeepassGroup, descendant_id: &str) -> bool {
+    for node in &group.children {
+        if let Node::Group(child) = node {
+            if child.uuid.to_string() == descendant_id {
+                return true;
+            }
+            if contains_descendant(child, descendant_id) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Ensures a recycle bin exists and returns its UUID.
+pub(crate) fn ensure_recycle_bin(db: &mut Database) -> String {
+    if let Some(recycle_uuid) = db.meta.recyclebin_uuid {
+        if find_group_by_id(&db.root, &recycle_uuid.to_string()).is_some() {
+            db.meta.recyclebin_enabled = Some(true);
+            db.meta.recyclebin_changed = Some(Times::now());
+            return recycle_uuid.to_string();
+        }
+    }
+
+    if let Some(group) = find_group_by_name(&db.root, "Recycle Bin") {
+        db.meta.recyclebin_enabled = Some(true);
+        db.meta.recyclebin_uuid = Some(group.uuid);
+        db.meta.recyclebin_changed = Some(Times::now());
+        return group.uuid.to_string();
+    }
+
+    let recycle_bin = KeepassGroup::new("Recycle Bin");
+    let recycle_uuid = recycle_bin.uuid;
+    db.root.add_child(recycle_bin);
+
+    db.meta.recyclebin_enabled = Some(true);
+    db.meta.recyclebin_uuid = Some(recycle_uuid);
+    db.meta.recyclebin_changed = Some(Times::now());
+
+    recycle_uuid.to_string()
+}
+
+/// Checks if a group has any children (groups or entries).
+pub(crate) fn group_has_children(group: &KeepassGroup) -> bool {
+    !group.children.is_empty()
 }

--- a/src-tauri/tests/commands/groups_test.rs
+++ b/src-tauri/tests/commands/groups_test.rs
@@ -7,10 +7,42 @@
 
 #![allow(clippy::expect_used)] // expect() is acceptable in tests
 
+use mithril_vault_lib::dto::database::DatabaseCreationOptions;
 use mithril_vault_lib::dto::error::AppError;
+use mithril_vault_lib::dto::group::UpdateGroupData;
 use mithril_vault_lib::services::kdbx::KdbxService;
+use std::thread::sleep;
+use std::time::Duration;
+use tempfile::TempDir;
 
 use super::open_test_database;
+
+/// Helper to create a new database for CRUD tests
+fn create_test_database() -> (KdbxService, TempDir) {
+    let dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let db_path = dir.path().join("group-crud.kdbx");
+
+    let options = DatabaseCreationOptions {
+        create_default_groups: false,
+        kdf_memory: Some(1024 * 1024),
+        kdf_iterations: Some(1),
+        kdf_parallelism: Some(1),
+        description: None,
+    };
+
+    let service = KdbxService::new();
+    service
+        .create_database(
+            &db_path.to_string_lossy(),
+            Some("testpass"),
+            None,
+            "Group CRUD",
+            &options,
+        )
+        .expect("Failed to create test database");
+
+    (service, dir)
+}
 
 // ============================================================================
 // list_groups command tests
@@ -99,5 +131,501 @@ fn test_get_group_database_not_open() {
     assert!(
         matches!(result, Err(AppError::DatabaseNotOpen)),
         "Should fail with DatabaseNotOpen when no database is open"
+    );
+}
+
+// ============================================================================
+// create_group command tests
+// ============================================================================
+
+#[test]
+fn test_create_group_in_root() {
+    let (service, _dir) = create_test_database();
+
+    let result = service.create_group(None, "New Group", None);
+
+    assert!(result.is_ok(), "Should successfully create group in root");
+    let group = result.expect("group");
+    assert_eq!(group.name, "New Group");
+    assert!(group.parent_id.is_some(), "Should have root as parent");
+}
+
+#[test]
+fn test_create_group_in_subgroup() {
+    let (service, _dir) = create_test_database();
+
+    // Create a parent group first
+    let parent = service
+        .create_group(None, "Parent Group", None)
+        .expect("parent group");
+
+    // Create child group
+    let result = service.create_group(Some(&parent.id), "Child Group", None);
+
+    assert!(
+        result.is_ok(),
+        "Should successfully create group in subgroup"
+    );
+    let child = result.expect("child group");
+    assert_eq!(child.name, "Child Group");
+    assert_eq!(
+        child.parent_id.as_deref(),
+        Some(parent.id.as_str()),
+        "Child should reference parent"
+    );
+}
+
+#[test]
+fn test_create_group_with_icon() {
+    let (service, _dir) = create_test_database();
+
+    let result = service.create_group(None, "Icon Group", Some(5));
+
+    assert!(result.is_ok(), "Should successfully create group with icon");
+    let group = result.expect("group");
+    assert_eq!(group.icon.as_deref(), Some("5"));
+}
+
+#[test]
+fn test_create_group_parent_not_found() {
+    let (service, _dir) = create_test_database();
+
+    let result = service.create_group(Some("nonexistent-id"), "Test", None);
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotFound(_))),
+        "Should fail with GroupNotFound for invalid parent ID"
+    );
+}
+
+#[test]
+fn test_create_group_database_not_open() {
+    let service = KdbxService::new();
+
+    let result = service.create_group(None, "Test", None);
+
+    assert!(
+        matches!(result, Err(AppError::DatabaseNotOpen)),
+        "Should fail with DatabaseNotOpen when no database is open"
+    );
+}
+
+// ============================================================================
+// update_group command tests
+// ============================================================================
+
+#[test]
+fn test_update_group_name() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "Original Name", None)
+        .expect("create group");
+
+    let result = service.update_group(
+        &group.id,
+        UpdateGroupData {
+            name: Some("Updated Name".to_string()),
+            icon: None,
+        },
+    );
+
+    assert!(result.is_ok(), "Should successfully update group name");
+    let updated = result.expect("updated group");
+    assert_eq!(updated.name, "Updated Name");
+}
+
+#[test]
+fn test_update_group_icon() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "Test Group", None)
+        .expect("create group");
+
+    let result = service.update_group(
+        &group.id,
+        UpdateGroupData {
+            name: None,
+            icon: Some("10".to_string()),
+        },
+    );
+
+    assert!(result.is_ok(), "Should successfully update group icon");
+    let updated = result.expect("updated group");
+    assert_eq!(updated.icon.as_deref(), Some("10"));
+}
+
+#[test]
+fn test_update_group_both_fields() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "Original", None)
+        .expect("create group");
+
+    let result = service.update_group(
+        &group.id,
+        UpdateGroupData {
+            name: Some("New Name".to_string()),
+            icon: Some("15".to_string()),
+        },
+    );
+
+    assert!(result.is_ok(), "Should successfully update both fields");
+    let updated = result.expect("updated group");
+    assert_eq!(updated.name, "New Name");
+    assert_eq!(updated.icon.as_deref(), Some("15"));
+}
+
+#[test]
+fn test_update_group_not_found() {
+    let (service, _dir) = create_test_database();
+
+    let result = service.update_group(
+        "nonexistent-id",
+        UpdateGroupData {
+            name: Some("Test".to_string()),
+            icon: None,
+        },
+    );
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotFound(_))),
+        "Should fail with GroupNotFound for invalid ID"
+    );
+}
+
+#[test]
+fn test_update_group_modified_timestamp_changes() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "Test", None)
+        .expect("create group");
+
+    // Get the group to see its initial state
+    let initial = service.get_group(&group.id).expect("get group");
+
+    sleep(Duration::from_secs(1));
+
+    let updated = service
+        .update_group(
+            &group.id,
+            UpdateGroupData {
+                name: Some("Updated".to_string()),
+                icon: None,
+            },
+        )
+        .expect("update group");
+
+    // Timestamps are on the group object, need to verify modification happened
+    // by checking the name changed and the group was marked modified
+    assert_eq!(updated.name, "Updated");
+    assert_ne!(initial.name, updated.name);
+}
+
+// ============================================================================
+// rename_group (via update_group) tests
+// ============================================================================
+
+#[test]
+fn test_rename_group_success() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "Old Name", None)
+        .expect("create group");
+
+    // rename_group internally uses update_group with only name
+    let result = service.update_group(
+        &group.id,
+        UpdateGroupData {
+            name: Some("New Name".to_string()),
+            icon: None,
+        },
+    );
+
+    assert!(result.is_ok(), "Should successfully rename group");
+    let renamed = result.expect("renamed group");
+    assert_eq!(renamed.name, "New Name");
+}
+
+#[test]
+fn test_rename_group_not_found() {
+    let (service, _dir) = create_test_database();
+
+    let result = service.update_group(
+        "nonexistent-id",
+        UpdateGroupData {
+            name: Some("New Name".to_string()),
+            icon: None,
+        },
+    );
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotFound(_))),
+        "Should fail with GroupNotFound for invalid ID"
+    );
+}
+
+// ============================================================================
+// delete_group command tests
+// ============================================================================
+
+#[test]
+fn test_delete_group_soft_delete() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "To Delete", None)
+        .expect("create group");
+    let group_id = group.id.clone();
+
+    // Delete without recursive, not permanent (moves to recycle bin)
+    let result = service.delete_group(&group_id, false, false);
+
+    assert!(result.is_ok(), "Should successfully soft delete group");
+
+    // The group should still exist (in recycle bin)
+    let groups = service.list_groups().expect("list groups");
+    let root = &groups[0];
+
+    // Check it's not in root anymore
+    let in_root = root.children.iter().any(|g| g.id == group_id);
+    assert!(!in_root, "Group should not be in root after delete");
+}
+
+#[test]
+fn test_delete_group_permanent() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "To Delete Permanently", None)
+        .expect("create group");
+    let group_id = group.id.clone();
+
+    // Delete permanently
+    let result = service.delete_group(&group_id, false, true);
+
+    assert!(
+        result.is_ok(),
+        "Should successfully permanently delete group"
+    );
+
+    // The group should not be found anymore
+    let get_result = service.get_group(&group_id);
+    assert!(
+        matches!(get_result, Err(AppError::GroupNotFound(_))),
+        "Permanently deleted group should not be found"
+    );
+}
+
+#[test]
+fn test_delete_group_recursive_with_children() {
+    let (service, _dir) = create_test_database();
+
+    let parent = service
+        .create_group(None, "Parent", None)
+        .expect("parent group");
+    let _child = service
+        .create_group(Some(&parent.id), "Child", None)
+        .expect("child group");
+
+    // Delete recursively
+    let result = service.delete_group(&parent.id, true, true);
+
+    assert!(
+        result.is_ok(),
+        "Should successfully recursively delete group with children"
+    );
+}
+
+#[test]
+fn test_delete_group_non_recursive_fails_with_children() {
+    let (service, _dir) = create_test_database();
+
+    let parent = service
+        .create_group(None, "Parent", None)
+        .expect("parent group");
+    let _child = service
+        .create_group(Some(&parent.id), "Child", None)
+        .expect("child group");
+
+    // Try to delete non-recursively
+    let result = service.delete_group(&parent.id, false, true);
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotEmpty(_))),
+        "Should fail with GroupNotEmpty when trying to delete non-recursively with children"
+    );
+}
+
+#[test]
+fn test_delete_group_cannot_delete_root() {
+    let (service, _dir) = create_test_database();
+    let info = service.get_info().expect("database info");
+
+    let result = service.delete_group(&info.root_group_id, false, false);
+
+    assert!(
+        matches!(result, Err(AppError::CannotDeleteRootGroup)),
+        "Should fail with CannotDeleteRootGroup when trying to delete root"
+    );
+}
+
+#[test]
+fn test_delete_group_not_found() {
+    let (service, _dir) = create_test_database();
+
+    let result = service.delete_group("nonexistent-id", false, false);
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotFound(_))),
+        "Should fail with GroupNotFound for invalid ID"
+    );
+}
+
+#[test]
+fn test_delete_group_database_not_open() {
+    let service = KdbxService::new();
+
+    let result = service.delete_group("some-id", false, false);
+
+    assert!(
+        matches!(result, Err(AppError::DatabaseNotOpen)),
+        "Should fail with DatabaseNotOpen when no database is open"
+    );
+}
+
+// ============================================================================
+// move_group command tests
+// ============================================================================
+
+#[test]
+fn test_move_group_to_different_parent() {
+    let (service, _dir) = create_test_database();
+
+    let group_a = service
+        .create_group(None, "Group A", None)
+        .expect("group A");
+    let group_b = service
+        .create_group(None, "Group B", None)
+        .expect("group B");
+
+    // Move Group A into Group B
+    let result = service.move_group(&group_a.id, Some(&group_b.id));
+
+    assert!(result.is_ok(), "Should successfully move group");
+    let moved = result.expect("moved group");
+    assert_eq!(
+        moved.parent_id.as_deref(),
+        Some(group_b.id.as_str()),
+        "Moved group should have new parent"
+    );
+}
+
+#[test]
+fn test_move_group_to_root() {
+    let (service, _dir) = create_test_database();
+    let info = service.get_info().expect("database info");
+
+    let parent = service
+        .create_group(None, "Parent", None)
+        .expect("parent group");
+    let child = service
+        .create_group(Some(&parent.id), "Child", None)
+        .expect("child group");
+
+    // Move child to root (target_parent_id = None means root)
+    let result = service.move_group(&child.id, None);
+
+    assert!(result.is_ok(), "Should successfully move group to root");
+    let moved = result.expect("moved group");
+    assert_eq!(
+        moved.parent_id.as_deref(),
+        Some(info.root_group_id.as_str()),
+        "Moved group should be under root"
+    );
+}
+
+#[test]
+fn test_move_group_cannot_move_root() {
+    let (service, _dir) = create_test_database();
+    let info = service.get_info().expect("database info");
+
+    let target = service.create_group(None, "Target", None).expect("target");
+
+    let result = service.move_group(&info.root_group_id, Some(&target.id));
+
+    assert!(
+        matches!(result, Err(AppError::CannotMoveRootGroup)),
+        "Should fail with CannotMoveRootGroup when trying to move root"
+    );
+}
+
+#[test]
+fn test_move_group_circular_reference_to_self() {
+    let (service, _dir) = create_test_database();
+
+    let group = service
+        .create_group(None, "Group", None)
+        .expect("create group");
+
+    // Try to move group into itself
+    let result = service.move_group(&group.id, Some(&group.id));
+
+    assert!(
+        matches!(result, Err(AppError::CircularReference)),
+        "Should fail with CircularReference when moving to self"
+    );
+}
+
+#[test]
+fn test_move_group_circular_reference_to_descendant() {
+    let (service, _dir) = create_test_database();
+
+    let parent = service.create_group(None, "Parent", None).expect("parent");
+    let child = service
+        .create_group(Some(&parent.id), "Child", None)
+        .expect("child");
+    let grandchild = service
+        .create_group(Some(&child.id), "Grandchild", None)
+        .expect("grandchild");
+
+    // Try to move parent into its grandchild (circular)
+    let result = service.move_group(&parent.id, Some(&grandchild.id));
+
+    assert!(
+        matches!(result, Err(AppError::CircularReference)),
+        "Should fail with CircularReference when moving to descendant"
+    );
+}
+
+#[test]
+fn test_move_group_not_found() {
+    let (service, _dir) = create_test_database();
+
+    let target = service.create_group(None, "Target", None).expect("target");
+
+    let result = service.move_group("nonexistent-id", Some(&target.id));
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotFound(_))),
+        "Should fail with GroupNotFound for invalid group ID"
+    );
+}
+
+#[test]
+fn test_move_group_target_not_found() {
+    let (service, _dir) = create_test_database();
+
+    let group = service.create_group(None, "Group", None).expect("group");
+
+    let result = service.move_group(&group.id, Some("nonexistent-target"));
+
+    assert!(
+        matches!(result, Err(AppError::GroupNotFound(_))),
+        "Should fail with GroupNotFound for invalid target ID"
     );
 }


### PR DESCRIPTION
## Summary
- Implement Create, Update, Delete, Move, and Rename operations for groups/folders in the KDBX database layer
- Add error handling for root group protection and circular reference prevention
- Add 26 test cases for comprehensive coverage (>70%)

## Changes
- **Error types**: Added `CannotDeleteRootGroup`, `CannotMoveRootGroup`, `CircularReference`, `GroupNotEmpty`
- **Helper functions**: Added shared utilities in `mapping.rs` for group tree operations
- **Service methods**: Implemented `create_group`, `update_group`, `delete_group`, `move_group` in `groups.rs`
- **Commands**: Updated handlers and added `rename_group` for frontend compatibility
- **Tests**: Added 26 test cases covering all CRUD operations

## Features
- Create groups in root or subgroups with optional icon
- Update group name and icon with timestamp tracking
- Soft delete (recycle bin) and permanent delete with recursive option
- Move groups with circular reference protection
- Root group protection (cannot delete or move)

## Test plan
- [x] All 57 command tests pass
- [x] All 123 total tests pass
- [x] Clippy clean
- [x] Format check passes
- [x] Frontend builds successfully

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)