### PR TITLE
feat(core): implement clipboard operations with auto-clear

### DIFF
--- a/src-tauri/src/commands/clipboard.rs
+++ b/src-tauri/src/commands/clipboard.rs
@@ -29,6 +29,20 @@ pub async fn copy_text_to_clipboard(
     clipboard.copy(&text, timeout_secs)
 }
 
+/// Copies a protected custom field to the clipboard with optional auto-clear.
+#[tauri::command]
+pub async fn copy_protected_field_to_clipboard(
+    db_id: String,
+    entry_id: String,
+    field_key: String,
+    timeout_secs: Option<u32>,
+    kdbx: State<'_, Arc<KdbxService>>,
+    clipboard: State<'_, Arc<ClipboardService>>,
+) -> Result<(), AppError> {
+    let field = kdbx.get_entry_protected_custom_field(&db_id, &entry_id, &field_key)?;
+    clipboard.copy(&field.value, timeout_secs)
+}
+
 /// Clears the clipboard.
 #[tauri::command]
 pub async fn clear_clipboard(clipboard: State<'_, Arc<ClipboardService>>) -> Result<(), AppError> {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -54,9 +54,12 @@ pub struct GeneralSettings {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)]
 pub struct SecuritySettings {
     pub auto_lock_timeout: u32,
     pub clipboard_clear_timeout: u32,
+    pub clear_clipboard_on_lock: bool,
+    pub show_clipboard_countdown: bool,
     pub show_password_by_default: bool,
     pub minimize_to_tray: bool,
     pub start_minimized: bool,
@@ -105,6 +108,8 @@ pub struct AppSettings {
     pub default_database_path: Option<String>,
     pub auto_lock_timeout: u32,
     pub clipboard_clear_timeout: u32,
+    pub clear_clipboard_on_lock: bool,
+    pub show_clipboard_countdown: bool,
     pub show_password_by_default: bool,
     pub minimize_to_tray: bool,
     pub start_minimized: bool,
@@ -129,6 +134,8 @@ impl Default for AppSettings {
             default_database_path: None,
             auto_lock_timeout: 300,
             clipboard_clear_timeout: 30,
+            clear_clipboard_on_lock: true,
+            show_clipboard_countdown: false,
             show_password_by_default: false,
             minimize_to_tray: true,
             start_minimized: false,
@@ -158,6 +165,8 @@ impl AppPreferences {
             security: SecuritySettings {
                 auto_lock_timeout: settings.auto_lock_timeout,
                 clipboard_clear_timeout: settings.clipboard_clear_timeout,
+                clear_clipboard_on_lock: settings.clear_clipboard_on_lock,
+                show_clipboard_countdown: settings.show_clipboard_countdown,
                 show_password_by_default: settings.show_password_by_default,
                 minimize_to_tray: settings.minimize_to_tray,
                 start_minimized: settings.start_minimized,
@@ -192,6 +201,8 @@ impl AppPreferences {
             .clone_from(&self.general.default_database_path);
         settings.auto_lock_timeout = self.security.auto_lock_timeout;
         settings.clipboard_clear_timeout = self.security.clipboard_clear_timeout;
+        settings.clear_clipboard_on_lock = self.security.clear_clipboard_on_lock;
+        settings.show_clipboard_countdown = self.security.show_clipboard_countdown;
         settings.show_password_by_default = self.security.show_password_by_default;
         settings.minimize_to_tray = self.security.minimize_to_tray;
         settings.start_minimized = self.security.start_minimized;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,16 +9,17 @@ pub mod utils;
 use crate::dto::error::AppError;
 use commands::{
     add_recent_database, clear_clipboard, clear_recent_databases, clear_session_key,
-    close_database, copy_password_to_clipboard, copy_text_to_clipboard, create_database,
-    create_entry, create_group, delete_entry, delete_group, delete_tag, generate_keyfile,
-    generate_passphrase, generate_password, get_app_preferences, get_custom_icons,
-    get_database_config, get_database_info, get_entry, get_entry_password,
-    get_entry_protected_custom_field, get_group, get_group_entry_counts, get_keyfile_for_database,
-    get_recycle_bin_id, get_settings, has_session_key, inspect_database, list_entries, list_groups,
-    list_open_databases, lock_database, move_entry, move_group, open_database,
-    open_database_with_keyfile, open_database_with_keyfile_only, remove_recent_database,
-    rename_group, rename_tag, reset_app_preferences, save_database, store_session_key,
-    unlock_database, update_app_preferences, update_entry, update_group, update_settings,
+    close_database, copy_password_to_clipboard, copy_protected_field_to_clipboard,
+    copy_text_to_clipboard, create_database, create_entry, create_group, delete_entry,
+    delete_group, delete_tag, generate_keyfile, generate_passphrase, generate_password,
+    get_app_preferences, get_custom_icons, get_database_config, get_database_info, get_entry,
+    get_entry_password, get_entry_protected_custom_field, get_group, get_group_entry_counts,
+    get_keyfile_for_database, get_recycle_bin_id, get_settings, has_session_key, inspect_database,
+    list_entries, list_groups, list_open_databases, lock_database, move_entry, move_group,
+    open_database, open_database_with_keyfile, open_database_with_keyfile_only,
+    remove_recent_database, rename_group, rename_tag, reset_app_preferences, save_database,
+    store_session_key, unlock_database, update_app_preferences, update_entry, update_group,
+    update_settings,
 };
 use services::clipboard::ClipboardService;
 use services::kdbx::KdbxService;
@@ -82,6 +83,7 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             has_session_key,
             clear_session_key,
             copy_password_to_clipboard,
+            copy_protected_field_to_clipboard,
             copy_text_to_clipboard,
             clear_clipboard,
         ])
@@ -108,7 +110,14 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
 #[allow(clippy::expect_used)]
 /// Runs the Tauri application.
 pub fn run() {
-    build_app(tauri::Builder::default())
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+    let app = build_app(tauri::Builder::default())
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+    app.run(|app, event| {
+        if let tauri::RunEvent::Exit = event {
+            if let Some(clipboard) = app.try_state::<Arc<ClipboardService>>() {
+                let _ = clipboard.clear();
+            }
+        }
+    });
 }

--- a/src-tauri/src/services/clipboard.rs
+++ b/src-tauri/src/services/clipboard.rs
@@ -39,9 +39,8 @@ impl ClipboardService {
                 // the value we originally copied.
                 if generation.load(Ordering::SeqCst) == gen {
                     if let Ok(mut cb) = arboard::Clipboard::new() {
-                        let should_clear = cb
-                            .get_text()
-                            .is_ok_and(|current| current == copied_text);
+                        let should_clear =
+                            cb.get_text().is_ok_and(|current| current == copied_text);
                         if should_clear {
                             let _ = cb.set_text("");
                         }

--- a/src-tauri/src/services/clipboard.rs
+++ b/src-tauri/src/services/clipboard.rs
@@ -20,6 +20,7 @@ impl ClipboardService {
     /// Copies text to the clipboard. If `clear_after_secs` is `Some`, spawns
     /// an async task that clears the clipboard after the specified duration.
     /// A subsequent copy cancels any pending clear.
+    /// The scheduled clear only runs if clipboard content still matches what we copied.
     pub fn copy(&self, text: &str, clear_after_secs: Option<u32>) -> Result<(), AppError> {
         let mut cb = arboard::Clipboard::new()
             .map_err(|e| AppError::Io(format!("Failed to access clipboard: {e}")))?;
@@ -31,12 +32,20 @@ impl ClipboardService {
 
         if let Some(secs) = clear_after_secs {
             let generation = Arc::clone(&self.copy_generation);
+            let copied_text = text.to_owned();
             tokio::spawn(async move {
                 tokio::time::sleep(std::time::Duration::from_secs(u64::from(secs))).await;
-                // Only clear if no newer copy happened.
+                // Only clear if no newer copy happened and clipboard still contains
+                // the value we originally copied.
                 if generation.load(Ordering::SeqCst) == gen {
                     if let Ok(mut cb) = arboard::Clipboard::new() {
-                        let _ = cb.set_text("");
+                        let should_clear = cb
+                            .get_text()
+                            .map(|current| current == copied_text)
+                            .unwrap_or(false);
+                        if should_clear {
+                            let _ = cb.set_text("");
+                        }
                     }
                 }
             });

--- a/src-tauri/src/services/clipboard.rs
+++ b/src-tauri/src/services/clipboard.rs
@@ -41,8 +41,7 @@ impl ClipboardService {
                     if let Ok(mut cb) = arboard::Clipboard::new() {
                         let should_clear = cb
                             .get_text()
-                            .map(|current| current == copied_text)
-                            .unwrap_or(false);
+                            .is_ok_and(|current| current == copied_text);
                         if should_clear {
                             let _ = cb.set_text("");
                         }

--- a/src-tauri/src/services/secure_storage.rs
+++ b/src-tauri/src/services/secure_storage.rs
@@ -170,7 +170,7 @@ mod tests {
 
         // Store a session key
         service
-            .store_session_key(test_key, Duration::from_secs(3600))
+            .store_session_key(test_key, Duration::from_hours(1))
             .expect("store");
 
         // Verify it's present and can be loaded
@@ -186,7 +186,7 @@ mod tests {
 
         // Store and then clear (use long TTL to avoid timing issues in CI)
         service
-            .store_session_key(test_key, Duration::from_secs(3600))
+            .store_session_key(test_key, Duration::from_hours(1))
             .expect("store");
         assert!(service.session_key_present().expect("presence check"));
 
@@ -204,10 +204,10 @@ mod tests {
         let key2 = b"second_key";
 
         service
-            .store_session_key(key1, Duration::from_secs(3600))
+            .store_session_key(key1, Duration::from_hours(1))
             .expect("store first");
         service
-            .store_session_key(key2, Duration::from_secs(3600))
+            .store_session_key(key2, Duration::from_hours(1))
             .expect("store second");
 
         let loaded = service.load_session_key().expect("load");
@@ -217,7 +217,7 @@ mod tests {
     #[test]
     fn test_default_session_ttl() {
         let ttl = SecureStorageService::default_session_ttl();
-        assert_eq!(ttl, Duration::from_secs(300));
+        assert_eq!(ttl, Duration::from_mins(5));
     }
 
     // Note: TTL expiration testing is omitted because Stronghold's TTL handling

--- a/src-tauri/tests/command_handlers_test.rs
+++ b/src-tauri/tests/command_handlers_test.rs
@@ -3,7 +3,9 @@
 
 #![allow(clippy::expect_used)]
 
-use mithril_vault_lib::commands::clipboard::{clear_clipboard, copy_password_to_clipboard};
+use mithril_vault_lib::commands::clipboard::{
+    clear_clipboard, copy_password_to_clipboard, copy_protected_field_to_clipboard,
+};
 use mithril_vault_lib::commands::database::{
     close_database, create_database, generate_keyfile, get_custom_icons, get_database_config,
     get_database_info, inspect_database, list_open_databases, lock_database, open_database,
@@ -107,6 +109,24 @@ fn clear_clipboard_command_returns_expected_result_shape() {
         result.is_ok() || matches!(result, Err(AppError::Io(_))),
         "clear_clipboard should either succeed or return IO error"
     );
+
+    cleanup_app_files(&app);
+}
+
+#[test]
+fn copy_protected_field_command_fails_when_database_is_not_open() {
+    let app = setup_app();
+
+    let err = tauri::async_runtime::block_on(copy_protected_field_to_clipboard(
+        "nonexistent.kdbx".to_string(),
+        "entry-id".to_string(),
+        "secret-field".to_string(),
+        Some(30),
+        app.state(),
+        app.state(),
+    ))
+    .expect_err("expected database not found");
+    assert!(matches!(err, AppError::DatabaseNotFound(_)));
 
     cleanup_app_files(&app);
 }

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -304,10 +304,14 @@ function UrlRow({ url, isDisabled }: { url: string; isDisabled: boolean }) {
   const { t } = useTranslation();
   const { copy, isCopied } = useCopyToClipboard();
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (isDisabled) return;
-    void copy(url);
-    toast.success(t("common.copied"));
+    try {
+      await copy(url);
+      toast.success(t("common.copied"));
+    } catch (error) {
+      console.error("Failed to copy URL:", error);
+    }
   };
 
   const handleOpen = async () => {
@@ -459,10 +463,14 @@ function EntryFieldRow({
   const { t } = useTranslation();
   const { copy, isCopied } = useCopyToClipboard();
 
-  const handleCopy = () => {
+  const handleCopy = async () => {
     if (isDisabled) return;
-    void copy(value);
-    toast.success(t("common.copied"));
+    try {
+      await copy(value);
+      toast.success(t("common.copied"));
+    } catch (error) {
+      console.error("Failed to copy field value:", error);
+    }
   };
 
   return (

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -235,11 +235,15 @@ function PasswordRow({
 
   const handleCopy = async () => {
     if (isDisabled) return;
-    await clipboard.copyPassword(dbId, entryId, clipboardClearTimeout);
-    setIsCopied(true);
-    toast.success(t("shortcuts.toast.passwordCopied"));
-    startCountdown(clipboardClearTimeout);
-    setTimeout(() => setIsCopied(false), 2000);
+    try {
+      await clipboard.copyPassword(dbId, entryId, clipboardClearTimeout);
+      setIsCopied(true);
+      toast.success(t("shortcuts.toast.passwordCopied"));
+      startCountdown(clipboardClearTimeout);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy password:", error);
+    }
   };
 
   const displayValue = isLoading ? (
@@ -391,16 +395,20 @@ function ProtectedCustomFieldRow({
 
   const handleCopy = async () => {
     if (isDisabled) return;
-    await clipboard.copyProtectedField(
-      dbId,
-      entryId,
-      meta.key,
-      clipboardClearTimeout
-    );
-    setIsCopied(true);
-    toast.success(t("common.copied"));
-    startCountdown(clipboardClearTimeout);
-    setTimeout(() => setIsCopied(false), 2000);
+    try {
+      await clipboard.copyProtectedField(
+        dbId,
+        entryId,
+        meta.key,
+        clipboardClearTimeout
+      );
+      setIsCopied(true);
+      toast.success(t("common.copied"));
+      startCountdown(clipboardClearTimeout);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy protected field:", error);
+    }
   };
 
   const displayValue = isLoading ? (

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -21,10 +21,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useEntryDetail } from "@/hooks/use-entry-detail";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useCustomIcons } from "@/hooks/use-custom-icons";
+import { useClipboardCountdown } from "@/hooks/use-clipboard-countdown";
 import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
 import { clipboard, entries as entriesApi } from "@/lib/tauri";
 import { getKeepassIcon } from "@/lib/keepass-icons";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
 import type { CustomFieldMeta } from "@/lib/types";
 
 interface EntryItemDetailsProps {
@@ -228,12 +230,15 @@ function PasswordRow({
 }) {
   const { t } = useTranslation();
   const clipboardClearTimeout = useClipboardTimeout();
+  const startCountdown = useClipboardCountdown();
   const [isCopied, setIsCopied] = useState(false);
 
   const handleCopy = async () => {
     if (isDisabled) return;
     await clipboard.copyPassword(dbId, entryId, clipboardClearTimeout);
     setIsCopied(true);
+    toast.success(t("shortcuts.toast.passwordCopied"));
+    startCountdown(clipboardClearTimeout);
     setTimeout(() => setIsCopied(false), 2000);
   };
 
@@ -302,6 +307,7 @@ function UrlRow({ url, isDisabled }: { url: string; isDisabled: boolean }) {
   const handleCopy = () => {
     if (isDisabled) return;
     void copy(url);
+    toast.success(t("common.copied"));
   };
 
   const handleOpen = async () => {
@@ -355,8 +361,11 @@ function ProtectedCustomFieldRow({
   isDisabled: boolean;
 }) {
   const { t } = useTranslation();
+  const clipboardClearTimeout = useClipboardTimeout();
+  const startCountdown = useClipboardCountdown();
   const [value, setValue] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isCopied, setIsCopied] = useState(false);
   const isVisible = value !== null;
 
   const reveal = useCallback(async () => {
@@ -376,19 +385,46 @@ function ProtectedCustomFieldRow({
 
   const hide = useCallback(() => setValue(null), []);
 
+  const handleCopy = async () => {
+    if (isDisabled) return;
+    await clipboard.copyProtectedField(
+      dbId,
+      entryId,
+      meta.key,
+      clipboardClearTimeout
+    );
+    setIsCopied(true);
+    toast.success(t("common.copied"));
+    startCountdown(clipboardClearTimeout);
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  const displayValue = isLoading ? (
+    <Loader2 className="inline h-3 w-3 animate-spin" />
+  ) : isVisible ? (
+    value
+  ) : (
+    "••••••••"
+  );
+
   return (
     <div className="flex min-w-0 justify-between items-center px-4 py-2 gap-2">
       <small className="shrink-0 text-sm font-medium">{meta.key}</small>
       <div className="flex w-0 min-w-0 flex-1 items-center justify-end-safe gap-2">
-        <span className="min-w-0 truncate text-right text-sm font-medium text-muted-foreground">
-          {isLoading ? (
-            <Loader2 className="inline h-3 w-3 animate-spin" />
-          ) : isVisible ? (
-            value
+        <button
+          onClick={handleCopy}
+          disabled={isDisabled}
+          className="group flex min-w-0 max-w-full flex-1 items-center justify-end gap-2 overflow-hidden rounded-sm px-2 py-1 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-accent"
+        >
+          <span className="min-w-0 truncate text-right transition-all duration-200">
+            {isCopied ? t("common.copied") : displayValue}
+          </span>
+          {isCopied ? (
+            <Check className="h-3 w-3 text-green-500 transition-all duration-200" />
           ) : (
-            "••••••••"
+            <Copy className="h-3 w-3 opacity-0 group-hover:opacity-100 transition-all duration-200" />
           )}
-        </span>
+        </button>
         <Button
           variant="outline"
           size="icon-xs"
@@ -426,6 +462,7 @@ function EntryFieldRow({
   const handleCopy = () => {
     if (isDisabled) return;
     void copy(value);
+    toast.success(t("common.copied"));
   };
 
   return (

--- a/src/components/entries/__tests__/EntryItemDetails.test.tsx
+++ b/src/components/entries/__tests__/EntryItemDetails.test.tsx
@@ -268,6 +268,20 @@ describe("EntryItemDetails", () => {
     );
   });
 
+  it("does not show password success toast when password copy fails", async () => {
+    vi.mocked(clipboard.copyPassword).mockRejectedValueOnce(
+      new Error("copy failed")
+    );
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const passwordText = screen.getByText("••••••••");
+    await act(async () => {
+      fireEvent.click(passwordText.closest("button") as HTMLButtonElement);
+    });
+    expect(toast.success).not.toHaveBeenCalledWith(
+      "shortcuts.toast.passwordCopied"
+    );
+  });
+
   it("shows toast on username copy", async () => {
     render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
     const usernameText = screen.getByText("user@example.com");
@@ -335,6 +349,31 @@ describe("EntryItemDetails", () => {
       fireEvent.click(protectedFieldButton);
     });
     expect(toast.success).toHaveBeenCalledWith("common.copied");
+  });
+
+  it("does not show protected field success toast when copy fails", async () => {
+    const protectedEntry: Entry = {
+      ...mockEntry,
+      customFields: {},
+      customFieldMeta: [{ key: "API Token", isProtected: true }],
+    };
+    vi.mocked(useEntryDetail).mockReturnValueOnce(
+      makeHookResult({ entry: protectedEntry })
+    );
+    vi.mocked(clipboard.copyProtectedField).mockRejectedValueOnce(
+      new Error("copy failed")
+    );
+
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const maskedTexts = screen.getAllByText("••••••••");
+    const protectedFieldButton = maskedTexts[1]!.closest(
+      "button"
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(protectedFieldButton);
+    });
+
+    expect(toast.success).not.toHaveBeenCalledWith("common.copied");
   });
 
   it("shows copied feedback for protected custom field", async () => {

--- a/src/components/entries/__tests__/EntryItemDetails.test.tsx
+++ b/src/components/entries/__tests__/EntryItemDetails.test.tsx
@@ -12,6 +12,7 @@ import EntryItemDetails from "../EntryItemDetails";
 import { useEntryDetail } from "@/hooks/use-entry-detail";
 import { clipboard, entries as entriesApi } from "@/lib/tauri";
 import { openUrl } from "@tauri-apps/plugin-opener";
+import { toast } from "sonner";
 import type { Entry } from "@/lib/types";
 
 const mockEntry: Entry = {
@@ -53,14 +54,28 @@ vi.mock("@/hooks/use-clipboard-timeout", () => ({
   useClipboardTimeout: vi.fn(() => 45),
 }));
 
+vi.mock("@/hooks/use-clipboard-countdown", () => ({
+  useClipboardCountdown: () => vi.fn(),
+}));
+
 vi.mock("@/lib/tauri", () => ({
-  clipboard: { copyPassword: vi.fn() },
+  clipboard: { copyPassword: vi.fn(), copyProtectedField: vi.fn() },
   entries: { getProtectedCustomField: vi.fn() },
 }));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: vi.fn(),
 }));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+Object.defineProperty(navigator, "clipboard", {
+  configurable: true,
+  value: { writeText },
+});
 
 function makeHookResult(
   overrides: Partial<ReturnType<typeof useEntryDetail>> = {}
@@ -239,5 +254,128 @@ describe("EntryItemDetails", () => {
     expect(
       screen.getByRole("button", { name: "entries.detail.openUrl" })
     ).toBeDisabled();
+  });
+
+  it("shows toast on password copy", async () => {
+    vi.mocked(clipboard.copyPassword).mockResolvedValueOnce(undefined);
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const passwordText = screen.getByText("••••••••");
+    await act(async () => {
+      fireEvent.click(passwordText.closest("button") as HTMLButtonElement);
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      "shortcuts.toast.passwordCopied"
+    );
+  });
+
+  it("shows toast on username copy", async () => {
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const usernameText = screen.getByText("user@example.com");
+    await act(async () => {
+      fireEvent.click(usernameText.closest("button") as HTMLButtonElement);
+    });
+    expect(toast.success).toHaveBeenCalledWith("common.copied");
+  });
+
+  it("shows toast on URL copy", async () => {
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const urlText = screen.getByText("https://example.com");
+    await act(async () => {
+      fireEvent.click(urlText.closest("button") as HTMLButtonElement);
+    });
+    expect(toast.success).toHaveBeenCalledWith("common.copied");
+  });
+
+  it("copies protected custom field via backend clipboard command", async () => {
+    const protectedEntry: Entry = {
+      ...mockEntry,
+      customFields: {},
+      customFieldMeta: [{ key: "API Token", isProtected: true }],
+    };
+    vi.mocked(useEntryDetail).mockReturnValueOnce(
+      makeHookResult({ entry: protectedEntry })
+    );
+    vi.mocked(clipboard.copyProtectedField).mockResolvedValueOnce(undefined);
+
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const maskedTexts = screen.getAllByText("••••••••");
+    // First is password row, second is protected field row
+    const protectedFieldButton = maskedTexts[1]!.closest(
+      "button"
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(protectedFieldButton);
+    });
+    expect(clipboard.copyProtectedField).toHaveBeenCalledWith(
+      "db-1",
+      "entry-1",
+      "API Token",
+      45
+    );
+  });
+
+  it("shows toast on protected custom field copy", async () => {
+    const protectedEntry: Entry = {
+      ...mockEntry,
+      customFields: {},
+      customFieldMeta: [{ key: "API Token", isProtected: true }],
+    };
+    vi.mocked(useEntryDetail).mockReturnValueOnce(
+      makeHookResult({ entry: protectedEntry })
+    );
+    vi.mocked(clipboard.copyProtectedField).mockResolvedValueOnce(undefined);
+
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const maskedTexts = screen.getAllByText("••••••••");
+    // First is password row, second is protected field row
+    const protectedFieldButton = maskedTexts[1]!.closest(
+      "button"
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(protectedFieldButton);
+    });
+    expect(toast.success).toHaveBeenCalledWith("common.copied");
+  });
+
+  it("shows copied feedback for protected custom field", async () => {
+    const protectedEntry: Entry = {
+      ...mockEntry,
+      customFields: {},
+      customFieldMeta: [{ key: "API Token", isProtected: true }],
+    };
+    vi.mocked(useEntryDetail).mockReturnValueOnce(
+      makeHookResult({ entry: protectedEntry })
+    );
+    vi.mocked(clipboard.copyProtectedField).mockResolvedValueOnce(undefined);
+
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const maskedTexts = screen.getAllByText("••••••••");
+    // First is password row, second is protected field row
+    const protectedFieldButton = maskedTexts[1]!.closest(
+      "button"
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(protectedFieldButton);
+    });
+    expect(screen.getByText("common.copied")).toBeInTheDocument();
+  });
+
+  it("disables protected custom field copy while transitioning", () => {
+    const protectedEntry: Entry = {
+      ...mockEntry,
+      customFields: {},
+      customFieldMeta: [{ key: "API Token", isProtected: true }],
+    };
+    vi.mocked(useEntryDetail).mockReturnValueOnce(
+      makeHookResult({ entry: protectedEntry, isTransitioning: true })
+    );
+
+    render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+    const maskedTexts = screen.getAllByText("••••••••");
+    // First is password row, second is protected field row
+    const protectedFieldButton = maskedTexts[1]!.closest(
+      "button"
+    ) as HTMLButtonElement;
+    expect(protectedFieldButton).toBeDisabled();
   });
 });

--- a/src/components/entries/__tests__/PasswordGeneratorDialog.test.tsx
+++ b/src/components/entries/__tests__/PasswordGeneratorDialog.test.tsx
@@ -13,6 +13,10 @@ vi.mock("@/hooks/use-clipboard-timeout", () => ({
   useClipboardTimeout: () => 12,
 }));
 
+vi.mock("@/hooks/use-clipboard-countdown", () => ({
+  useClipboardCountdown: () => vi.fn(),
+}));
+
 vi.mock("@/lib/tauri", () => ({
   clipboard: {
     copyText: vi.fn(),

--- a/src/components/generator/PasswordGenerator.tsx
+++ b/src/components/generator/PasswordGenerator.tsx
@@ -17,6 +17,7 @@ import {
   usePasswordGenerator,
 } from "@/hooks/use-password-generator";
 import { clipboard } from "@/lib/tauri";
+import { useClipboardCountdown } from "@/hooks/use-clipboard-countdown";
 import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
 import type {
   PassphraseGeneratorOptions,
@@ -49,6 +50,7 @@ interface PasswordGeneratorProps {
 export function PasswordGenerator({ onUsePassword }: PasswordGeneratorProps) {
   const { t } = useTranslation();
   const clipboardClearTimeout = useClipboardTimeout();
+  const startCountdown = useClipboardCountdown();
   const [activeTab, setActiveTab] = useState("password");
 
   const [passwordOptions, setPasswordOptions] =
@@ -89,6 +91,7 @@ export function PasswordGenerator({ onUsePassword }: PasswordGeneratorProps) {
     if (!text) return;
     await clipboard.copyText(text, clipboardClearTimeout);
     setIsCopied(true);
+    startCountdown(clipboardClearTimeout);
     window.setTimeout(() => setIsCopied(false), 2000);
   }
 

--- a/src/components/generator/__tests__/PasswordGeneratorPage.test.tsx
+++ b/src/components/generator/__tests__/PasswordGeneratorPage.test.tsx
@@ -25,6 +25,10 @@ vi.mock("@/hooks/use-clipboard-timeout", () => ({
   useClipboardTimeout: () => 30,
 }));
 
+vi.mock("@/hooks/use-clipboard-countdown", () => ({
+  useClipboardCountdown: () => vi.fn(),
+}));
+
 vi.mock("@/lib/tauri", () => ({
   clipboard: {
     copyText: vi.fn(),

--- a/src/components/layout/database-switcher.tsx
+++ b/src/components/layout/database-switcher.tsx
@@ -54,7 +54,11 @@ export function DatabaseSwitcher() {
 
     try {
       if (preferences?.security.clearClipboardOnLock) {
-        await clipboard.clear();
+        try {
+          await clipboard.clear();
+        } catch (error) {
+          console.error("Failed to clear clipboard before lock:", error);
+        }
       }
       await database.close(dbId);
       removeTab(tab.id);

--- a/src/components/layout/database-switcher.tsx
+++ b/src/components/layout/database-switcher.tsx
@@ -20,8 +20,9 @@ import {
 } from "@/components/ui/sidebar.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { useActiveDatabase } from "@/hooks/use-active-database";
+import { useAppPreferences } from "@/hooks/use-app-preferences";
 import { useRecentDatabases } from "@/hooks/use-recent-databases.ts";
-import { database } from "@/lib/tauri.ts";
+import { clipboard, database } from "@/lib/tauri.ts";
 import {
   type DatabaseTabsState,
   useDatabaseTabs,
@@ -44,6 +45,7 @@ export function DatabaseSwitcher() {
     (state: DatabaseTabsState) => state.removeTab
   );
   const { recentDatabases, isLoading: isLoadingRecent } = useRecentDatabases();
+  const { preferences } = useAppPreferences();
 
   const handleLock = async () => {
     if (!tab?.id || !dbId) {
@@ -51,6 +53,9 @@ export function DatabaseSwitcher() {
     }
 
     try {
+      if (preferences?.security.clearClipboardOnLock) {
+        await clipboard.clear();
+      }
       await database.close(dbId);
       removeTab(tab.id);
       void navigate({ to: "/" });

--- a/src/components/layout/database-tab-bar.tsx
+++ b/src/components/layout/database-tab-bar.tsx
@@ -5,7 +5,8 @@ import { open } from "@tauri-apps/plugin-dialog";
 import { Plus, X } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import { database } from "@/lib/tauri";
+import { useAppPreferences } from "@/hooks/use-app-preferences";
+import { clipboard, database } from "@/lib/tauri";
 import { cn } from "@/lib/utils";
 import {
   type DatabaseTab,
@@ -21,6 +22,7 @@ function getFilename(path?: string): string {
 
 export function DatabaseTabBar() {
   const navigate = useNavigate();
+  const { preferences } = useAppPreferences();
   const tabs = useDatabaseTabs(
     (state: DatabaseTabsState) => state.tabs
   ) as DatabaseTab[];
@@ -73,6 +75,13 @@ export function DatabaseTabBar() {
 
     if (tab?.state === "open" && tab.path) {
       try {
+        if (preferences?.security.clearClipboardOnLock) {
+          try {
+            await clipboard.clear();
+          } catch (error) {
+            console.error("Failed to clear clipboard before lock:", error);
+          }
+        }
         await database.close(tab.path);
       } catch (error) {
         console.error("Failed to close database:", error);

--- a/src/components/layout/drag-region.tsx
+++ b/src/components/layout/drag-region.tsx
@@ -26,6 +26,7 @@ import SortDropdown from "@/components/entries/sort-dropdown";
 import { useEntryListHeader } from "@/hooks/use-entry-list-header";
 import { useEntryDetail } from "@/hooks/use-entry-detail";
 import { useActiveDatabase } from "@/hooks/use-active-database";
+import { useAppPreferences } from "@/hooks/use-app-preferences";
 import { useEntryMutations } from "@/hooks/use-entry-mutations";
 import { useClipboardCountdown } from "@/hooks/use-clipboard-countdown";
 import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
@@ -160,6 +161,10 @@ export default function DragRegion() {
   const removeTab = useDatabaseTabs((s) => s.removeTab);
   const clipboardTimeout = useClipboardTimeout();
   const startCountdown = useClipboardCountdown();
+  const { preferences } = useAppPreferences();
+  const clearClipboardOnLock = Boolean(
+    preferences?.security.clearClipboardOnLock
+  );
 
   const getSelectedEntry = useCallback((): Entry | undefined => {
     if (!dbId || !selectedEntryId) return undefined;
@@ -187,6 +192,13 @@ export default function DragRegion() {
       if (!tab?.id || !dbId) return;
       void (async () => {
         try {
+          if (clearClipboardOnLock) {
+            try {
+              await clipboard.clear();
+            } catch (error) {
+              console.error("Failed to clear clipboard before lock:", error);
+            }
+          }
           await database.close(dbId);
           removeTab(tab.id);
           void navigate({ to: "/" });
@@ -194,7 +206,7 @@ export default function DragRegion() {
           // lock failed silently
         }
       })();
-    }, [tab, dbId, removeTab, navigate]),
+    }, [tab, dbId, removeTab, navigate, clearClipboardOnLock]),
     Boolean(dbId) && !isEditing
   );
 

--- a/src/components/layout/drag-region.tsx
+++ b/src/components/layout/drag-region.tsx
@@ -27,6 +27,7 @@ import { useEntryListHeader } from "@/hooks/use-entry-list-header";
 import { useEntryDetail } from "@/hooks/use-entry-detail";
 import { useActiveDatabase } from "@/hooks/use-active-database";
 import { useEntryMutations } from "@/hooks/use-entry-mutations";
+import { useClipboardCountdown } from "@/hooks/use-clipboard-countdown";
 import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
 import { useDatabaseTabs } from "@/stores/database-tabs";
 import { ask } from "@tauri-apps/plugin-dialog";
@@ -158,6 +159,7 @@ export default function DragRegion() {
   const queryClient = useQueryClient();
   const removeTab = useDatabaseTabs((s) => s.removeTab);
   const clipboardTimeout = useClipboardTimeout();
+  const startCountdown = useClipboardCountdown();
 
   const getSelectedEntry = useCallback((): Entry | undefined => {
     if (!dbId || !selectedEntryId) return undefined;
@@ -227,8 +229,9 @@ export default function DragRegion() {
         .copyPassword(dbId, selectedEntryId, clipboardTimeout)
         .then(() => {
           toast.success(t("shortcuts.toast.passwordCopied"));
+          startCountdown(clipboardTimeout);
         });
-    }, [dbId, selectedEntryId, clipboardTimeout, t]),
+    }, [dbId, selectedEntryId, clipboardTimeout, startCountdown, t]),
     Boolean(dbId) && Boolean(selectedEntryId) && !isEditing
   );
 

--- a/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/src/components/settings/__tests__/SettingsView.test.tsx
@@ -45,6 +45,8 @@ function makePreferences(): AppPreferences {
     security: {
       autoLockTimeout: 300,
       clipboardClearTimeout: 30,
+      clearClipboardOnLock: true,
+      showClipboardCountdown: false,
       showPasswordByDefault: false,
       minimizeToTray: true,
       startMinimized: false,

--- a/src/components/settings/sections/SecuritySettingsSection.tsx
+++ b/src/components/settings/sections/SecuritySettingsSection.tsx
@@ -82,6 +82,36 @@ export function SecuritySettingsSection({
       <div className="grid gap-4 md:grid-cols-3">
         <label className="flex items-center gap-2 text-sm">
           <Checkbox
+            checked={draft.security.clearClipboardOnLock}
+            onCheckedChange={(checked) =>
+              updateDraft((previous) => ({
+                ...previous,
+                security: {
+                  ...previous.security,
+                  clearClipboardOnLock: checked === true,
+                },
+              }))
+            }
+          />
+          {t("settings.security.clearClipboardOnLock")}
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox
+            checked={draft.security.showClipboardCountdown}
+            onCheckedChange={(checked) =>
+              updateDraft((previous) => ({
+                ...previous,
+                security: {
+                  ...previous.security,
+                  showClipboardCountdown: checked === true,
+                },
+              }))
+            }
+          />
+          {t("settings.security.showClipboardCountdown")}
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <Checkbox
             checked={draft.security.showPasswordByDefault}
             onCheckedChange={(checked) =>
               updateDraft((previous) => ({

--- a/src/hooks/__tests__/use-app-preferences.test.tsx
+++ b/src/hooks/__tests__/use-app-preferences.test.tsx
@@ -26,6 +26,8 @@ function makePreferences(): AppPreferences {
     security: {
       autoLockTimeout: 300,
       clipboardClearTimeout: 30,
+      clearClipboardOnLock: true,
+      showClipboardCountdown: false,
       showPasswordByDefault: false,
       minimizeToTray: true,
       startMinimized: false,

--- a/src/hooks/__tests__/use-clipboard-countdown.test.ts
+++ b/src/hooks/__tests__/use-clipboard-countdown.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useClipboardCountdown } from "../use-clipboard-countdown";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), dismiss: vi.fn() },
+}));
+
+vi.mock("@/hooks/use-app-preferences", () => ({
+  useAppPreferences: vi.fn(() => ({
+    preferences: {
+      security: {
+        showClipboardCountdown: true,
+      },
+    },
+  })),
+}));
+
+describe("useClipboardCountdown", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("shows toast with countdown when started", () => {
+    const { result } = renderHook(() => useClipboardCountdown());
+    act(() => {
+      result.current(10);
+    });
+    expect(toast.success).toHaveBeenCalledWith(
+      "clipboard.countdown",
+      expect.objectContaining({ id: "clipboard-countdown", duration: Infinity })
+    );
+  });
+
+  it("updates toast each second", () => {
+    const { result } = renderHook(() => useClipboardCountdown());
+    act(() => {
+      result.current(3);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(3);
+  });
+
+  it("dismisses toast when countdown reaches zero", () => {
+    const { result } = renderHook(() => useClipboardCountdown());
+    act(() => {
+      result.current(2);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(toast.dismiss).toHaveBeenCalledWith("clipboard-countdown");
+  });
+
+  it("restarts countdown when called again", () => {
+    const { result } = renderHook(() => useClipboardCountdown());
+    act(() => {
+      result.current(5);
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    vi.clearAllMocks();
+    act(() => {
+      result.current(3);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when showClipboardCountdown is disabled", async () => {
+    const { useAppPreferences } = await import("@/hooks/use-app-preferences");
+    vi.mocked(useAppPreferences).mockReturnValue({
+      preferences: {
+        security: { showClipboardCountdown: false },
+      },
+    } as ReturnType<typeof useAppPreferences>);
+
+    const { result } = renderHook(() => useClipboardCountdown());
+    act(() => {
+      result.current(10);
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/use-clipboard-countdown.test.ts
+++ b/src/hooks/__tests__/use-clipboard-countdown.test.ts
@@ -87,6 +87,31 @@ describe("useClipboardCountdown", () => {
     expect(toast.success).toHaveBeenCalledTimes(1);
   });
 
+  it("uses a single active countdown across multiple hook instances", () => {
+    const { result: first } = renderHook(() => useClipboardCountdown());
+    const { result: second } = renderHook(() => useClipboardCountdown());
+
+    act(() => {
+      first.current(5);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      second.current(3);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(3);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(toast.success).toHaveBeenCalledTimes(4);
+  });
+
   it("does nothing when showClipboardCountdown is disabled", async () => {
     const { useAppPreferences } = await import("@/hooks/use-app-preferences");
     vi.mocked(useAppPreferences).mockReturnValue({

--- a/src/hooks/__tests__/use-clipboard-countdown.test.ts
+++ b/src/hooks/__tests__/use-clipboard-countdown.test.ts
@@ -126,4 +126,33 @@ describe("useClipboardCountdown", () => {
     });
     expect(toast.success).not.toHaveBeenCalled();
   });
+
+  it("stops active countdown when preference is disabled", async () => {
+    const { useAppPreferences } = await import("@/hooks/use-app-preferences");
+    vi.mocked(useAppPreferences).mockReturnValue({
+      preferences: {
+        security: { showClipboardCountdown: true },
+      },
+    } as ReturnType<typeof useAppPreferences>);
+
+    const { result, rerender } = renderHook(() => useClipboardCountdown());
+    act(() => {
+      result.current(3);
+    });
+
+    vi.mocked(useAppPreferences).mockReturnValue({
+      preferences: {
+        security: { showClipboardCountdown: false },
+      },
+    } as ReturnType<typeof useAppPreferences>);
+    rerender();
+
+    expect(toast.dismiss).toHaveBeenCalledWith("clipboard-countdown");
+    const callsBefore = vi.mocked(toast.success).mock.calls.length;
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(vi.mocked(toast.success).mock.calls.length).toBe(callsBefore);
+  });
 });

--- a/src/hooks/use-clipboard-countdown.ts
+++ b/src/hooks/use-clipboard-countdown.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useAppPreferences } from "@/hooks/use-app-preferences";
@@ -11,6 +11,18 @@ let activeInterval: ReturnType<typeof setInterval> | null = null;
 export function useClipboardCountdown() {
   const { t } = useTranslation();
   const { preferences } = useAppPreferences();
+
+  useEffect(() => {
+    if (preferences?.security.showClipboardCountdown !== false) {
+      return;
+    }
+
+    if (activeInterval) {
+      clearInterval(activeInterval);
+      activeInterval = null;
+    }
+    toast.dismiss(TOAST_ID);
+  }, [preferences?.security.showClipboardCountdown]);
 
   const startCountdown = useCallback(
     (seconds: number) => {

--- a/src/hooks/use-clipboard-countdown.ts
+++ b/src/hooks/use-clipboard-countdown.ts
@@ -21,7 +21,7 @@ export function useClipboardCountdown() {
       clearInterval(activeInterval);
       activeInterval = null;
     }
-    toast.dismiss(TOAST_ID);
+    toast.dismiss?.(TOAST_ID);
   }, [preferences?.security.showClipboardCountdown]);
 
   const startCountdown = useCallback(

--- a/src/hooks/use-clipboard-countdown.ts
+++ b/src/hooks/use-clipboard-countdown.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useRef } from "react";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import { useAppPreferences } from "@/hooks/use-app-preferences";
+
+const TOAST_ID = "clipboard-countdown";
+
+export function useClipboardCountdown() {
+  const { t } = useTranslation();
+  const { preferences } = useAppPreferences();
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const startCountdown = useCallback(
+    (seconds: number) => {
+      if (!preferences?.security.showClipboardCountdown) return;
+
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+
+      let remaining = seconds;
+      toast.success(t("clipboard.countdown", { seconds: remaining }), {
+        id: TOAST_ID,
+        duration: Infinity,
+      });
+
+      intervalRef.current = setInterval(() => {
+        remaining -= 1;
+        if (remaining <= 0) {
+          if (intervalRef.current) {
+            clearInterval(intervalRef.current);
+            intervalRef.current = null;
+          }
+          toast.dismiss(TOAST_ID);
+        } else {
+          toast.success(t("clipboard.countdown", { seconds: remaining }), {
+            id: TOAST_ID,
+            duration: Infinity,
+          });
+        }
+      }, 1000);
+    },
+    [preferences?.security.showClipboardCountdown, t]
+  );
+
+  return startCountdown;
+}

--- a/src/hooks/use-clipboard-countdown.ts
+++ b/src/hooks/use-clipboard-countdown.ts
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: MIT
 
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useAppPreferences } from "@/hooks/use-app-preferences";
 
 const TOAST_ID = "clipboard-countdown";
+let activeInterval: ReturnType<typeof setInterval> | null = null;
 
 export function useClipboardCountdown() {
   const { t } = useTranslation();
   const { preferences } = useAppPreferences();
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const startCountdown = useCallback(
     (seconds: number) => {
       if (!preferences?.security.showClipboardCountdown) return;
 
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+      if (activeInterval) {
+        clearInterval(activeInterval);
       }
 
       let remaining = seconds;
@@ -26,12 +26,12 @@ export function useClipboardCountdown() {
         duration: Infinity,
       });
 
-      intervalRef.current = setInterval(() => {
+      activeInterval = setInterval(() => {
         remaining -= 1;
         if (remaining <= 0) {
-          if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-            intervalRef.current = null;
+          if (activeInterval) {
+            clearInterval(activeInterval);
+            activeInterval = null;
           }
           toast.dismiss(TOAST_ID);
         } else {

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -74,6 +74,8 @@ describe("tauri wrappers validation", () => {
       security: {
         autoLockTimeout: 300,
         clipboardClearTimeout: 30,
+        clearClipboardOnLock: true,
+        showClipboardCountdown: false,
         showPasswordByDefault: false,
         minimizeToTray: true,
         startMinimized: false,
@@ -129,6 +131,8 @@ describe("tauri wrappers validation", () => {
         security: {
           autoLockTimeout: 300,
           clipboardClearTimeout: 30,
+          clearClipboardOnLock: true,
+          showClipboardCountdown: false,
           showPasswordByDefault: false,
           minimizeToTray: true,
           startMinimized: false,

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -99,6 +99,13 @@ const CopyTextSchema = z.object({
   timeoutSecs: z.number().int().positive().optional(),
 });
 
+const CopyProtectedFieldSchema = z.object({
+  dbId: z.string().min(1),
+  entryId: KeepassIdSchema,
+  fieldKey: z.string().min(1),
+  timeoutSecs: z.number().int().positive().optional(),
+});
+
 const CreateDatabaseSchema = z.object({
   path: z.string().min(1),
   name: z.string().min(1),
@@ -461,6 +468,21 @@ export const clipboard = {
   ): Promise<void> {
     CopyPasswordSchema.parse({ dbId, entryId, timeoutSecs });
     return invoke("copy_password_to_clipboard", { dbId, entryId, timeoutSecs });
+  },
+
+  async copyProtectedField(
+    dbId: string,
+    entryId: string,
+    fieldKey: string,
+    timeoutSecs?: number
+  ): Promise<void> {
+    CopyProtectedFieldSchema.parse({ dbId, entryId, fieldKey, timeoutSecs });
+    return invoke("copy_protected_field_to_clipboard", {
+      dbId,
+      entryId,
+      fieldKey,
+      timeoutSecs,
+    });
   },
 
   async clear(): Promise<void> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -220,6 +220,8 @@ export type GeneralSettings = z.infer<typeof GeneralSettingsSchema>;
 export const SecuritySettingsSchema = z.object({
   autoLockTimeout: z.number().int().positive(),
   clipboardClearTimeout: z.number().int().positive(),
+  clearClipboardOnLock: z.boolean(),
+  showClipboardCountdown: z.boolean(),
   showPasswordByDefault: z.boolean(),
   minimizeToTray: z.boolean(),
   startMinimized: z.boolean(),
@@ -263,6 +265,8 @@ export const AppSettingsSchema = z.object({
   defaultDatabasePath: z.string().nullable(),
   autoLockTimeout: z.number().int(),
   clipboardClearTimeout: z.number().int(),
+  clearClipboardOnLock: z.boolean(),
+  showClipboardCountdown: z.boolean(),
   showPasswordByDefault: z.boolean(),
   minimizeToTray: z.boolean(),
   startMinimized: z.boolean(),

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -15,6 +15,9 @@
     "copied": "Kopiert",
     "noDatabase": "Keine Datenbank"
   },
+  "clipboard": {
+    "countdown": "Zwischenablage wird in {{seconds}}s gelöscht"
+  },
   "settings": {
     "title": "Einstellungen",
     "description": "Anwendungseinstellungen und Datenbankkonfiguration.",
@@ -49,6 +52,8 @@
       "autoLockTimeout": "Automatische Sperre (Sekunden)",
       "autoLockNote": "TODO: Inaktivitäts-/OS-Sperrereignisse sind noch nicht implementiert.",
       "clipboardTimeout": "Zwischenablage löschen nach (Sekunden)",
+      "clearClipboardOnLock": "Zwischenablage beim Sperren leeren",
+      "showClipboardCountdown": "Countdown der Zwischenablage anzeigen",
       "showPasswordByDefault": "Passwörter standardmäßig anzeigen",
       "minimizeToTray": "In Taskleiste minimieren",
       "startMinimized": "Minimiert starten"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -15,6 +15,9 @@
     "copied": "Copied",
     "noDatabase": "No database"
   },
+  "clipboard": {
+    "countdown": "Clipboard clears in {{seconds}}s"
+  },
   "settings": {
     "title": "Settings",
     "description": "Application preferences and database configuration.",
@@ -49,6 +52,8 @@
       "autoLockTimeout": "Auto-lock timeout (seconds)",
       "autoLockNote": "TODO: inactivity/OS-lock event wiring is not implemented yet.",
       "clipboardTimeout": "Clipboard clear timeout (seconds)",
+      "clearClipboardOnLock": "Clear clipboard on database lock",
+      "showClipboardCountdown": "Show clipboard countdown",
       "showPasswordByDefault": "Show passwords by default",
       "minimizeToTray": "Minimize to tray",
       "startMinimized": "Start minimized"

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -15,6 +15,9 @@
     "copied": "Copiado",
     "noDatabase": "Sin base de datos"
   },
+  "clipboard": {
+    "countdown": "El portapapeles se limpia en {{seconds}}s"
+  },
   "settings": {
     "title": "Configuración",
     "description": "Preferencias de la aplicación y configuración de la base de datos.",
@@ -49,6 +52,8 @@
       "autoLockTimeout": "Tiempo de bloqueo automático (segundos)",
       "autoLockNote": "TODO: los eventos de inactividad/bloqueo del SO aún no están implementados.",
       "clipboardTimeout": "Tiempo de limpieza del portapapeles (segundos)",
+      "clearClipboardOnLock": "Limpiar portapapeles al bloquear",
+      "showClipboardCountdown": "Mostrar cuenta regresiva del portapapeles",
       "showPasswordByDefault": "Mostrar contraseñas por defecto",
       "minimizeToTray": "Minimizar a la bandeja",
       "startMinimized": "Iniciar minimizado"

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -15,6 +15,9 @@
     "copied": "Copié",
     "noDatabase": "Aucune base de données"
   },
+  "clipboard": {
+    "countdown": "Le presse-papiers s'efface dans {{seconds}}s"
+  },
   "settings": {
     "title": "Paramètres",
     "description": "Préférences de l'application et configuration de la base de données.",
@@ -49,6 +52,8 @@
       "autoLockTimeout": "Délai de verrouillage automatique (secondes)",
       "autoLockNote": "TODO : les événements d'inactivité/verrouillage du système ne sont pas encore implémentés.",
       "clipboardTimeout": "Délai d'effacement du presse-papiers (secondes)",
+      "clearClipboardOnLock": "Effacer le presse-papiers au verrouillage",
+      "showClipboardCountdown": "Afficher le compte à rebours du presse-papiers",
       "showPasswordByDefault": "Afficher les mots de passe par défaut",
       "minimizeToTray": "Réduire dans la barre des tâches",
       "startMinimized": "Démarrer réduit"

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -15,6 +15,9 @@
     "copied": "Kopirano",
     "noDatabase": "Nema baze podataka"
   },
+  "clipboard": {
+    "countdown": "Privremena memorija se briše za {{seconds}}s"
+  },
   "settings": {
     "title": "Podešavanja",
     "description": "Podešavanja aplikacije i konfiguracija baze podataka.",
@@ -49,6 +52,8 @@
       "autoLockTimeout": "Vreme automatskog zaključavanja (sekunde)",
       "autoLockNote": "TODO: događaji neaktivnosti/zaključavanja OS-a još nisu implementirani.",
       "clipboardTimeout": "Vreme brisanja privremene memorije (sekunde)",
+      "clearClipboardOnLock": "Obriši privremenu memoriju pri zaključavanju",
+      "showClipboardCountdown": "Prikaži odbrojavanje privremene memorije",
       "showPasswordByDefault": "Podrazumevano prikaži lozinke",
       "minimizeToTray": "Minimiziraj u sistemsku traku",
       "startMinimized": "Pokreni minimizovano"

--- a/src/views/MobileContentArea.tsx
+++ b/src/views/MobileContentArea.tsx
@@ -13,11 +13,12 @@ import { useSearchShortcut } from "@/hooks/use-search-shortcut";
 import { useShortcut } from "@/hooks/use-shortcut";
 import { useEntryListHeader } from "@/hooks/use-entry-list-header";
 import { useActiveDatabase } from "@/hooks/use-active-database";
+import { useAppPreferences } from "@/hooks/use-app-preferences";
 import { useDatabaseTabs } from "@/stores/database-tabs";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { toast } from "sonner";
 import { SHORTCUTS } from "@/lib/shortcuts";
-import { database } from "@/lib/tauri";
+import { clipboard, database } from "@/lib/tauri";
 
 const MOBILE_SEARCH_INPUT_ID = "mobile-global-search-input";
 
@@ -27,6 +28,10 @@ export default function MobileContentArea() {
   const navigate = useNavigate();
   const { tab, dbId } = useActiveDatabase();
   const removeTab = useDatabaseTabs((s) => s.removeTab);
+  const { preferences } = useAppPreferences();
+  const clearClipboardOnLock = Boolean(
+    preferences?.security.clearClipboardOnLock
+  );
 
   const search = useSearch({ strict: false });
   const searchGroupId = (search.groupId as string | undefined) ?? null;
@@ -69,6 +74,13 @@ export default function MobileContentArea() {
       if (!tab?.id || !dbId) return;
       void (async () => {
         try {
+          if (clearClipboardOnLock) {
+            try {
+              await clipboard.clear();
+            } catch (error) {
+              console.error("Failed to clear clipboard before lock:", error);
+            }
+          }
           await database.close(dbId);
           removeTab(tab.id);
           void navigate({ to: "/" });
@@ -76,7 +88,7 @@ export default function MobileContentArea() {
           // lock failed silently
         }
       })();
-    }, [tab, dbId, removeTab, navigate]),
+    }, [tab, dbId, removeTab, navigate, clearClipboardOnLock]),
     Boolean(dbId)
   );
 


### PR DESCRIPTION
## Summary
- add backend clipboard support for protected custom fields via a new `copy_protected_field_to_clipboard` command
- add security preference flags for clearing clipboard on lock and showing a clipboard countdown
- clear clipboard on app exit and on database lock (when preference is enabled)
- add countdown/toast feedback for clipboard copy actions in entry details, generator, and keyboard shortcut paths
- update i18n strings and tests to cover the new clipboard behavior

## Validation
- `bun run test -- src/hooks/__tests__/use-clipboard-countdown.test.ts src/components/entries/__tests__/EntryItemDetails.test.tsx src/components/generator/__tests__/PasswordGeneratorPage.test.tsx src/components/entries/__tests__/PasswordGeneratorDialog.test.tsx src/components/settings/__tests__/SettingsView.test.tsx src/hooks/__tests__/use-app-preferences.test.tsx src/lib/tauri.test.ts`
- `cargo test --test command_handlers_test` (from `src-tauri`)

Closes #38