### PR TITLE
fix(ui): adopt eslint-plugin-react-hooks v7.1 rules

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.5",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.26",
         "globals": "^17.0.0",
         "husky": "^9.1.7",
@@ -895,7 +895,7 @@
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
 
-    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.0.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA=="],
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
     "eslint-plugin-react-refresh": ["eslint-plugin-react-refresh@0.4.26", "", { "peerDependencies": { "eslint": ">=8.40" } }, "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ=="],
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^17.0.0",
     "husky": "^9.1.7",

--- a/src/components/generator/PasswordGenerator.tsx
+++ b/src/components/generator/PasswordGenerator.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, Copy, Dices } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -58,23 +58,12 @@ export function PasswordGenerator({ onUsePassword }: PasswordGeneratorProps) {
   const [passphraseOptions, setPassphraseOptions] =
     useState<PassphraseGeneratorOptions>(DEFAULT_PASSPHRASE_OPTIONS);
 
-  const stablePasswordOptions = useMemo(
-    () => passwordOptions,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(passwordOptions)]
-  );
-  const stablePassphraseOptions = useMemo(
-    () => passphraseOptions,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(passphraseOptions)]
-  );
-
   const passwordGen = usePasswordGenerator(
-    stablePasswordOptions,
+    passwordOptions,
     activeTab === "password"
   );
   const passphraseGen = usePassphraseGenerator(
-    stablePassphraseOptions,
+    passphraseOptions,
     activeTab === "passphrase"
   );
 

--- a/src/components/layout/nav-actions.tsx
+++ b/src/components/layout/nav-actions.tsx
@@ -101,10 +101,6 @@ const data = [
 export function NavActions() {
   const [isOpen, setIsOpen] = React.useState(false);
 
-  React.useEffect(() => {
-    setIsOpen(false);
-  }, []);
-
   return (
     <div className="flex items-center gap-2 text-sm">
       {/*<div className="text-muted-foreground hidden font-medium md:inline-block">*/}

--- a/src/components/security/unlock-database-form/UnlockDbForm.tsx
+++ b/src/components/security/unlock-database-form/UnlockDbForm.tsx
@@ -120,14 +120,23 @@ export function UnlockDbForm({
     }
   }, [initialPath, openDbForm]);
 
+  // Sync the rememberKeyfile checkbox to the prop during render so we don't
+  // trigger an extra render via useEffect setState.
+  const [prevRememberKeyfileDefault, setPrevRememberKeyfileDefault] = useState(
+    rememberKeyfileDefault
+  );
+  if (prevRememberKeyfileDefault !== rememberKeyfileDefault) {
+    setPrevRememberKeyfileDefault(rememberKeyfileDefault);
+    if (rememberKeyfileDefault !== undefined) {
+      setRememberKeyfile(Boolean(rememberKeyfileDefault));
+    }
+  }
+
   useEffect(() => {
     if (initialKeyfile !== undefined) {
       openDbForm.setValue("keyfilePath", initialKeyfile ?? "");
     }
-    if (rememberKeyfileDefault !== undefined) {
-      setRememberKeyfile(Boolean(rememberKeyfileDefault));
-    }
-  }, [initialKeyfile, rememberKeyfileDefault, openDbForm]);
+  }, [initialKeyfile, openDbForm]);
 
   async function handleSelectDatabase() {
     try {

--- a/src/hooks/use-entry-detail.ts
+++ b/src/hooks/use-entry-detail.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
 import { entries } from "@/lib/tauri";
@@ -8,6 +8,15 @@ import { entries } from "@/lib/tauri";
 export function useEntryDetail(entryId: string | null, dbId: string | null) {
   const [password, setPassword] = useState<string | null>(null);
   const [isPasswordLoading, setIsPasswordLoading] = useState(false);
+
+  // Clear password when entry changes (security requirement).
+  // Done during render via the "store previous prop in state" pattern so we
+  // don't trigger an extra render via useEffect.
+  const [prevEntryId, setPrevEntryId] = useState(entryId);
+  if (prevEntryId !== entryId) {
+    setPrevEntryId(entryId);
+    setPassword(null);
+  }
 
   const {
     data: entry,
@@ -25,11 +34,6 @@ export function useEntryDetail(entryId: string | null, dbId: string | null) {
   const isTransitioning = Boolean(
     entryId && entry && (isPlaceholderData || entry.id !== entryId)
   );
-
-  // Clear password when entry changes (security requirement)
-  useEffect(() => {
-    setPassword(null);
-  }, [entryId]);
 
   const revealPassword = useCallback(async () => {
     if (!dbId || !entryId) return;

--- a/src/hooks/use-entry-edit-form.ts
+++ b/src/hooks/use-entry-edit-form.ts
@@ -105,11 +105,20 @@ export function useEntryEditForm({
     groupIdRef.current = groupId;
   }, [groupId]);
 
+  // Reset state when the active entry changes. React-internal state (error,
+  // loading flag) is reset during render via the "store previous prop in
+  // state" pattern; the RHF form.reset stays in an effect since it's an
+  // external system update.
+  const [prevFormKey, setPrevFormKey] = useState({ dbId, entryId });
+  if (prevFormKey.dbId !== dbId || prevFormKey.entryId !== entryId) {
+    setPrevFormKey({ dbId, entryId });
+    setSecretLoadError(null);
+    setIsLoadingSecrets(Boolean(entryId));
+  }
+
   useEffect(() => {
     const currentEntry = entryRef.current ?? null;
     form.reset(getEntryFormDefaults(currentEntry, groupIdRef.current));
-    setSecretLoadError(null);
-    setIsLoadingSecrets(Boolean(entryId));
   }, [dbId, entryId, form]);
 
   useEffect(() => {

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -3,8 +3,8 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined
+  const [isMobile, setIsMobile] = React.useState<boolean>(
+    () => typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT
   );
 
   React.useEffect(() => {
@@ -13,9 +13,8 @@ export function useIsMobile() {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     };
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
-  return !!isMobile;
+  return isMobile;
 }

--- a/src/hooks/use-password-generator.ts
+++ b/src/hooks/use-password-generator.ts
@@ -42,6 +42,9 @@ export function usePasswordGenerator(
 
   useEffect(() => {
     if (enabled) {
+      // regenerate awaits a Rust IPC call before any setState fires, so this
+      // is external-system sync, not synchronous setState in the effect body.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       void regenerate(options);
     }
   }, [enabled, regenerate, options]);
@@ -90,6 +93,8 @@ export function usePassphraseGenerator(
 
   useEffect(() => {
     if (enabled) {
+      // See usePasswordGenerator above for why this is suppressed.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       void regenerate(options);
     }
   }, [enabled, regenerate, options]);


### PR DESCRIPTION
## Summary

Bumps `eslint-plugin-react-hooks` to `^7.1.1` and cleans up the source patterns the new rules flag, so future Dependabot bumps (e.g. #166) don't break the lint job.

## Why

Plugin 7.1.x ships three new rules that fire against pre-existing code:
- `react-hooks/set-state-in-effect` — flags synchronous `setState` calls inside `useEffect`
- `react-hooks/use-memo` — flags non-simple expressions in dep arrays (e.g. `[JSON.stringify(x)]`)
- `react-hooks/incompatible-library` — informational, only a warning for TanStack Table

Without this PR, #166 (the Dependabot dep group bump) and any subsequent bump that drags this plugin past 7.0.x will fail CI.

## Changes

- **`PasswordGenerator.tsx`** — drop the `useMemo([JSON.stringify(opts)])` wrappers; React state references are already stable between renders, so the memo was a no-op.
- **`use-mobile.tsx`** — initialize from `window.innerWidth` via lazy `useState` instead of an effect that immediately calls `setState`.
- **`nav-actions.tsx`** — drop the redundant mount-time `setIsOpen(false)` effect; initial `useState(false)` already covers it.
- **`use-entry-detail.ts`**, **`use-entry-edit-form.ts`**, **`UnlockDbForm.tsx`** — adopt the React-recommended ["store previous prop in state"](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) pattern: reset React-internal state during render. RHF `form.reset` / `setValue` calls stay in `useEffect` since they're a genuine external-system sync.
- **`use-password-generator.ts`** — targeted `eslint-disable-next-line react-hooks/set-state-in-effect` on the `regenerate(options)` call. Justification: `regenerate` `await`s a Rust IPC call before any `setState` fires, so this is external-system sync, not synchronous `setState` in the effect body. The lint rule's static analysis can't tell the difference; `useEffectEvent` would be the proper tool but it's still experimental in React 19.

The TanStack Table `react-hooks/incompatible-library` warning in `data-table.tsx` is informational and remains a (non-blocking) warning.

## Test plan

- [x] `bun run check` — 0 errors, only pre-existing `react-refresh/only-export-components` warnings remain
- [x] `bun run test` — all 307 frontend tests pass
- [ ] Manual smoke: unlock flow, entry edit form, password generator regenerate, mobile/desktop layout switch
- [ ] Once merged, rebase #166 — its lint job should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)