### PR TITLE
fix(core): hide recycle bin entries from unfiltered list

### DIFF
--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -1,6 +1,6 @@
 use crate::dto::entry::{CreateEntryData, CustomFieldValue, Entry, UpdateEntryData};
 use crate::dto::error::AppError;
-use keepass::db::{Entry as KeepassEntry, Times, Value};
+use keepass::db::{Entry as KeepassEntry, EntryRef, Times, Value};
 use keepass::Database;
 
 use super::mapping::{
@@ -33,7 +33,17 @@ impl KdbxService {
                 entries.push(convert_entry(&entry, &group_uuid));
             }
         } else {
+            // The unfiltered "all entries" view hides anything inside the
+            // recycle bin so deleted entries don't appear to come back. The
+            // recycle bin group is still navigable directly through the
+            // `Some(gid)` branch above.
+            let recycle_uuid = db.meta.recyclebin_uuid;
             for entry in db.iter_all_entries() {
+                if let Some(rid) = recycle_uuid {
+                    if is_in_recycle_bin(db, &entry, rid) {
+                        continue;
+                    }
+                }
                 let group_uuid = entry.parent().id().uuid().to_string();
                 entries.push(convert_entry(&entry, &group_uuid));
             }
@@ -339,6 +349,23 @@ impl KdbxService {
     }
 }
 
+fn is_in_recycle_bin(db: &Database, entry: &EntryRef<'_>, recycle_uuid: uuid::Uuid) -> bool {
+    // Walk ancestors by GroupId rather than holding a GroupRef across the
+    // loop — re-looking up via db.group(gid) gives each iteration its own
+    // borrow scope, matching is_ancestor_of's pattern in mapping.rs.
+    let mut current_id = Some(entry.parent().id());
+    while let Some(gid) = current_id {
+        if gid.uuid() == recycle_uuid {
+            return true;
+        }
+        let Some(group) = db.group(gid) else {
+            return false;
+        };
+        current_id = group.parent().map(|p| p.id());
+    }
+    false
+}
+
 fn populate_entry(entry: &mut keepass::db::EntryMut<'_>, data: &CreateEntryData) {
     entry
         .fields
@@ -520,4 +547,124 @@ fn dedupe_preserving_order(tags: &mut Vec<String>) {
         }
     }
     *tags = deduped;
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::domain::secure::SecureString;
+    use crate::dto::database::DatabaseCreationOptions;
+    use tempfile::TempDir;
+
+    fn create_test_database() -> (KdbxService, TempDir, String, String, String) {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("entries-tests.kdbx");
+        let db_path_str = db_path.to_string_lossy().to_string();
+
+        let options = DatabaseCreationOptions {
+            create_default_groups: true,
+            kdf_memory: Some(1024 * 1024),
+            kdf_iterations: Some(1),
+            kdf_parallelism: Some(1),
+            description: None,
+        };
+
+        let service = KdbxService::new();
+        service
+            .create_database(
+                &db_path_str,
+                Some("testpass"),
+                None,
+                "Entries Tests",
+                &options,
+            )
+            .expect("create db");
+        let info = service.get_info(&db_path_str).expect("database info");
+
+        let entry_a = service
+            .create_entry(
+                &db_path_str,
+                &info.root_group_id,
+                CreateEntryData {
+                    title: "Entry A".to_string(),
+                    username: "alice".to_string(),
+                    password: SecureString::from("secret"),
+                    url: None,
+                    notes: None,
+                    icon_id: Some(0),
+                    tags: None,
+                    custom_fields: None,
+                    protected_custom_fields: None,
+                },
+            )
+            .expect("create entry A");
+        let entry_b = service
+            .create_entry(
+                &db_path_str,
+                &info.root_group_id,
+                CreateEntryData {
+                    title: "Entry B".to_string(),
+                    username: "bob".to_string(),
+                    password: SecureString::from("secret"),
+                    url: None,
+                    notes: None,
+                    icon_id: Some(0),
+                    tags: None,
+                    custom_fields: None,
+                    protected_custom_fields: None,
+                },
+            )
+            .expect("create entry B");
+
+        (service, dir, db_path_str, entry_a.id, entry_b.id)
+    }
+
+    #[test]
+    fn list_entries_without_group_filter_hides_recycle_bin_entries() {
+        // Regression: deleting an entry moves it to the recycle bin, but the
+        // unfiltered list view used to keep returning it (since
+        // db.iter_all_entries() walks the whole tree). The user observed:
+        // entry vanishes from details, stays in list, "isn't really deleted".
+        let (service, _dir, db_path, entry_a, entry_b) = create_test_database();
+
+        let initial = service
+            .list_entries(&db_path, None)
+            .expect("list all entries");
+        let initial_ids: Vec<&str> = initial.iter().map(|e| e.id.as_str()).collect();
+        assert!(initial_ids.contains(&entry_a.as_str()));
+        assert!(initial_ids.contains(&entry_b.as_str()));
+
+        service
+            .delete_entry(&db_path, &entry_a)
+            .expect("delete entry A");
+
+        let after = service
+            .list_entries(&db_path, None)
+            .expect("list all entries after delete");
+        let after_ids: Vec<&str> = after.iter().map(|e| e.id.as_str()).collect();
+        assert!(
+            !after_ids.contains(&entry_a.as_str()),
+            "deleted entry should not appear in the unfiltered list"
+        );
+        assert!(
+            after_ids.contains(&entry_b.as_str()),
+            "non-deleted siblings should remain"
+        );
+
+        // The entry is still in the database — just inside the recycle bin —
+        // and accessible when the recycle bin group is queried directly.
+        let recycle_id = service
+            .get_recycle_bin_id(&db_path)
+            .expect("get recycle bin id")
+            .expect("recycle bin should exist after a delete");
+        let in_recycle = service
+            .list_entries(&db_path, Some(&recycle_id))
+            .expect("list recycle bin entries");
+        let recycle_ids: Vec<&str> = in_recycle.iter().map(|e| e.id.as_str()).collect();
+        assert!(
+            recycle_ids.contains(&entry_a.as_str()),
+            "deleted entry should be visible inside the recycle bin group"
+        );
+    }
 }

--- a/src-tauri/tests/commands/entries_test.rs
+++ b/src-tauri/tests/commands/entries_test.rs
@@ -487,8 +487,20 @@ fn test_delete_entry_moves_to_recycle_bin() {
         .list_entries(&db_path_str, None)
         .expect("all entries");
     assert!(
-        all_entries.iter().any(|item| item.id == entry.id),
-        "Entry should remain in database after delete"
+        !all_entries.iter().any(|item| item.id == entry.id),
+        "Recycle-bin entries should be hidden from the unfiltered list"
+    );
+
+    let recycle_id = service
+        .get_recycle_bin_id(&db_path_str)
+        .expect("get recycle bin id")
+        .expect("recycle bin should exist after a delete");
+    let recycle_entries = service
+        .list_entries(&db_path_str, Some(&recycle_id))
+        .expect("recycle bin entries");
+    assert!(
+        recycle_entries.iter().any(|item| item.id == entry.id),
+        "Deleted entry should remain in the database, inside the recycle bin"
     );
 
     let moved_entry = service


### PR DESCRIPTION
## Summary

Fixes a bug where deleting an entry appeared not to work:

- User clicks Delete → details panel clears, but the entry stays in the list.
- On reopening the database, the entry is still present.
- User concludes "delete is broken."

### Root cause

\`KdbxService::list_entries(db_id, None)\` walked \`db.iter_all_entries()\` over the whole database tree, including entries inside the recycle bin. The default dashboard route leaves \`search.groupId\` undefined (\`src/routes/dashboard/index.\$dbId.tsx:11\`), so this no-filter path is the "all entries" view the user is typically looking at.

\`delete_entry\` correctly moves the entry to the recycle bin (standard KeePass semantics). The query invalidation correctly refetches. But the refetched list still included the now-in-recycle-bin entry, so the UI showed no change.

The bug is **pre-existing on \`main\`** — not introduced by any recent refactor.

### Fix

Filter recycle-bin descendants out of \`list_entries\` when no group filter is provided. Explicit navigation to the recycle bin (clicking it in the sidebar) goes through the \`Some(gid)\` branch with \`group.entries()\` and is unchanged.

The ancestor walk goes by \`GroupId\` rather than holding a \`GroupRef\` across loop iterations (matches the existing \`is_ancestor_of\` pattern in \`mapping.rs\`). This catches the case where a whole group was moved into the recycle bin — the entry's direct parent is the moved group, but it's still effectively deleted.

### Test plan

- [x] New unit test \`list_entries_without_group_filter_hides_recycle_bin_entries\` covers the regression.
- [x] Updated one existing integration test (\`test_delete_entry_moves_to_recycle_bin\`) that previously asserted the *buggy* behavior — it expected deleted entries to be visible in \`list_entries(db, None)\`. Now verifies the correct invariant: entry is hidden from the unfiltered list, but still accessible via the recycle bin group.
- [x] \`cargo test --lib\` — 112 passed.
- [x] \`cargo test\` (integration) — all pass.
- [x] \`cargo clippy --tests --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --check\` — clean.
- [x] \`bun run test\` — 318 passed.
- [x] \`bunx tsc --noEmit\` — clean.
- [ ] Manual smoke: open a database without selecting a group, delete an entry, verify it vanishes from the list as well as the details panel.
- [ ] Manual smoke: click the Recycle Bin group in the sidebar, verify the deleted entry is there.
- [ ] Manual smoke: close and reopen the database, verify the entry is still inside the recycle bin (not gone forever — that's a separate feature).

### Out of scope

- **Permanent delete for entries.** \`delete_group\` accepts \`permanent: bool\`; \`delete_entry\` doesn't. Adding it is a feature, not a bug fix.
- **"Empty recycle bin"** action. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)