### PR TITLE
feat(core): pre-save vault snapshot MVP with enable-backups toggle (#190)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::dto::error::AppError;
+use crate::services::kdbx::KdbxService;
 use crate::services::settings::SettingsService;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -138,6 +139,19 @@ pub struct AdvancedSettings {
     pub data_location: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct BackupSettings {
+    pub enabled: bool,
+}
+
+impl Default for BackupSettings {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
@@ -147,6 +161,7 @@ pub struct AppPreferences {
     pub appearance: AppearanceSettings,
     pub browser_integration: BrowserIntegrationSettings,
     pub advanced: AdvancedSettings,
+    pub backups: BackupSettings,
 }
 
 /// Persisted shape written to `settings.json`. Combines the editable
@@ -171,15 +186,21 @@ pub async fn get_app_preferences(
 pub async fn update_app_preferences(
     new_preferences: AppPreferences,
     settings_service: State<'_, Arc<SettingsService>>,
+    kdbx_service: State<'_, Arc<KdbxService>>,
 ) -> Result<(), AppError> {
-    settings_service.update_app_preferences(&new_preferences)
+    settings_service.update_app_preferences(&new_preferences)?;
+    kdbx_service.set_backup_settings(new_preferences.backups)?;
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn reset_app_preferences(
     settings_service: State<'_, Arc<SettingsService>>,
+    kdbx_service: State<'_, Arc<KdbxService>>,
 ) -> Result<AppPreferences, AppError> {
-    settings_service.reset_app_preferences()
+    let prefs = settings_service.reset_app_preferences()?;
+    kdbx_service.set_backup_settings(prefs.backups.clone())?;
+    Ok(prefs)
 }
 
 #[tauri::command]

--- a/src-tauri/src/dto/error.rs
+++ b/src-tauri/src/dto/error.rs
@@ -106,6 +106,9 @@ pub enum AppError {
 
     #[error("Invalid input: {0}")]
     InvalidInput(String),
+
+    #[error("Backup failed for {path}: {reason}")]
+    BackupFailed { path: String, reason: String },
 }
 
 impl Serialize for AppError {
@@ -120,5 +123,18 @@ impl Serialize for AppError {
 impl From<std::io::Error> for AppError {
     fn from(err: std::io::Error) -> Self {
         Self::Io(err.to_string())
+    }
+}
+
+impl From<crate::services::kdbx::backups::BackupError> for AppError {
+    fn from(err: crate::services::kdbx::backups::BackupError) -> Self {
+        match err {
+            crate::services::kdbx::backups::BackupError::BackupFailed { path, source } => {
+                Self::BackupFailed {
+                    path: path.to_string_lossy().into_owned(),
+                    reason: source.to_string(),
+                }
+            }
+        }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -122,12 +122,18 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     app.manage(Arc::new(secure_storage));
 
     let kdbx_service = KdbxService::new();
-    app.manage(Arc::new(kdbx_service));
+    let kdbx_arc = Arc::new(kdbx_service);
+    app.manage(Arc::clone(&kdbx_arc));
 
     let clipboard_service = ClipboardService::new();
     app.manage(Arc::new(clipboard_service));
 
     let settings_service = SettingsService::new(app)?;
+    // Push the persisted backup config into the KDBX service so the save
+    // hook honours it from first save onward.
+    if let Ok(prefs) = settings_service.get_app_preferences() {
+        let _ = kdbx_arc.set_backup_settings(prefs.backups);
+    }
     app.manage(Arc::new(settings_service));
 
     let auto_lock_service = AutoLockService::new();

--- a/src-tauri/src/services/kdbx/backups/filename.rs
+++ b/src-tauri/src/services/kdbx/backups/filename.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: MIT
+
+//! Pure helpers for backup snapshot filenames.
+//!
+//! Pattern: `<vault-filename-with-extension>.backup.<YYYYMMDDTHHMMSS.mmmZ>.kdbx`.
+//! Lex sort over generated names matches chronological order by construction
+//! (fixed-width fields, UTC, basic ISO 8601). Same-millisecond collisions are
+//! resolved by bumping to the next free millisecond.
+
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+
+const TIMESTAMP_FMT: &str = "%Y%m%dT%H%M%S%.3fZ";
+const BACKUP_INFIX: &str = ".backup.";
+const BACKUP_SUFFIX: &str = ".kdbx";
+
+/// Builds the snapshot filename for a Vault and an auto-snapshot timestamp.
+pub fn make_backup_filename(vault_filename: &str, ts: DateTime<Utc>) -> String {
+    format!(
+        "{vault_filename}{BACKUP_INFIX}{}{BACKUP_SUFFIX}",
+        ts.format(TIMESTAMP_FMT)
+    )
+}
+
+/// Parses a snapshot filename back into the source Vault filename and its
+/// auto-snapshot timestamp. Returns `None` if the name does not match the
+/// auto-snapshot pattern.
+pub fn parse_backup_filename(filename: &str) -> Option<(String, DateTime<Utc>)> {
+    let stem = filename.strip_suffix(BACKUP_SUFFIX)?;
+    let dot = stem.rfind(BACKUP_INFIX)?;
+    let (vault_filename, rest) = stem.split_at(dot);
+    let ts_str = &rest[BACKUP_INFIX.len()..];
+    let parsed = NaiveDateTime::parse_from_str(ts_str, TIMESTAMP_FMT).ok()?;
+    let ts = Utc.from_utc_datetime(&parsed);
+    Some((vault_filename.to_string(), ts))
+}
+
+/// Returns the next timestamp at-or-after `start` whose generated filename is
+/// not already taken by `existing`. Bumps in 1ms increments. Pure.
+pub fn next_free_timestamp<S: std::hash::BuildHasher>(
+    vault_filename: &str,
+    start: DateTime<Utc>,
+    existing: &std::collections::HashSet<String, S>,
+) -> DateTime<Utc> {
+    let mut ts = start;
+    loop {
+        let candidate = make_backup_filename(vault_filename, ts);
+        if !existing.contains(&candidate) {
+            return ts;
+        }
+        ts += chrono::Duration::milliseconds(1);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use std::collections::HashSet;
+
+    fn ts(ms: i64) -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(ms).single().expect("valid ts")
+    }
+
+    #[test]
+    fn make_filename_matches_expected_pattern() {
+        let t = Utc
+            .with_ymd_and_hms(2026, 5, 12, 14, 30, 45)
+            .single()
+            .expect("valid")
+            + chrono::Duration::milliseconds(123);
+        let name = make_backup_filename("vault.kdbx", t);
+        assert_eq!(name, "vault.kdbx.backup.20260512T143045.123Z.kdbx");
+    }
+
+    #[test]
+    fn parse_roundtrip() {
+        let original = ts(1_715_000_000_123);
+        let name = make_backup_filename("vault.kdbx", original);
+        let (vault, parsed) = parse_backup_filename(&name).expect("parses");
+        assert_eq!(vault, "vault.kdbx");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn parse_rejects_non_backup_names() {
+        assert!(parse_backup_filename("vault.kdbx").is_none());
+        assert!(parse_backup_filename("vault.kdbx.bak").is_none());
+        assert!(parse_backup_filename("vault.kdbx.backup.notadate.kdbx").is_none());
+    }
+
+    #[test]
+    fn parse_handles_vault_names_containing_dot_backup() {
+        let original = ts(1_715_000_000_456);
+        let name = make_backup_filename("my.backup.notes.kdbx", original);
+        let (vault, parsed) = parse_backup_filename(&name).expect("parses");
+        assert_eq!(vault, "my.backup.notes.kdbx");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn lex_sort_matches_chronological_sort() {
+        let timestamps = [
+            ts(1_715_000_000_000),
+            ts(1_715_000_000_001),
+            ts(1_715_000_001_000),
+            ts(1_715_000_500_000),
+            ts(1_900_000_000_000),
+        ];
+        let names: Vec<String> = timestamps
+            .iter()
+            .map(|t| make_backup_filename("vault.kdbx", *t))
+            .collect();
+
+        let mut by_chrono = names.clone();
+        // Already in chrono order because the source list is.
+        let mut by_lex = names.clone();
+        by_lex.sort();
+        // by_chrono is already chronological, but make it explicit.
+        by_chrono.sort_by_key(|n| {
+            parse_backup_filename(n)
+                .expect("parses")
+                .1
+                .timestamp_millis()
+        });
+
+        assert_eq!(by_lex, by_chrono);
+    }
+
+    #[test]
+    fn next_free_returns_start_when_no_collision() {
+        let start = ts(1_715_000_000_000);
+        let chosen = next_free_timestamp("vault.kdbx", start, &HashSet::new());
+        assert_eq!(chosen, start);
+    }
+
+    #[test]
+    fn next_free_bumps_until_unused() {
+        let start = ts(1_715_000_000_000);
+        let mut taken: HashSet<String> = HashSet::new();
+        taken.insert(make_backup_filename("vault.kdbx", start));
+        taken.insert(make_backup_filename(
+            "vault.kdbx",
+            start + chrono::Duration::milliseconds(1),
+        ));
+
+        let chosen = next_free_timestamp("vault.kdbx", start, &taken);
+        assert_eq!(chosen, start + chrono::Duration::milliseconds(2));
+    }
+}

--- a/src-tauri/src/services/kdbx/backups/mod.rs
+++ b/src-tauri/src/services/kdbx/backups/mod.rs
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+
+//! Pre-save Vault snapshot module.
+//!
+//! Owns directory resolution, snapshot filename construction, and the snapshot
+//! write itself. See parent issue #61 for the full design and #190 for this slice.
+
+pub mod filename;
+
+use crate::commands::settings::BackupSettings;
+use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
+use chrono::Utc;
+use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Sibling subdirectory that holds snapshot files for a Vault.
+pub const BACKUP_SUBDIR: &str = ".kdbx-backups";
+
+/// Outcome of a successful snapshot.
+#[derive(Debug, Clone)]
+pub struct BackupInfo {
+    pub path: PathBuf,
+}
+
+/// Failure modes for snapshot creation.
+#[derive(Debug, Error)]
+pub enum BackupError {
+    #[error("Backup failed for {path}: {source}")]
+    BackupFailed {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+}
+
+/// Creates a pre-image snapshot of the on-disk Vault.
+///
+/// Returns `Ok(None)` when the source path does not exist yet — the first save
+/// of a brand-new Vault (or the first save after `save_as` to a fresh path)
+/// has no pre-image to capture and must not error.
+///
+/// Returns `Ok(Some(info))` on a successful snapshot, or `Err(BackupFailed)`
+/// if the directory cannot be prepared or the snapshot cannot be written.
+pub fn snapshot(
+    source: &Path,
+    settings: &BackupSettings,
+) -> Result<Option<BackupInfo>, BackupError> {
+    if !settings.enabled {
+        return Ok(None);
+    }
+
+    // First-save (and first-save-after-save-as) skip: source does not exist yet.
+    // `try_exists` is used so a real I/O failure surfaces rather than being
+    // silently treated as "not yet there".
+    let exists = source.try_exists().map_err(|e| BackupError::BackupFailed {
+        path: source.to_path_buf(),
+        source: e,
+    })?;
+    if !exists {
+        return Ok(None);
+    }
+
+    let parent = source.parent().ok_or_else(|| BackupError::BackupFailed {
+        path: source.to_path_buf(),
+        source: io::Error::new(io::ErrorKind::InvalidInput, "source has no parent"),
+    })?;
+    let backup_dir = parent.join(BACKUP_SUBDIR);
+    ensure_backup_dir(&backup_dir).map_err(|e| BackupError::BackupFailed {
+        path: backup_dir.clone(),
+        source: e,
+    })?;
+
+    let vault_filename =
+        source
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| BackupError::BackupFailed {
+                path: source.to_path_buf(),
+                source: io::Error::new(io::ErrorKind::InvalidInput, "source has no filename"),
+            })?;
+
+    let existing = read_existing_basenames(&backup_dir);
+    let ts = filename::next_free_timestamp(vault_filename, Utc::now(), &existing);
+    let backup_name = filename::make_backup_filename(vault_filename, ts);
+    let backup_path = backup_dir.join(&backup_name);
+    let backup_path_str = backup_path.to_string_lossy().into_owned();
+
+    let source_owned = source.to_path_buf();
+    atomic_write(
+        &backup_path_str,
+        &AtomicWriteOptions {
+            preserve_permissions: false,
+        },
+        |file| {
+            let mut src = fs::File::open(&source_owned).map_err(|e| {
+                crate::dto::error::AppError::Io(format!("Failed to open source for snapshot: {e}"))
+            })?;
+            io::copy(&mut src, file).map_err(|e| {
+                crate::dto::error::AppError::Io(format!("Failed to copy snapshot bytes: {e}"))
+            })?;
+            Ok(())
+        },
+    )
+    .map_err(|e| BackupError::BackupFailed {
+        path: backup_path.clone(),
+        source: io::Error::other(e.to_string()),
+    })?;
+
+    Ok(Some(BackupInfo { path: backup_path }))
+}
+
+fn ensure_backup_dir(dir: &Path) -> io::Result<()> {
+    // Reject a symlink at the backup path so a stale or hostile link cannot
+    // redirect snapshot bytes outside the vault folder. `symlink_metadata`
+    // does not follow links.
+    if let Ok(meta) = fs::symlink_metadata(dir) {
+        if meta.file_type().is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "backup directory path is a symlink",
+            ));
+        }
+    }
+    if !dir.exists() {
+        fs::create_dir_all(dir)?;
+    }
+    // Always (re-)apply 0700 on Unix — a directory left over from an earlier
+    // app version or created by another process may have broader permissions
+    // that would leak vault filenames/timestamps.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dir, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+fn read_existing_basenames(dir: &Path) -> HashSet<String> {
+    fs::read_dir(dir)
+        .ok()
+        .map(|entries| {
+            entries
+                .filter_map(Result::ok)
+                .filter_map(|e| e.file_name().to_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/src-tauri/src/services/kdbx/mod.rs
+++ b/src-tauri/src/services/kdbx/mod.rs
@@ -1,3 +1,4 @@
+pub mod backups;
 pub mod conversions;
 pub mod create;
 pub mod custom_icons;
@@ -11,6 +12,7 @@ pub mod open;
 pub mod save;
 pub mod vault;
 
+use crate::commands::settings::BackupSettings;
 use crate::domain::kdbx::OpenDatabase;
 use crate::dto::database::DatabaseInfo;
 use crate::dto::error::AppError;
@@ -25,6 +27,7 @@ pub struct KdbxService {
     /// The key is the canonical/normalized path to ensure consistent lookups.
     databases: Mutex<HashMap<String, OpenDatabase>>,
     pub(crate) favicons: FaviconCooldown,
+    backup_settings: Mutex<BackupSettings>,
 }
 
 impl KdbxService {
@@ -33,7 +36,23 @@ impl KdbxService {
         Self {
             databases: Mutex::new(HashMap::new()),
             favicons: FaviconCooldown::new(),
+            backup_settings: Mutex::new(BackupSettings::default()),
         }
+    }
+
+    /// Replaces the backup settings the save hook reads on each save.
+    ///
+    /// Called from app setup with the persisted value and from the settings
+    /// update command whenever the user changes the toggle.
+    pub fn set_backup_settings(&self, settings: BackupSettings) -> Result<(), AppError> {
+        let mut guard = self.backup_settings.lock().map_err(|_| AppError::Lock)?;
+        *guard = settings;
+        Ok(())
+    }
+
+    pub fn current_backup_settings(&self) -> Result<BackupSettings, AppError> {
+        let guard = self.backup_settings.lock().map_err(|_| AppError::Lock)?;
+        Ok(guard.clone())
     }
 
     /// Normalizes a database path for consistent `HashMap` keys.

--- a/src-tauri/src/services/kdbx/save.rs
+++ b/src-tauri/src/services/kdbx/save.rs
@@ -1,7 +1,9 @@
 use crate::domain::secure::SecureString;
 use crate::dto::error::AppError;
+use crate::services::kdbx::backups;
 use crate::services::kdbx::key::build_database_key;
 use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
+use std::path::Path;
 
 use super::KdbxService;
 
@@ -29,6 +31,12 @@ impl KdbxService {
             .db
             .as_ref()
             .ok_or_else(|| AppError::DatabaseLocked(open_db.path.clone()))?;
+
+        // Fail-closed pre-image snapshot. Returns Ok(None) when the source
+        // does not yet exist (first save of a brand-new vault or first save
+        // after save_as to a fresh path) — those proceed without a backup.
+        let backup_settings = self.current_backup_settings()?;
+        backups::snapshot(Path::new(&path), &backup_settings)?;
 
         atomic_write(
             &path,

--- a/src-tauri/tests/backups.rs
+++ b/src-tauri/tests/backups.rs
@@ -1,0 +1,265 @@
+#![allow(
+    clippy::expect_used,
+    clippy::panic,
+    clippy::case_sensitive_file_extension_comparisons
+)]
+
+//! Integration tests for the backup snapshot module.
+//!
+//! Tracks acceptance criteria from issue #190: pre-image bytes, filename shape,
+//! Unix permissions, first-save skip, fail-closed semantics, symlink resolution.
+
+use mithril_vault_lib::commands::settings::BackupSettings;
+#[cfg(unix)]
+use mithril_vault_lib::services::kdbx::backups::BackupError;
+use mithril_vault_lib::services::kdbx::backups::{snapshot, BACKUP_SUBDIR};
+use tempfile::tempdir;
+
+fn enabled() -> BackupSettings {
+    BackupSettings { enabled: true }
+}
+
+fn disabled() -> BackupSettings {
+    BackupSettings { enabled: false }
+}
+
+#[test]
+fn snapshot_creates_file_with_pre_image_bytes() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"pre-image bytes").expect("write source");
+
+    let info = snapshot(&vault_path, &enabled())
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    assert!(info.path.exists(), "snapshot file should exist");
+    let bytes = std::fs::read(&info.path).expect("read snapshot");
+    assert_eq!(bytes, b"pre-image bytes");
+}
+
+#[test]
+fn snapshot_filename_matches_documented_pattern() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("my-vault.kdbx");
+    std::fs::write(&vault_path, b"x").expect("write source");
+
+    let info = snapshot(&vault_path, &enabled())
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    let filename = info
+        .path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("filename");
+    assert!(
+        filename.starts_with("my-vault.kdbx.backup."),
+        "unexpected prefix: {filename}"
+    );
+    assert!(filename.ends_with(".kdbx"), "unexpected suffix: {filename}");
+    // Pattern: my-vault.kdbx.backup.YYYYMMDDTHHMMSS.mmmZ.kdbx
+    let middle = filename
+        .strip_prefix("my-vault.kdbx.backup.")
+        .and_then(|s| s.strip_suffix(".kdbx"))
+        .expect("middle");
+    assert_eq!(middle.len(), 20, "iso ts should be 20 chars: {middle}");
+    assert!(middle.ends_with('Z'), "iso ts should end with Z: {middle}");
+}
+
+#[test]
+fn snapshot_skips_when_source_missing() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("never-existed.kdbx");
+
+    let result = snapshot(&vault_path, &enabled()).expect("snapshot ok");
+    assert!(result.is_none(), "no snapshot on missing source");
+
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    assert!(
+        !backup_dir.exists(),
+        "no backup dir should be created on first-save skip"
+    );
+}
+
+#[test]
+fn snapshot_skips_when_disabled() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    let result = snapshot(&vault_path, &disabled()).expect("snapshot ok");
+    assert!(result.is_none(), "disabled snapshot returns None");
+
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    assert!(!backup_dir.exists(), "no backup dir when disabled");
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_unix_permissions_are_locked_down() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    let info = snapshot(&vault_path, &enabled())
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    let dir_mode = std::fs::metadata(&backup_dir)
+        .expect("dir metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        dir_mode, 0o700,
+        "backup dir should be 0700, got {dir_mode:o}"
+    );
+
+    let file_mode = std::fs::metadata(&info.path)
+        .expect("file metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        file_mode, 0o600,
+        "backup file should be 0600, got {file_mode:o}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_fails_closed_when_directory_cannot_be_created() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    // Make the parent directory read-only so .kdbx-backups/ cannot be created.
+    let mut perms = std::fs::metadata(dir.path())
+        .expect("dir meta")
+        .permissions();
+    let original = perms.mode();
+    perms.set_mode(0o500);
+    std::fs::set_permissions(dir.path(), perms).expect("set ro");
+
+    let result = snapshot(&vault_path, &enabled());
+
+    // Restore so tempdir cleanup works.
+    let mut restore = std::fs::metadata(dir.path())
+        .expect("dir meta")
+        .permissions();
+    restore.set_mode(original);
+    std::fs::set_permissions(dir.path(), restore).expect("restore");
+
+    match result {
+        Err(BackupError::BackupFailed { path, .. }) => {
+            assert!(
+                path.ends_with(BACKUP_SUBDIR),
+                "BackupFailed path should name the backup directory, got {path:?}"
+            );
+        }
+        other => panic!("expected BackupFailed, got {other:?}"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_follows_symlinks_to_target_bytes() {
+    let dir = tempdir().expect("tempdir");
+    let real_vault = dir.path().join("real-vault.kdbx");
+    let symlink = dir.path().join("vault.kdbx");
+    std::fs::write(&real_vault, b"target bytes").expect("write target");
+    std::os::unix::fs::symlink(&real_vault, &symlink).expect("symlink");
+
+    let info = snapshot(&symlink, &enabled())
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    let bytes = std::fs::read(&info.path).expect("read snapshot");
+    assert_eq!(bytes, b"target bytes");
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_rehardens_backup_dir_to_0700_if_left_loose() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    // Simulate a pre-existing .kdbx-backups/ created with broader mode
+    // (e.g. by an older version of the app or a manual `mkdir`).
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    std::fs::create_dir_all(&backup_dir).expect("create dir");
+    std::fs::set_permissions(&backup_dir, std::fs::Permissions::from_mode(0o755))
+        .expect("set loose");
+
+    snapshot(&vault_path, &enabled())
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    let mode = std::fs::metadata(&backup_dir)
+        .expect("dir meta")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o700,
+        "pre-existing backup dir should be re-hardened to 0700, got {mode:o}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_rejects_symlinked_backup_directory() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    // Plant a symlink at the .kdbx-backups/ path pointing somewhere else.
+    let elsewhere = tempdir().expect("tempdir 2");
+    let backup_link = dir.path().join(BACKUP_SUBDIR);
+    std::os::unix::fs::symlink(elsewhere.path(), &backup_link).expect("symlink");
+
+    let result = snapshot(&vault_path, &enabled());
+    assert!(
+        matches!(result, Err(BackupError::BackupFailed { .. })),
+        "symlinked backup directory must abort the snapshot, got {result:?}"
+    );
+
+    // Confirm we did not write into the symlink target.
+    let exfiltrated: Vec<_> = std::fs::read_dir(elsewhere.path())
+        .expect("read elsewhere")
+        .filter_map(Result::ok)
+        .collect();
+    assert!(
+        exfiltrated.is_empty(),
+        "no bytes should have been written via the symlink"
+    );
+}
+
+#[test]
+fn snapshot_handles_same_millisecond_collision() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"v1").expect("write source");
+
+    let first = snapshot(&vault_path, &enabled())
+        .expect("snapshot ok")
+        .expect("created");
+    // Overwrite source to bump mtime; rapid second call may hit same ms.
+    std::fs::write(&vault_path, b"v2").expect("write source");
+    let second = snapshot(&vault_path, &enabled())
+        .expect("snapshot ok")
+        .expect("created");
+
+    assert_ne!(first.path, second.path, "collision should bump filename");
+    let bytes = std::fs::read(&second.path).expect("read");
+    assert_eq!(bytes, b"v2");
+}

--- a/src-tauri/tests/commands/settings_test.rs
+++ b/src-tauri/tests/commands/settings_test.rs
@@ -8,6 +8,7 @@ use mithril_vault_lib::commands::settings::{
     get_recent_databases, remove_recent_database, reset_app_preferences, update_app_preferences,
     StartupBehavior,
 };
+use mithril_vault_lib::services::kdbx::KdbxService;
 use mithril_vault_lib::services::settings::SettingsService;
 use std::sync::Arc;
 use tauri::test::mock_app;
@@ -17,6 +18,7 @@ fn setup_app() -> tauri::App<tauri::test::MockRuntime> {
     let app = mock_app();
     let settings_service = SettingsService::new(app.handle()).expect("create settings service");
     app.manage(Arc::new(settings_service));
+    app.manage(Arc::new(KdbxService::new()));
     app
 }
 
@@ -43,7 +45,7 @@ fn get_and_update_preferences_commands() {
     updated.appearance.theme = "light".into();
     updated.security.prevent_screen_capture = false;
 
-    tauri::async_runtime::block_on(update_app_preferences(updated, app.state()))
+    tauri::async_runtime::block_on(update_app_preferences(updated, app.state(), app.state()))
         .expect("update preferences");
 
     let refreshed =
@@ -123,8 +125,12 @@ fn app_preferences_commands() {
     prefs.browser_integration.allowed_sites = vec!["example.com".into()];
     prefs.advanced.debug_mode = true;
 
-    tauri::async_runtime::block_on(update_app_preferences(prefs.clone(), app.state()))
-        .expect("update preferences");
+    tauri::async_runtime::block_on(update_app_preferences(
+        prefs.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("update preferences");
 
     let refreshed =
         tauri::async_runtime::block_on(get_app_preferences(app.state())).expect("get preferences");
@@ -144,8 +150,8 @@ fn app_preferences_commands() {
     );
     assert!(refreshed.advanced.debug_mode);
 
-    let reset =
-        tauri::async_runtime::block_on(reset_app_preferences(app.state())).expect("reset prefs");
+    let reset = tauri::async_runtime::block_on(reset_app_preferences(app.state(), app.state()))
+        .expect("reset prefs");
     assert_eq!(reset.general.language, "en");
     assert_eq!(reset.security.clipboard_clear_timeout, 30);
     assert!(!reset.security.auto_download_favicons);
@@ -156,6 +162,37 @@ fn app_preferences_commands() {
     let recent =
         tauri::async_runtime::block_on(get_recent_databases(app.state())).expect("get recent");
     assert_eq!(recent.len(), 1);
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn update_app_preferences_propagates_backups_to_kdbx_service() {
+    let app = setup_app();
+
+    let mut prefs =
+        tauri::async_runtime::block_on(get_app_preferences(app.state())).expect("get preferences");
+    assert!(
+        prefs.backups.enabled,
+        "default backups.enabled should be true"
+    );
+
+    prefs.backups.enabled = false;
+    tauri::async_runtime::block_on(update_app_preferences(
+        prefs.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("update preferences");
+
+    let kdbx: tauri::State<'_, Arc<KdbxService>> = app.state();
+    let current = kdbx
+        .current_backup_settings()
+        .expect("read current backup settings");
+    assert!(
+        !current.enabled,
+        "KdbxService should see backups disabled after update"
+    );
 
     cleanup_settings_file(&app);
 }

--- a/src-tauri/tests/kdbx_save.rs
+++ b/src-tauri/tests/kdbx_save.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::expect_used)]
 
+use mithril_vault_lib::commands::settings::BackupSettings;
 use mithril_vault_lib::dto::error::AppError;
+use mithril_vault_lib::services::kdbx::backups::BACKUP_SUBDIR;
 use mithril_vault_lib::services::kdbx::KdbxService;
 use tempfile::tempdir;
 
@@ -448,6 +450,136 @@ fn test_save_preserves_existing_permissions() {
     assert_eq!(
         mode_after, 0o640,
         "Permissions should be preserved after save, got {mode_after:o}"
+    );
+}
+
+#[test]
+fn test_save_creates_pre_image_backup_when_enabled() {
+    let dir = tempdir().expect("Failed to create temp dir");
+    let db_path = dir.path().join("with-backups.kdbx");
+    let db_path_str = db_path.to_string_lossy().to_string();
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+
+    let service = KdbxService::new();
+    service
+        .create(&db_path_str, "pw", "Backed Up")
+        .expect("create");
+
+    // First save after create: file exists on disk, snapshot the pre-image bytes.
+    let pre_image_bytes = std::fs::read(&db_path).expect("read pre-image");
+    service.save(&db_path_str).expect("save");
+
+    assert!(backup_dir.exists(), ".kdbx-backups/ should be created");
+    let entries: Vec<_> = std::fs::read_dir(&backup_dir)
+        .expect("read backup dir")
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(entries.len(), 1, "exactly one backup should be created");
+
+    let backup_bytes = std::fs::read(entries[0].path()).expect("read backup");
+    assert_eq!(
+        backup_bytes, pre_image_bytes,
+        "backup bytes should equal pre-save vault bytes"
+    );
+}
+
+#[test]
+fn test_save_with_backups_disabled_creates_no_files() {
+    let dir = tempdir().expect("Failed to create temp dir");
+    let db_path = dir.path().join("no-backups.kdbx");
+    let db_path_str = db_path.to_string_lossy().to_string();
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+
+    let service = KdbxService::new();
+    service
+        .set_backup_settings(BackupSettings { enabled: false })
+        .expect("set settings");
+    service
+        .create(&db_path_str, "pw", "Disabled")
+        .expect("create");
+
+    service.save(&db_path_str).expect("save");
+
+    assert!(
+        !backup_dir.exists(),
+        "no .kdbx-backups/ when backups disabled"
+    );
+}
+
+#[test]
+fn test_save_as_to_fresh_path_creates_no_backup_first_time() {
+    let dir = tempdir().expect("Failed to create temp dir");
+    let original_path = dir.path().join("orig.kdbx");
+    let new_path = dir.path().join("fresh.kdbx");
+    let original_str = original_path.to_string_lossy().to_string();
+    let new_str = new_path.to_string_lossy().to_string();
+    let new_backup_dir = dir.path().join(BACKUP_SUBDIR);
+
+    let service = KdbxService::new();
+    service.create(&original_str, "pw", "Orig").expect("create");
+
+    service
+        .save_as(&original_str, &new_str, None)
+        .expect("save_as");
+
+    // The fresh new_path had no pre-image when save_as targeted it. AC #5.
+    // Note: original's backup dir may or may not exist depending on whether
+    // save_as snapshots the source — per spec the hook is in save(), not save_as.
+    // The acceptance criterion here is that the *new* path's saves behave
+    // like a fresh vault — no backup until a real save happens against it.
+    let new_backup_count = std::fs::read_dir(&new_backup_dir)
+        .ok()
+        .map_or(0, |it| it.filter_map(Result::ok).count());
+    assert_eq!(
+        new_backup_count, 0,
+        "save_as to fresh path should not snapshot at new path"
+    );
+
+    // Subsequent save() at new_path should create a backup.
+    service.save(&new_str).expect("save at new path");
+    let after = std::fs::read_dir(&new_backup_dir)
+        .expect("backup dir should exist now")
+        .filter_map(Result::ok)
+        .count();
+    assert_eq!(after, 1, "subsequent save should create one backup");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_save_fails_closed_when_backup_dir_unwritable() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempdir().expect("Failed to create temp dir");
+    let db_path = dir.path().join("locked-backups.kdbx");
+    let db_path_str = db_path.to_string_lossy().to_string();
+
+    let service = KdbxService::new();
+    service
+        .create(&db_path_str, "pw", "Locked")
+        .expect("create");
+    let pre_save_bytes = std::fs::read(&db_path).expect("read pre-save");
+
+    // Make the parent read-only so .kdbx-backups/ cannot be created.
+    let mut perms = std::fs::metadata(dir.path()).expect("meta").permissions();
+    let original = perms.mode();
+    perms.set_mode(0o500);
+    std::fs::set_permissions(dir.path(), perms).expect("ro");
+
+    let result = service.save(&db_path_str);
+
+    // Restore so cleanup works regardless of outcome.
+    let mut restore = std::fs::metadata(dir.path()).expect("meta").permissions();
+    restore.set_mode(original);
+    std::fs::set_permissions(dir.path(), restore).expect("restore");
+
+    assert!(
+        result.is_err(),
+        "save should fail when backup cannot be made"
+    );
+    let post_bytes = std::fs::read(&db_path).expect("read post");
+    assert_eq!(
+        post_bytes, pre_save_bytes,
+        "vault file must be unchanged when save aborts on backup failure"
     );
 }
 

--- a/src-tauri/tests/services/settings_service_test.rs
+++ b/src-tauri/tests/services/settings_service_test.rs
@@ -389,6 +389,76 @@ fn clear_recent_databases_surfaces_save_error() {
 }
 
 #[test]
+fn backups_enabled_defaults_to_true_and_roundtrips() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+
+    let service = new_service(&app);
+    let prefs = service.get_app_preferences().expect("get prefs");
+    assert!(
+        prefs.backups.enabled,
+        "backups.enabled should default to true"
+    );
+
+    let mut updated = prefs.clone();
+    updated.backups.enabled = false;
+    service
+        .update_app_preferences(&updated)
+        .expect("update prefs");
+
+    let reloaded = new_service(&app);
+    let after = reloaded.get_app_preferences().expect("get prefs");
+    assert!(
+        !after.backups.enabled,
+        "backups.enabled should persist across reload"
+    );
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn missing_backup_enabled_field_defaults_to_true() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+
+    let path = settings_file_path(&app);
+    std::fs::write(&path, "{}").expect("write empty settings");
+
+    let service = new_service(&app);
+    let prefs = service.get_app_preferences().expect("get prefs");
+    assert!(
+        prefs.backups.enabled,
+        "missing backup_enabled in settings.json should load as true"
+    );
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn reset_app_preferences_restores_backups_default() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+
+    let service = new_service(&app);
+    let mut prefs = service.get_app_preferences().expect("get prefs");
+    prefs.backups.enabled = false;
+    service
+        .update_app_preferences(&prefs)
+        .expect("update prefs");
+
+    let reset = service.reset_app_preferences().expect("reset prefs");
+    assert!(
+        reset.backups.enabled,
+        "reset should restore backups.enabled to true"
+    );
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
 fn app_preferences_roundtrip_and_reset_preserves_recents() {
     let _lock = crate::settings_test_lock();
     let app = setup_app();

--- a/src/components/settings/SettingsEditor.tsx
+++ b/src/components/settings/SettingsEditor.tsx
@@ -26,6 +26,7 @@ import {
 import { isColorPresetId } from "@/lib/theme-presets";
 import { AdvancedSettingsSection } from "@/components/settings/sections/AdvancedSettingsSection";
 import { AppearanceSettingsSection } from "@/components/settings/sections/AppearanceSettingsSection";
+import { BackupsSettingsSection } from "@/components/settings/sections/BackupsSettingsSection";
 import { BrowserIntegrationSettingsSection } from "@/components/settings/sections/BrowserIntegrationSettingsSection";
 import { DatabaseSettingsSection } from "@/components/settings/sections/DatabaseSettingsSection";
 import { GeneralSettingsSection } from "@/components/settings/sections/GeneralSettingsSection";
@@ -277,6 +278,7 @@ export function SettingsEditor({
       <KeyboardShortcutsSettingsSection />
       <PasswordGeneratorSettingsSection />
       <AdvancedSettingsSection draft={draft} updateDraft={updateDraft} />
+      <BackupsSettingsSection draft={draft} updateDraft={updateDraft} />
       <DatabaseSettingsSection
         dbId={dbId}
         databaseConfig={databaseConfig}

--- a/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/src/components/settings/__tests__/SettingsView.test.tsx
@@ -77,6 +77,9 @@ function makePreferences(): AppPreferences {
       debugMode: false,
       dataLocation: "/tmp/mithril-vault",
     },
+    backups: {
+      enabled: true,
+    },
   };
 }
 
@@ -138,8 +141,43 @@ describe("SettingsView", () => {
       screen.getByRole("heading", { name: "settings.advanced.title" })
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("heading", { name: "settings.backups.title" })
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("heading", { name: "settings.database.title" })
     ).toBeInTheDocument();
+  });
+
+  it("persists backups.enabled toggle", async () => {
+    const updatePreferences = vi.fn().mockResolvedValue(undefined);
+    mockUseAppPreferences.mockReturnValue({
+      preferences: makePreferences(),
+      isLoading: false,
+      error: null,
+      updatePreferences,
+      isUpdating: false,
+      resetPreferences: vi.fn().mockResolvedValue(makePreferences()),
+      isResetting: false,
+    });
+
+    render(<SettingsView />);
+
+    const toggle = screen.getByLabelText("settings.backups.enabled.label");
+    fireEvent.click(toggle);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "settings.saveChanges" })
+    );
+
+    await waitFor(() => {
+      expect(updatePreferences).toHaveBeenCalledTimes(1);
+    });
+
+    expect(updatePreferences).toHaveBeenCalledWith(
+      expect.objectContaining({
+        backups: expect.objectContaining({ enabled: false }),
+      })
+    );
   });
 
   it("renders loading state", () => {

--- a/src/components/settings/sections/BackupsSettingsSection.tsx
+++ b/src/components/settings/sections/BackupsSettingsSection.tsx
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/components/ui/checkbox";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import type { AppPreferences } from "@/lib/types";
+
+interface BackupsSettingsSectionProps {
+  draft: AppPreferences;
+  updateDraft: (updater: (previous: AppPreferences) => AppPreferences) => void;
+}
+
+export function BackupsSettingsSection({
+  draft,
+  updateDraft,
+}: Readonly<BackupsSettingsSectionProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <SettingsSection
+      id="backups"
+      title={t("settings.backups.title")}
+      description={t("settings.backups.description")}
+    >
+      <label className="flex items-start gap-2 text-sm">
+        <Checkbox
+          aria-label={t("settings.backups.enabled.label")}
+          checked={draft.backups.enabled}
+          onCheckedChange={(checked) =>
+            updateDraft((previous) => ({
+              ...previous,
+              backups: {
+                ...previous.backups,
+                enabled: checked === true,
+              },
+            }))
+          }
+        />
+        <span className="flex flex-col gap-1">
+          <span>{t("settings.backups.enabled.label")}</span>
+          <span className="text-muted-foreground">
+            {t("settings.backups.enabled.description")}
+          </span>
+        </span>
+      </label>
+    </SettingsSection>
+  );
+}

--- a/src/hooks/__tests__/use-app-preferences.test.tsx
+++ b/src/hooks/__tests__/use-app-preferences.test.tsx
@@ -58,6 +58,9 @@ function makePreferences(): AppPreferences {
       debugMode: false,
       dataLocation: "/tmp/mithril-vault",
     },
+    backups: {
+      enabled: true,
+    },
   };
 }
 

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -167,6 +167,9 @@ describe("tauri wrappers validation", () => {
         debugMode: false,
         dataLocation: "/tmp/mithril-vault",
       },
+      backups: {
+        enabled: true,
+      },
     } as const;
 
     vi.mocked(invoke)
@@ -226,6 +229,9 @@ describe("tauri wrappers validation", () => {
         advanced: {
           debugMode: false,
           dataLocation: "/tmp",
+        },
+        backups: {
+          enabled: true,
         },
       })
     ).rejects.toThrow();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -266,12 +266,18 @@ export const AdvancedSettingsSchema = z.object({
 });
 export type AdvancedSettings = z.infer<typeof AdvancedSettingsSchema>;
 
+export const BackupSettingsSchema = z.object({
+  enabled: z.boolean(),
+});
+export type BackupSettings = z.infer<typeof BackupSettingsSchema>;
+
 export const AppPreferencesSchema = z.object({
   general: GeneralSettingsSchema,
   security: SecuritySettingsSchema,
   appearance: AppearanceSettingsSchema,
   browserIntegration: BrowserIntegrationSettingsSchema,
   advanced: AdvancedSettingsSchema,
+  backups: BackupSettingsSchema,
 });
 export type AppPreferences = z.infer<typeof AppPreferencesSchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -107,6 +107,17 @@
       "enableDebugMode": "Debug-Modus aktivieren",
       "dataLocation": "Datenspeicherort"
     },
+    "backups": {
+      "title": "Backups",
+      "description": "Automatic snapshots of your vault file before every save.",
+      "enabled": {
+        "label": "Enable backups",
+        "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
+      },
+      "error": {
+        "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      }
+    },
     "shortcuts": {
       "title": "Tastenkürzel",
       "description": "Alle verfügbaren Tastenkürzel anzeigen."

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -107,6 +107,17 @@
       "enableDebugMode": "Enable debug mode",
       "dataLocation": "Data location"
     },
+    "backups": {
+      "title": "Backups",
+      "description": "Automatic snapshots of your vault file before every save.",
+      "enabled": {
+        "label": "Enable backups",
+        "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
+      },
+      "error": {
+        "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      }
+    },
     "shortcuts": {
       "title": "Keyboard Shortcuts",
       "description": "View all available keyboard shortcuts."

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -107,6 +107,17 @@
       "enableDebugMode": "Habilitar modo de depuración",
       "dataLocation": "Ubicación de datos"
     },
+    "backups": {
+      "title": "Backups",
+      "description": "Automatic snapshots of your vault file before every save.",
+      "enabled": {
+        "label": "Enable backups",
+        "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
+      },
+      "error": {
+        "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      }
+    },
     "shortcuts": {
       "title": "Atajos de teclado",
       "description": "Ver todos los atajos de teclado disponibles."

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -107,6 +107,17 @@
       "enableDebugMode": "Activer le mode débogage",
       "dataLocation": "Emplacement des données"
     },
+    "backups": {
+      "title": "Backups",
+      "description": "Automatic snapshots of your vault file before every save.",
+      "enabled": {
+        "label": "Enable backups",
+        "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
+      },
+      "error": {
+        "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      }
+    },
     "shortcuts": {
       "title": "Raccourcis clavier",
       "description": "Voir tous les raccourcis clavier disponibles."

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -107,6 +107,17 @@
       "enableDebugMode": "Omogući režim za otklanjanje grešaka",
       "dataLocation": "Lokacija podataka"
     },
+    "backups": {
+      "title": "Backups",
+      "description": "Automatic snapshots of your vault file before every save.",
+      "enabled": {
+        "label": "Enable backups",
+        "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
+      },
+      "error": {
+        "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      }
+    },
     "shortcuts": {
       "title": "Prečice na tastaturi",
       "description": "Pogledajte sve dostupne prečice na tastaturi."


### PR DESCRIPTION
Closes #190. Parent: #61.

## Summary

- Adds a pre-save snapshot of the on-disk vault bytes into a hidden `.kdbx-backups/` subdirectory next to the vault file. Snapshot failure aborts the save with `BackupError::BackupFailed { path, source }` rather than silently proceeding.
- Adds a new `backups: { enabled }` section to App Preferences (default `true`), persisted via a flat `backup_enabled` field with `#[serde(default)]` so existing `settings.json` files load with defaults — no schema bump.
- Adds the Settings → Backups section with the single "Enable backups" toggle. English i18n keys land in `en/common.json`; English placeholders ship in `de`/`es`/`fr`/`sr` for translation in a follow-up.

## Design notes

- `BackupService` (`services/kdbx/backups/`) is the deep module per the parent PRD: a small public surface (`snapshot`), with directory creation, filename construction, and the snapshot write itself all internal. The filename utility is lifted into a pure submodule for cheap unit tests.
- Filename pattern: `<vault>.backup.<YYYYMMDDTHHMMSS.mmmZ>.kdbx`. Fixed-width UTC fields make lexicographic sort match chronological sort by construction. Same-millisecond collisions bump 1 ms at a time until free.
- Snapshot write reuses the existing `atomic_write` primitive with a streaming `io::copy` so a process kill mid-snapshot cannot leave a half-written file.
- Unix permissions: `.kdbx-backups/` is `0700`, snapshot files are `0600`.
- Symlinked vaults: `fs::File::open` follows the link, so the snapshot captures the target bytes.
- First-save skip: when the source path does not exist yet (newly created vault, or first save after `save_as` to a fresh path), `snapshot` returns `Ok(None)` and the save proceeds with no backup file.
- `KdbxService` holds `Mutex<BackupSettings>` so the save hook can read the current value without depending on `SettingsService`. `lib.rs` pushes the persisted value at startup; `update_app_preferences` / `reset_app_preferences` commands also push to keep them in sync.

## Out of scope

Deferred to later slices of #61: open-side snapshot hook + dedup, rotation, manual snapshots, `backup_directory` / `max_versions` / `on_open` config, and the four IPC commands (`list_backups` / `create_manual_backup` / `delete_backup` / `restore_backup`).

## Test plan

Backend (Rust):
- [x] `tests/backups.rs` — pre-image bytes, filename pattern, first-save skip, disabled skip, Unix 0700/0600 permissions, fail-closed on read-only parent, symlink-follows-target, same-ms collision bump.
- [x] `tests/kdbx_save.rs` — save creates pre-image, disabled creates nothing, `save_as` to fresh path doesn't snapshot but subsequent save does, fail-closed leaves vault unchanged.
- [x] `tests/services/settings_service_test.rs` — default-true, missing-field defaults, reset restores default, round-trip persistence.
- [x] `tests/commands/settings_test.rs` — `update_app_preferences` propagates `backups.enabled` into `KdbxService`.
- [x] Pure unit tests in `services/kdbx/backups/filename.rs` — round-trip, lex==chrono sort, collision bump.
- [x] Full backend suite: 342 tests pass; `cargo clippy --all-targets` clean.

Frontend (Vitest):
- [x] `SettingsView.test.tsx` — section renders, toggling persists `backups.enabled = false` via `updatePreferences`.
- [x] Full frontend suite: 319 tests pass; `bun run check` clean.

## PR stacking

Base: `refactor/introduce-vault-seam`. When that PR merges to `main`, GitHub will auto-retarget this one. Future #61 slices will continue to be opened as their own PRs (no umbrella PR) since each slice is independently shippable per the parent PRD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)