### PR TITLE
feat(core): snapshot rotation with count cap and manual-exclusion glob (#191)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -144,11 +144,56 @@ pub struct AdvancedSettings {
 #[serde(default)]
 pub struct BackupSettings {
     pub enabled: bool,
+    #[serde(default = "default_max_versions")]
+    pub max_versions: u32,
+}
+
+pub(crate) const DEFAULT_MAX_VERSIONS: u32 = 10;
+
+fn default_max_versions() -> u32 {
+    DEFAULT_MAX_VERSIONS
 }
 
 impl Default for BackupSettings {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            max_versions: DEFAULT_MAX_VERSIONS,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod backup_settings_tests {
+    use super::BackupSettings;
+
+    #[test]
+    fn default_max_versions_is_ten() {
+        let s = BackupSettings::default();
+        assert_eq!(s.max_versions, 10);
+    }
+
+    #[test]
+    fn absent_max_versions_deserializes_to_ten_not_zero() {
+        // Existing settings.json files written before this slice have no
+        // maxVersions field. Without a field-level serde default they would
+        // deserialize as 0, which would break rotation. Cover both `{}`
+        // (whole struct missing) and `{"enabled": ..}` (field missing).
+        let from_empty: BackupSettings = serde_json::from_str("{}").expect("parse {}");
+        assert_eq!(from_empty.max_versions, 10);
+
+        let from_partial: BackupSettings =
+            serde_json::from_str(r#"{"enabled": true}"#).expect("parse partial");
+        assert_eq!(from_partial.max_versions, 10);
+    }
+
+    #[test]
+    fn explicit_max_versions_round_trips() {
+        let parsed: BackupSettings =
+            serde_json::from_str(r#"{"enabled": true, "maxVersions": 25}"#)
+                .expect("parse explicit");
+        assert_eq!(parsed.max_versions, 25);
     }
 }
 

--- a/src-tauri/src/services/kdbx/backups/mod.rs
+++ b/src-tauri/src/services/kdbx/backups/mod.rs
@@ -6,6 +6,7 @@
 //! write itself. See parent issue #61 for the full design and #190 for this slice.
 
 pub mod filename;
+pub(crate) mod rotation;
 
 use crate::commands::settings::BackupSettings;
 use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
@@ -107,6 +108,16 @@ pub fn snapshot(
     .map_err(|e| BackupError::BackupFailed {
         path: backup_path.clone(),
         source: io::Error::other(e.to_string()),
+    })?;
+
+    // Trim only after a successful new-snapshot write so a failed snapshot
+    // never deletes existing backups. Rotation is keyed on the source Vault's
+    // basename: two Vaults sharing a backup directory rotate independently.
+    rotation::rotate(&backup_dir, vault_filename, settings.max_versions).map_err(|e| {
+        BackupError::BackupFailed {
+            path: backup_dir.clone(),
+            source: e,
+        }
     })?;
 
     Ok(Some(BackupInfo { path: backup_path }))

--- a/src-tauri/src/services/kdbx/backups/rotation.rs
+++ b/src-tauri/src/services/kdbx/backups/rotation.rs
@@ -50,10 +50,10 @@ where
             }
         })
         .collect();
-    // Newest first. Stable sort isn't strictly required because timestamps
-    // are unique-by-construction (same-ms collisions bump the snapshot's
-    // chosen timestamp at write time), but stability costs nothing.
-    out.sort_by(|a, b| b.0.cmp(&a.0));
+    // Newest first. Timestamps are unique-by-construction (same-ms collisions
+    // bump the snapshot's chosen timestamp at write time) so sort stability
+    // doesn't matter here.
+    out.sort_by_key(|entry| std::cmp::Reverse(entry.0));
     out
 }
 

--- a/src-tauri/src/services/kdbx/backups/rotation.rs
+++ b/src-tauri/src/services/kdbx/backups/rotation.rs
@@ -83,7 +83,7 @@ pub(crate) fn list_auto_snapshots(
     // a save that already wrote its new snapshot would error post-write.
     let names: Vec<String> = read_dir
         .filter_map(Result::ok)
-        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
+        .filter(|e| e.file_type().is_ok_and(|t| t.is_file()))
         .filter_map(|e| e.file_name().into_string().ok())
         .collect();
     let selected = select_auto_snapshots(names.iter().map(String::as_str), vault_filename);

--- a/src-tauri/src/services/kdbx/backups/rotation.rs
+++ b/src-tauri/src/services/kdbx/backups/rotation.rs
@@ -18,9 +18,13 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 
-/// Substring that marks a manual backup. Reserved for the manual-backup slice
-/// (issue parent #61); auto-snapshot rotation must never touch these.
-const MANUAL_MARKER: &str = ".backup.manual.";
+/// Suffix segment marking a manual backup. Reserved for the manual-backup
+/// slice (issue parent #61); auto-snapshot rotation must never touch these.
+///
+/// Anchored to the position right after the source Vault's basename so a
+/// Vault literally named `foo.backup.manual.kdbx` does not accidentally
+/// match itself out of rotation.
+const MANUAL_SUFFIX_INFIX: &str = ".backup.manual.";
 
 /// Returns auto-snapshot filenames belonging to `vault_filename`, sorted
 /// **newest-first** by the timestamp parsed from the filename (not by file
@@ -29,7 +33,7 @@ const MANUAL_MARKER: &str = ".backup.manual.";
 ///
 /// Excluded:
 /// - Foreign-vault backups (different basename).
-/// - Files containing the `.backup.manual.` marker.
+/// - Manual-marker files for our Vault (`<vault>.backup.manual.*`).
 /// - Any name that doesn't match the auto-snapshot pattern.
 pub(crate) fn select_auto_snapshots<'a, I>(
     names: I,
@@ -38,9 +42,14 @@ pub(crate) fn select_auto_snapshots<'a, I>(
 where
     I: IntoIterator<Item = &'a str>,
 {
+    // Anchor the manual-marker check to *our* Vault's basename so a Vault
+    // whose name itself contains `.backup.manual.` (e.g. `foo.backup.manual.kdbx`)
+    // still has its auto-snapshots rotated. The marker can only appear in
+    // the backup-suffix segment, never inside the source Vault basename.
+    let manual_prefix = format!("{vault_filename}{MANUAL_SUFFIX_INFIX}");
     let mut out: Vec<(DateTime<Utc>, &str)> = names
         .into_iter()
-        .filter(|name| !name.contains(MANUAL_MARKER))
+        .filter(|name| !name.starts_with(&manual_prefix))
         .filter_map(|name| {
             let (vault, ts) = parse_backup_filename(name)?;
             if vault == vault_filename {
@@ -69,8 +78,12 @@ pub(crate) fn list_auto_snapshots(
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
         Err(e) => return Err(e),
     };
+    // Only consider regular files. If a subdirectory happens to be named
+    // like a snapshot, `fs::remove_file` would fail with `EISDIR` later and
+    // a save that already wrote its new snapshot would error post-write.
     let names: Vec<String> = read_dir
         .filter_map(Result::ok)
+        .filter(|e| e.file_type().map(|t| t.is_file()).unwrap_or(false))
         .filter_map(|e| e.file_name().into_string().ok())
         .collect();
     let selected = select_auto_snapshots(names.iter().map(String::as_str), vault_filename);
@@ -88,14 +101,17 @@ pub(crate) fn list_auto_snapshots(
 /// (foreign-Vault backups, manual-marker files, unrelated files).
 ///
 /// `max_versions` is expected to be in `1..=500` — validation is enforced on
-/// the App Preferences boundary, so this function trusts the caller.
+/// the App Preferences boundary. As a defensive belt-and-braces measure for
+/// hand-edited or corrupted `settings.json` files, a value of `0` is treated
+/// as `1` so a single retention slot is always preserved. A misconfiguration
+/// must never silently wipe every backup.
 pub(crate) fn rotate(
     backup_dir: &Path,
     vault_filename: &str,
     max_versions: u32,
 ) -> io::Result<usize> {
     let snapshots = list_auto_snapshots(backup_dir, vault_filename)?;
-    let keep = max_versions as usize;
+    let keep = max_versions.max(1) as usize;
     if snapshots.len() <= keep {
         return Ok(0);
     }
@@ -230,5 +246,76 @@ mod tests {
         let result =
             list_auto_snapshots(&missing, "vault.kdbx").expect("missing dir should not error");
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn manual_marker_check_is_anchored_to_vault_basename() {
+        // A Vault literally named `foo.backup.manual.kdbx` should still
+        // have its auto-snapshots rotated. The earlier broad-substring
+        // check would have filtered every snapshot of this Vault out.
+        let vault = "foo.backup.manual.kdbx";
+        let auto = name_for(vault, 1_715_000_000_000);
+        // A manual snapshot of the same Vault — must be excluded.
+        let manual = format!("{vault}.backup.manual.20260512T143045.123Z.kdbx");
+
+        let names = [auto.as_str(), manual.as_str()];
+        let kept: Vec<&str> = select_auto_snapshots(names, vault)
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect();
+
+        assert_eq!(
+            kept,
+            vec![auto.as_str()],
+            "auto-snapshots of a vault whose name contains the marker must still rotate"
+        );
+    }
+
+    #[test]
+    fn rotate_clamps_max_versions_zero_to_keep_one() {
+        // Defense-in-depth for a corrupt/hand-edited settings.json file
+        // that smuggles `maxVersions = 0` past the App Preferences boundary.
+        // Rotation must never wipe every backup.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for ms in [1_715_000_000_000i64, 1_715_000_001_000, 1_715_000_002_000] {
+            let path = tmp.path().join(name_for("vault.kdbx", ms));
+            std::fs::write(&path, b"snap").expect("write");
+        }
+
+        let deleted = rotate(tmp.path(), "vault.kdbx", 0).expect("rotate");
+
+        let surviving: Vec<_> = std::fs::read_dir(tmp.path())
+            .expect("read")
+            .filter_map(Result::ok)
+            .collect();
+        assert_eq!(deleted, 2, "should delete all but the newest");
+        assert_eq!(
+            surviving.len(),
+            1,
+            "max_versions=0 must be coerced to keep at least one snapshot"
+        );
+    }
+
+    #[test]
+    fn rotate_ignores_directories_named_like_snapshots() {
+        // A directory in the backup folder that happens to be named like a
+        // snapshot must not propagate `EISDIR` out as a failed save.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        for ms in [1_715_000_000_000i64, 1_715_000_001_000] {
+            let path = tmp.path().join(name_for("vault.kdbx", ms));
+            std::fs::write(&path, b"snap").expect("write");
+        }
+        // Plant a directory with a snapshot-shaped name (oldest timestamp
+        // so it would be the rotation target).
+        let evil_dir = tmp.path().join(name_for("vault.kdbx", 1_710_000_000_000));
+        std::fs::create_dir(&evil_dir).expect("create dir");
+
+        // cap=1 → without the file-type filter, this would attempt
+        // remove_file on `evil_dir` and surface EISDIR as a save failure.
+        let deleted = rotate(tmp.path(), "vault.kdbx", 1).expect("rotate must succeed");
+
+        assert!(evil_dir.exists(), "subdirectory must be untouched");
+        // One of the two real snapshots got trimmed.
+        assert_eq!(deleted, 1);
     }
 }

--- a/src-tauri/src/services/kdbx/backups/rotation.rs
+++ b/src-tauri/src/services/kdbx/backups/rotation.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+
+//! Snapshot rotation for the pre-save backup module.
+//!
+//! Pure helpers that operate on filenames (no I/O), plus a thin filesystem
+//! wrapper that reads a backup directory and applies the cap. The split keeps
+//! the glob/sort/exclusion logic unit-testable without touching disk.
+//!
+//! Rotation is keyed on the source Vault's basename, so two Vaults co-located
+//! in the same backup directory rotate independently. The `.backup.manual.`
+//! marker is reserved for the later manual-backup slice and is excluded here
+//! defensively even though the auto-snapshot parse already rejects those
+//! filenames (their timestamp slot is non-numeric).
+
+use crate::services::kdbx::backups::filename::parse_backup_filename;
+use chrono::{DateTime, Utc};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// Substring that marks a manual backup. Reserved for the manual-backup slice
+/// (issue parent #61); auto-snapshot rotation must never touch these.
+const MANUAL_MARKER: &str = ".backup.manual.";
+
+/// Returns auto-snapshot filenames belonging to `vault_filename`, sorted
+/// **newest-first** by the timestamp parsed from the filename (not by file
+/// mtime — `fs::copy` preserves the source mtime, so mtime is meaningless
+/// for ordering snapshots).
+///
+/// Excluded:
+/// - Foreign-vault backups (different basename).
+/// - Files containing the `.backup.manual.` marker.
+/// - Any name that doesn't match the auto-snapshot pattern.
+pub(crate) fn select_auto_snapshots<'a, I>(
+    names: I,
+    vault_filename: &str,
+) -> Vec<(DateTime<Utc>, &'a str)>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let mut out: Vec<(DateTime<Utc>, &str)> = names
+        .into_iter()
+        .filter(|name| !name.contains(MANUAL_MARKER))
+        .filter_map(|name| {
+            let (vault, ts) = parse_backup_filename(name)?;
+            if vault == vault_filename {
+                Some((ts, name))
+            } else {
+                None
+            }
+        })
+        .collect();
+    // Newest first. Stable sort isn't strictly required because timestamps
+    // are unique-by-construction (same-ms collisions bump the snapshot's
+    // chosen timestamp at write time), but stability costs nothing.
+    out.sort_by(|a, b| b.0.cmp(&a.0));
+    out
+}
+
+/// Walks `backup_dir` and returns auto-snapshot paths for `vault_filename`,
+/// sorted newest-first by parsed timestamp. Returns `Ok(vec![])` when the
+/// directory does not exist yet (first save).
+pub(crate) fn list_auto_snapshots(
+    backup_dir: &Path,
+    vault_filename: &str,
+) -> io::Result<Vec<PathBuf>> {
+    let read_dir = match fs::read_dir(backup_dir) {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let names: Vec<String> = read_dir
+        .filter_map(Result::ok)
+        .filter_map(|e| e.file_name().into_string().ok())
+        .collect();
+    let selected = select_auto_snapshots(names.iter().map(String::as_str), vault_filename);
+    Ok(selected
+        .into_iter()
+        .map(|(_, name)| backup_dir.join(name))
+        .collect())
+}
+
+/// Deletes auto-snapshots beyond `max_versions` for `vault_filename`. Newest
+/// `max_versions` files are retained; older ones are removed. Returns the
+/// number of files deleted.
+///
+/// Never touches files outside the auto-snapshot glob for this Vault
+/// (foreign-Vault backups, manual-marker files, unrelated files).
+///
+/// `max_versions` is expected to be in `1..=500` — validation is enforced on
+/// the App Preferences boundary, so this function trusts the caller.
+pub(crate) fn rotate(
+    backup_dir: &Path,
+    vault_filename: &str,
+    max_versions: u32,
+) -> io::Result<usize> {
+    let snapshots = list_auto_snapshots(backup_dir, vault_filename)?;
+    let keep = max_versions as usize;
+    if snapshots.len() <= keep {
+        return Ok(0);
+    }
+    let mut deleted = 0usize;
+    for path in snapshots.into_iter().skip(keep) {
+        match fs::remove_file(&path) {
+            Ok(()) => deleted += 1,
+            // Tolerate races (e.g. another process trimmed concurrently).
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(deleted)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::services::kdbx::backups::filename::make_backup_filename;
+    use chrono::TimeZone;
+
+    fn ts(ms: i64) -> DateTime<Utc> {
+        Utc.timestamp_millis_opt(ms).single().expect("valid ts")
+    }
+
+    fn name_for(vault: &str, ms: i64) -> String {
+        make_backup_filename(vault, ts(ms))
+    }
+
+    #[test]
+    fn excludes_foreign_vault_backups() {
+        let our_old = name_for("vault.kdbx", 1_715_000_000_000);
+        let our_new = name_for("vault.kdbx", 1_715_000_001_000);
+        let foreign = name_for("other.kdbx", 1_715_000_000_500);
+
+        let names = [our_old.as_str(), foreign.as_str(), our_new.as_str()];
+        let kept: Vec<&str> = select_auto_snapshots(names, "vault.kdbx")
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect();
+
+        assert_eq!(
+            kept,
+            vec![our_new.as_str(), our_old.as_str()],
+            "must keep only our-vault snapshots, newest-first"
+        );
+    }
+
+    #[test]
+    fn excludes_manual_marker_files() {
+        let auto = name_for("vault.kdbx", 1_715_000_000_000);
+        // Manual-backup naming convention reserved for the later slice.
+        let manual = "vault.kdbx.backup.manual.20260512T143045.123Z.kdbx".to_string();
+
+        let names = [auto.as_str(), manual.as_str()];
+        let kept: Vec<&str> = select_auto_snapshots(names, "vault.kdbx")
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect();
+
+        assert_eq!(kept, vec![auto.as_str()], "must skip manual-marker file");
+    }
+
+    #[test]
+    fn excludes_unrelated_files() {
+        let auto = name_for("vault.kdbx", 1_715_000_000_000);
+        let names = [
+            auto.as_str(),
+            "README.txt",
+            "vault.kdbx",
+            "vault.kdbx.bak",
+            ".DS_Store",
+            "vault.kdbx.backup.notadate.kdbx",
+        ];
+        let kept: Vec<&str> = select_auto_snapshots(names, "vault.kdbx")
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect();
+
+        assert_eq!(
+            kept,
+            vec![auto.as_str()],
+            "must skip every name that is not an auto-snapshot for our vault"
+        );
+    }
+
+    #[test]
+    fn sorts_newest_first_by_parsed_timestamp_not_lex() {
+        // Construct timestamps that would sort the same way lexically and
+        // chronologically (the filename format guarantees that), then assert
+        // newest comes first.
+        let oldest = name_for("vault.kdbx", 1_715_000_000_000);
+        let middle = name_for("vault.kdbx", 1_715_500_000_000);
+        let newest = name_for("vault.kdbx", 1_900_000_000_000);
+
+        // Feed in shuffled order to ensure sort is deterministic regardless of
+        // directory enumeration order (which is OS-dependent).
+        let names = [middle.as_str(), oldest.as_str(), newest.as_str()];
+        let kept: Vec<&str> = select_auto_snapshots(names, "vault.kdbx")
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect();
+
+        assert_eq!(
+            kept,
+            vec![newest.as_str(), middle.as_str(), oldest.as_str()]
+        );
+    }
+
+    #[test]
+    fn handles_vault_basenames_that_themselves_contain_backup() {
+        // The vault file might be literally named `my.backup.kdbx`. Confirm
+        // parsing and basename matching still works.
+        let vault = "my.backup.kdbx";
+        let ours = name_for(vault, 1_715_000_000_000);
+        let foreign = name_for("other.kdbx", 1_715_000_000_000);
+
+        let names = [ours.as_str(), foreign.as_str()];
+        let kept: Vec<&str> = select_auto_snapshots(names, vault)
+            .into_iter()
+            .map(|(_, n)| n)
+            .collect();
+
+        assert_eq!(kept, vec![ours.as_str()]);
+    }
+
+    #[test]
+    fn list_auto_snapshots_returns_empty_when_dir_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        let result =
+            list_auto_snapshots(&missing, "vault.kdbx").expect("missing dir should not error");
+        assert!(result.is_empty());
+    }
+}

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -35,14 +35,22 @@ impl SettingsService {
     fn load_or_default(path: &PathBuf) -> Result<AppSettings, AppError> {
         if path.exists() {
             let content = std::fs::read_to_string(path)?;
-            if let Ok(settings) = serde_json::from_str(&content) {
-                Ok(settings)
-            } else {
-                let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
-                let backup_name = format!("{SETTINGS_FILE}.bad-{timestamp}");
-                let backup_path = path.with_file_name(backup_name);
-                let _ = std::fs::rename(path, backup_path);
-                Ok(AppSettings::default())
+            let parsed: Result<AppSettings, _> = serde_json::from_str(&content);
+            // Treat out-of-range values the same as a malformed file: back up
+            // the bad copy and use defaults. Otherwise a hand-edited file
+            // could push `max_versions = 0` straight to rotation and erase
+            // every snapshot on the next save.
+            match parsed {
+                Ok(settings) if Self::validate_preferences(&settings.preferences).is_ok() => {
+                    Ok(settings)
+                }
+                _ => {
+                    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
+                    let backup_name = format!("{SETTINGS_FILE}.bad-{timestamp}");
+                    let backup_path = path.with_file_name(backup_name);
+                    let _ = std::fs::rename(path, backup_path);
+                    Ok(AppSettings::default())
+                }
             }
         } else {
             Ok(AppSettings::default())

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -71,6 +71,7 @@ impl SettingsService {
     }
 
     pub fn update_app_preferences(&self, new_preferences: &AppPreferences) -> Result<(), AppError> {
+        Self::validate_preferences(new_preferences)?;
         let mut settings = self.settings.lock().map_err(|_| AppError::Lock)?;
         settings.preferences = new_preferences.clone();
         // data_location is derived at read time; don't trust the value the
@@ -143,6 +144,20 @@ impl SettingsService {
         let mut settings = self.settings.lock().map_err(|_| AppError::Lock)?;
         settings.recent_databases.clear();
         self.save(&settings)
+    }
+
+    /// Rejects out-of-range values on the App Preferences boundary so a
+    /// malformed IPC payload (or a future settings.json with corrupt values)
+    /// cannot push the backup module into invariant violations.
+    fn validate_preferences(prefs: &AppPreferences) -> Result<(), AppError> {
+        const MAX_VERSIONS_RANGE: std::ops::RangeInclusive<u32> = 1..=500;
+        let v = prefs.backups.max_versions;
+        if !MAX_VERSIONS_RANGE.contains(&v) {
+            return Err(AppError::InvalidInput(format!(
+                "backups.maxVersions must be in 1..=500, got {v}"
+            )));
+        }
+        Ok(())
     }
 
     fn data_location_display(&self) -> String {

--- a/src-tauri/tests/backups.rs
+++ b/src-tauri/tests/backups.rs
@@ -16,11 +16,17 @@ use mithril_vault_lib::services::kdbx::backups::{snapshot, BACKUP_SUBDIR};
 use tempfile::tempdir;
 
 fn enabled() -> BackupSettings {
-    BackupSettings { enabled: true }
+    BackupSettings {
+        enabled: true,
+        ..BackupSettings::default()
+    }
 }
 
 fn disabled() -> BackupSettings {
-    BackupSettings { enabled: false }
+    BackupSettings {
+        enabled: false,
+        ..BackupSettings::default()
+    }
 }
 
 #[test]
@@ -241,6 +247,262 @@ fn snapshot_rejects_symlinked_backup_directory() {
     assert!(
         exfiltrated.is_empty(),
         "no bytes should have been written via the symlink"
+    );
+}
+
+#[test]
+fn rotation_caps_snapshots_at_max_versions() {
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 10,
+    };
+
+    // Twelve consecutive snapshots: each save mutates the source so the
+    // pre-image bytes differ and there's something distinct to capture.
+    for i in 0..12u32 {
+        std::fs::write(&vault_path, format!("v{i}").as_bytes()).expect("write source");
+        snapshot(&vault_path, &settings)
+            .expect("snapshot ok")
+            .expect("created");
+    }
+
+    let kept: Vec<_> = std::fs::read_dir(&backup_dir)
+        .expect("read backup dir")
+        .filter_map(Result::ok)
+        .filter(|e| e.path().is_file())
+        .collect();
+    assert_eq!(
+        kept.len(),
+        10,
+        "after 12 saves with max_versions=10, exactly 10 snapshots remain"
+    );
+}
+
+#[test]
+fn rotation_retains_newest_snapshots_not_oldest() {
+    // Build 5 snapshots with cap=3 and confirm the *newest* 3 survive.
+    // Without this we'd silently keep the oldest 3 and lose every recent
+    // pre-image, which is the opposite of useful.
+    use mithril_vault_lib::services::kdbx::backups::filename::parse_backup_filename;
+
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 3,
+    };
+
+    let mut all_timestamps = Vec::new();
+    for i in 0..5u32 {
+        std::fs::write(&vault_path, format!("v{i}").as_bytes()).expect("write source");
+        let info = snapshot(&vault_path, &settings)
+            .expect("snapshot ok")
+            .expect("created");
+        let name = info.path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        let (_, ts) = parse_backup_filename(name).expect("parse");
+        all_timestamps.push(ts);
+    }
+
+    let surviving_timestamps: Vec<_> = std::fs::read_dir(&backup_dir)
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .filter_map(|e| {
+            let n = e.file_name().to_string_lossy().to_string();
+            parse_backup_filename(&n).map(|(_, ts)| ts)
+        })
+        .collect();
+
+    let mut newest_three = all_timestamps.clone();
+    newest_three.sort();
+    let newest_three: Vec<_> = newest_three.into_iter().rev().take(3).collect();
+
+    for ts in &newest_three {
+        assert!(
+            surviving_timestamps.contains(ts),
+            "newest snapshot {ts:?} should have been retained"
+        );
+    }
+    assert_eq!(
+        surviving_timestamps.len(),
+        3,
+        "exactly cap=3 snapshots should remain"
+    );
+}
+
+#[test]
+fn rotation_keeps_two_vaults_in_same_directory_independent() {
+    // Two Vaults that happen to share a backup directory must rotate keyed
+    // on their own basename, never touching the other's snapshots.
+    let dir = tempdir().expect("tempdir");
+    let vault_a = dir.path().join("vault-a.kdbx");
+    let vault_b = dir.path().join("vault-b.kdbx");
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 2,
+    };
+
+    // 5 snapshots of vault A, 4 snapshots of vault B, interleaved so they
+    // share the same .kdbx-backups/ directory.
+    for i in 0..5u32 {
+        std::fs::write(&vault_a, format!("a{i}").as_bytes()).expect("write a");
+        snapshot(&vault_a, &settings)
+            .expect("snapshot a ok")
+            .expect("created a");
+        if i < 4 {
+            std::fs::write(&vault_b, format!("b{i}").as_bytes()).expect("write b");
+            snapshot(&vault_b, &settings)
+                .expect("snapshot b ok")
+                .expect("created b");
+        }
+    }
+
+    let files: Vec<String> = std::fs::read_dir(&backup_dir)
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+
+    let a_count = files
+        .iter()
+        .filter(|n| n.starts_with("vault-a.kdbx.backup."))
+        .count();
+    let b_count = files
+        .iter()
+        .filter(|n| n.starts_with("vault-b.kdbx.backup."))
+        .count();
+
+    assert_eq!(
+        a_count, 2,
+        "vault-a should have cap=2 snapshots, got {a_count}"
+    );
+    assert_eq!(
+        b_count, 2,
+        "vault-b should have cap=2 snapshots, got {b_count}"
+    );
+}
+
+#[test]
+fn rotation_preserves_foreign_files_in_backup_dir() {
+    // The rotation glob must never touch files outside its pattern even
+    // when they happen to live alongside our snapshots.
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 1,
+    };
+
+    // Seed one snapshot to force creation of .kdbx-backups/.
+    std::fs::write(&vault_path, b"seed").expect("write source");
+    snapshot(&vault_path, &settings)
+        .expect("seed snapshot ok")
+        .expect("created");
+
+    // Plant a foreign-vault snapshot and unrelated files now that the dir exists.
+    let foreign = backup_dir.join("other.kdbx.backup.20260101T000000.000Z.kdbx");
+    let manual = backup_dir.join("vault.kdbx.backup.manual.20260101T000000.000Z.kdbx");
+    let readme = backup_dir.join("README.txt");
+    std::fs::write(&foreign, b"foreign").expect("write foreign");
+    std::fs::write(&manual, b"manual").expect("write manual");
+    std::fs::write(&readme, b"readme").expect("write readme");
+
+    // Drive several rotations of our vault.
+    for i in 0..4u32 {
+        std::fs::write(&vault_path, format!("v{i}").as_bytes()).expect("write source");
+        snapshot(&vault_path, &settings)
+            .expect("snapshot ok")
+            .expect("created");
+    }
+
+    assert!(
+        foreign.exists(),
+        "foreign-vault snapshot must not be deleted"
+    );
+    assert!(manual.exists(), "manual-marker file must not be deleted");
+    assert!(readme.exists(), "unrelated file must not be deleted");
+
+    let our_snapshots = std::fs::read_dir(&backup_dir)
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let n = e.file_name().to_string_lossy().to_string();
+            n.starts_with("vault.kdbx.backup.") && !n.contains(".backup.manual.")
+        })
+        .count();
+    assert_eq!(
+        our_snapshots, 1,
+        "cap=1 on our auto-snapshots, got {our_snapshots}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn rotation_does_not_run_when_snapshot_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Seed two pre-existing snapshots, then force the *next* snapshot to
+    // fail by making the backup dir read-only. The existing two must remain.
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    let backup_dir = dir.path().join(BACKUP_SUBDIR);
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 5,
+    };
+
+    for i in 0..2u32 {
+        std::fs::write(&vault_path, format!("seed-{i}").as_bytes()).expect("write source");
+        snapshot(&vault_path, &settings)
+            .expect("seed ok")
+            .expect("seed created");
+    }
+    let pre_count = std::fs::read_dir(&backup_dir)
+        .expect("read backup dir")
+        .filter_map(Result::ok)
+        .count();
+    assert_eq!(pre_count, 2);
+
+    // Lower max_versions so rotation *would* delete one if it ran. Force
+    // the snapshot write to fail by making the source vault unreadable.
+    // (Making the backup directory read-only here is futile: ensure_backup_dir
+    // re-hardens it to 0700 on every call, restoring write permission.)
+    let trim_settings = BackupSettings {
+        enabled: true,
+        max_versions: 1,
+    };
+    std::fs::write(&vault_path, b"will-fail").expect("write source");
+    let original_vault_perms = std::fs::metadata(&vault_path)
+        .expect("vault meta")
+        .permissions();
+    std::fs::set_permissions(&vault_path, std::fs::Permissions::from_mode(0o000))
+        .expect("set unreadable");
+
+    let result = snapshot(&vault_path, &trim_settings);
+
+    // Restore so tempdir cleanup works.
+    std::fs::set_permissions(&vault_path, original_vault_perms).expect("restore");
+
+    assert!(
+        result.is_err(),
+        "snapshot must fail when source vault cannot be read"
+    );
+    let our_snapshots = std::fs::read_dir(&backup_dir)
+        .expect("read backup dir post")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let n = e.file_name().to_string_lossy().to_string();
+            n.starts_with("vault.kdbx.backup.") && !n.contains(".backup.manual.")
+        })
+        .count();
+    assert_eq!(
+        our_snapshots, 2,
+        "failed snapshot must leave existing backups untouched, got {our_snapshots}"
     );
 }
 

--- a/src-tauri/tests/kdbx_save.rs
+++ b/src-tauri/tests/kdbx_save.rs
@@ -492,7 +492,10 @@ fn test_save_with_backups_disabled_creates_no_files() {
 
     let service = KdbxService::new();
     service
-        .set_backup_settings(BackupSettings { enabled: false })
+        .set_backup_settings(BackupSettings {
+            enabled: false,
+            ..BackupSettings::default()
+        })
         .expect("set settings");
     service
         .create(&db_path_str, "pw", "Disabled")

--- a/src-tauri/tests/services/settings_service_unitlike_test.rs
+++ b/src-tauri/tests/services/settings_service_unitlike_test.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 //! Tests for settings service persistence
 
-#![allow(clippy::expect_used)]
+#![allow(clippy::expect_used, clippy::panic)]
 
-use mithril_vault_lib::commands::settings::{AppPreferences, SecuritySettings};
+use mithril_vault_lib::commands::settings::{AppPreferences, BackupSettings, SecuritySettings};
+use mithril_vault_lib::dto::error::AppError;
 use mithril_vault_lib::services::settings::SettingsService;
 use tauri::test::mock_app;
 use tauri::Manager;
@@ -204,6 +205,137 @@ fn keyfile_lookup_remove_and_clear() {
 
     let settings = service.get_settings().expect("get settings");
     assert!(settings.recent_databases.is_empty());
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn reset_restores_default_max_versions() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+    let service = SettingsService::new(app.handle()).expect("create service");
+
+    let mut prefs = AppPreferences::default();
+    prefs.backups.max_versions = 25;
+    service
+        .update_app_preferences(&prefs)
+        .expect("update accepted");
+
+    let reset = service.reset_app_preferences().expect("reset");
+    assert_eq!(
+        reset.backups.max_versions, 10,
+        "reset must restore max_versions to default 10"
+    );
+
+    // And the value survives reload.
+    let reloaded = SettingsService::new(app.handle()).expect("reload service");
+    let after = reloaded.get_app_preferences().expect("get prefs");
+    assert_eq!(after.backups.max_versions, 10);
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn update_rejects_max_versions_zero_and_preserves_state() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+    let service = SettingsService::new(app.handle()).expect("create service");
+
+    // Seed a known-good value.
+    let mut good = AppPreferences::default();
+    good.backups.max_versions = 25;
+    service
+        .update_app_preferences(&good)
+        .expect("seed accepted");
+
+    // Attempt invalid update.
+    let mut bad = good.clone();
+    bad.backups.max_versions = 0;
+    let result = service.update_app_preferences(&bad);
+    assert!(
+        matches!(result, Err(AppError::InvalidInput(_))),
+        "max_versions=0 must be rejected with InvalidInput, got {result:?}"
+    );
+
+    // State unchanged.
+    let after = service.get_app_preferences().expect("get prefs");
+    assert_eq!(
+        after.backups.max_versions, 25,
+        "rejected update must not mutate persisted state"
+    );
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn update_rejects_max_versions_above_cap() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+    let service = SettingsService::new(app.handle()).expect("create service");
+
+    let mut prefs = AppPreferences::default();
+    prefs.backups.max_versions = 501;
+    let result = service.update_app_preferences(&prefs);
+    assert!(
+        matches!(result, Err(AppError::InvalidInput(_))),
+        "max_versions=501 must be rejected with InvalidInput, got {result:?}"
+    );
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn update_accepts_max_versions_at_boundary_values() {
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+    let service = SettingsService::new(app.handle()).expect("create service");
+
+    for value in [1u32, 500u32] {
+        let mut prefs = AppPreferences::default();
+        prefs.backups.max_versions = value;
+        service
+            .update_app_preferences(&prefs)
+            .unwrap_or_else(|e| panic!("max_versions={value} must be accepted, got {e:?}"));
+        let after = service.get_app_preferences().expect("get prefs");
+        assert_eq!(after.backups.max_versions, value);
+    }
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
+fn update_rejects_when_only_backups_substruct_is_invalid() {
+    // Sanity check that validation reads the actual nested field, not the
+    // top-level default value, and surfaces a useful error message.
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+    let service = SettingsService::new(app.handle()).expect("create service");
+
+    let prefs = AppPreferences {
+        backups: BackupSettings {
+            enabled: true,
+            max_versions: 0,
+        },
+        ..AppPreferences::default()
+    };
+    let err = service
+        .update_app_preferences(&prefs)
+        .expect_err("must reject");
+    match err {
+        AppError::InvalidInput(msg) => {
+            assert!(
+                msg.to_lowercase().contains("max_versions")
+                    || msg.to_lowercase().contains("maxversions"),
+                "error message should mention the offending field, got: {msg}"
+            );
+        }
+        other => panic!("expected InvalidInput, got {other:?}"),
+    }
 
     cleanup_settings_file(&app);
 }

--- a/src-tauri/tests/services/settings_service_unitlike_test.rs
+++ b/src-tauri/tests/services/settings_service_unitlike_test.rs
@@ -210,6 +210,55 @@ fn keyfile_lookup_remove_and_clear() {
 }
 
 #[test]
+fn load_rejects_persisted_max_versions_out_of_range() {
+    // A hand-edited or corrupted settings.json with maxVersions=0 must not
+    // be honoured at load time; otherwise rotation would wipe every backup
+    // on the next save. The existing "back up bad file and fall back" path
+    // is reused.
+    let _lock = crate::settings_test_lock();
+    let app = setup_app();
+    cleanup_settings_file(&app);
+
+    let path = settings_path(&app);
+    std::fs::write(
+        &path,
+        r#"{"preferences":{"backups":{"enabled":true,"maxVersions":0}},"recentDatabases":[]}"#,
+    )
+    .expect("write bad settings");
+
+    let service = SettingsService::new(app.handle()).expect("create service");
+    let prefs = service.get_app_preferences().expect("get prefs");
+
+    assert_eq!(
+        prefs.backups.max_versions, 10,
+        "load must reject out-of-range maxVersions and fall back to default"
+    );
+    assert!(
+        prefs.backups.enabled,
+        "fall-back uses defaults (enabled=true)"
+    );
+
+    // The corrupt file should have been moved aside, mirroring the
+    // existing behaviour for malformed JSON.
+    let bad_files: Vec<_> = std::fs::read_dir(path.parent().expect("parent"))
+        .expect("read dir")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            e.file_name()
+                .to_string_lossy()
+                .starts_with("settings.json.bad-")
+        })
+        .collect();
+    assert_eq!(
+        bad_files.len(),
+        1,
+        "out-of-range settings.json should be quarantined"
+    );
+
+    cleanup_settings_file(&app);
+}
+
+#[test]
 fn reset_restores_default_max_versions() {
     let _lock = crate::settings_test_lock();
     let app = setup_app();

--- a/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/src/components/settings/__tests__/SettingsView.test.tsx
@@ -79,6 +79,7 @@ function makePreferences(): AppPreferences {
     },
     backups: {
       enabled: true,
+      maxVersions: 10,
     },
   };
 }

--- a/src/components/settings/sections/BackupsSettingsSection.tsx
+++ b/src/components/settings/sections/BackupsSettingsSection.tsx
@@ -2,8 +2,19 @@
 
 import { useTranslation } from "react-i18next";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { SettingsSection } from "@/components/settings/SettingsSection";
-import type { AppPreferences } from "@/lib/types";
+import {
+  BACKUP_MAX_VERSIONS_PRESETS,
+  DEFAULT_BACKUP_MAX_VERSIONS,
+  type AppPreferences,
+} from "@/lib/types";
 
 interface BackupsSettingsSectionProps {
   draft: AppPreferences;
@@ -15,6 +26,18 @@ export function BackupsSettingsSection({
   updateDraft,
 }: Readonly<BackupsSettingsSectionProps>) {
   const { t } = useTranslation();
+
+  // Use the documented presets as the canonical choice set. If a foreign
+  // settings.json file has been migrated with an off-preset value we still
+  // surface it so the dropdown doesn't silently rewrite the user's setting.
+  const currentValue = draft.backups.maxVersions ?? DEFAULT_BACKUP_MAX_VERSIONS;
+  const optionValues = BACKUP_MAX_VERSIONS_PRESETS.includes(
+    currentValue as (typeof BACKUP_MAX_VERSIONS_PRESETS)[number]
+  )
+    ? BACKUP_MAX_VERSIONS_PRESETS
+    : ([...BACKUP_MAX_VERSIONS_PRESETS, currentValue].sort(
+        (a, b) => a - b
+      ) as readonly number[]);
 
   return (
     <SettingsSection
@@ -43,6 +66,41 @@ export function BackupsSettingsSection({
           </span>
         </span>
       </label>
+
+      <div className="flex flex-col gap-2 text-sm">
+        <span>{t("settings.backups.maxVersions.label")}</span>
+        <Select
+          value={String(currentValue)}
+          onValueChange={(next) => {
+            const parsed = Number.parseInt(next, 10);
+            if (Number.isNaN(parsed)) return;
+            updateDraft((previous) => ({
+              ...previous,
+              backups: {
+                ...previous.backups,
+                maxVersions: parsed,
+              },
+            }));
+          }}
+        >
+          <SelectTrigger
+            aria-label={t("settings.backups.maxVersions.label")}
+            className="w-40"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {optionValues.map((preset) => (
+              <SelectItem key={preset} value={String(preset)}>
+                {String(preset)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <span className="text-muted-foreground">
+          {t("settings.backups.maxVersions.description")}
+        </span>
+      </div>
     </SettingsSection>
   );
 }

--- a/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+// jsdom doesn't implement these APIs that Radix Select reaches for when
+// the listbox opens. Stub them so the production component can be exercised
+// end-to-end without rewriting the UI just for tests.
+beforeAll(() => {
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = vi.fn(() => false);
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = vi.fn();
+  }
+});
+
+import { BackupsSettingsSection } from "@/components/settings/sections/BackupsSettingsSection";
+import { BACKUP_MAX_VERSIONS_PRESETS, type AppPreferences } from "@/lib/types";
+
+function makeDraft(maxVersions = 10): AppPreferences {
+  return {
+    general: {
+      language: "en",
+      startupBehavior: "showUnlockScreen",
+      defaultDatabasePath: null,
+    },
+    security: {
+      autoLockTimeout: 300,
+      clipboardClearTimeout: 30,
+      clearClipboardOnLock: true,
+      showClipboardCountdown: false,
+      showPasswordByDefault: false,
+      minimizeToTray: true,
+      startMinimized: false,
+      preventScreenCapture: true,
+      autoDownloadFavicons: false,
+      allowThirdPartyFaviconFallbacks: false,
+    },
+    appearance: {
+      theme: "system",
+      colorPreset: "default",
+      fontSize: 14,
+      entryListColumns: {
+        username: true,
+        url: true,
+        modifiedAt: true,
+        tags: true,
+      },
+    },
+    browserIntegration: { enabled: false, allowedSites: [] },
+    advanced: { debugMode: false, dataLocation: "/tmp" },
+    backups: { enabled: true, maxVersions },
+  };
+}
+
+describe("BackupsSettingsSection", () => {
+  it("renders the max-versions trigger with the current preset value", () => {
+    render(
+      <BackupsSettingsSection draft={makeDraft(25)} updateDraft={vi.fn()} />
+    );
+
+    const trigger = screen.getByRole("combobox", {
+      name: "settings.backups.maxVersions.label",
+    });
+    // The Radix Select trigger renders the selected value as its text.
+    expect(trigger).toHaveTextContent("25");
+  });
+
+  it("offers exactly the documented presets when opened", () => {
+    render(
+      <BackupsSettingsSection draft={makeDraft(10)} updateDraft={vi.fn()} />
+    );
+
+    const trigger = screen.getByRole("combobox", {
+      name: "settings.backups.maxVersions.label",
+    });
+    fireEvent.click(trigger);
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(BACKUP_MAX_VERSIONS_PRESETS.length);
+    for (const preset of BACKUP_MAX_VERSIONS_PRESETS) {
+      expect(
+        screen.getByRole("option", { name: String(preset) })
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("updates draft.backups.maxVersions when a preset is picked", () => {
+    const updateDraft = vi.fn();
+    render(
+      <BackupsSettingsSection draft={makeDraft(10)} updateDraft={updateDraft} />
+    );
+
+    const trigger = screen.getByRole("combobox", {
+      name: "settings.backups.maxVersions.label",
+    });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("option", { name: "50" }));
+
+    expect(updateDraft).toHaveBeenCalledTimes(1);
+    // The section invokes updateDraft with a functional updater so the
+    // surrounding SettingsView can compose draft changes safely.
+    const updater = updateDraft.mock.calls[0][0] as (
+      prev: AppPreferences
+    ) => AppPreferences;
+    const next = updater(makeDraft(10));
+    expect(next.backups.maxVersions).toBe(50);
+    // Other backup settings stay untouched.
+    expect(next.backups.enabled).toBe(true);
+  });
+});

--- a/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
@@ -104,9 +104,9 @@ describe("BackupsSettingsSection", () => {
     expect(updateDraft).toHaveBeenCalledTimes(1);
     // The section invokes updateDraft with a functional updater so the
     // surrounding SettingsView can compose draft changes safely.
-    const updater = updateDraft.mock.calls[0][0] as (
-      prev: AppPreferences
-    ) => AppPreferences;
+    const firstCall = updateDraft.mock.calls[0];
+    if (!firstCall) throw new Error("expected updateDraft to be called");
+    const updater = firstCall[0] as (prev: AppPreferences) => AppPreferences;
     const next = updater(makeDraft(10));
     expect(next.backups.maxVersions).toBe(50);
     // Other backup settings stay untouched.

--- a/src/hooks/__tests__/use-app-preferences.test.tsx
+++ b/src/hooks/__tests__/use-app-preferences.test.tsx
@@ -60,6 +60,7 @@ function makePreferences(): AppPreferences {
     },
     backups: {
       enabled: true,
+      maxVersions: 10,
     },
   };
 }

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -169,6 +169,7 @@ describe("tauri wrappers validation", () => {
       },
       backups: {
         enabled: true,
+        maxVersions: 10,
       },
     } as const;
 

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -233,6 +233,7 @@ describe("tauri wrappers validation", () => {
         },
         backups: {
           enabled: true,
+          maxVersions: 10,
         },
       })
     ).rejects.toThrow();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -268,8 +268,11 @@ export type AdvancedSettings = z.infer<typeof AdvancedSettingsSchema>;
 
 export const BackupSettingsSchema = z.object({
   enabled: z.boolean(),
+  maxVersions: z.number().int().min(1).max(500),
 });
 export type BackupSettings = z.infer<typeof BackupSettingsSchema>;
+export const BACKUP_MAX_VERSIONS_PRESETS = [5, 10, 25, 50, 100] as const;
+export const DEFAULT_BACKUP_MAX_VERSIONS = 10;
 
 export const AppPreferencesSchema = z.object({
   general: GeneralSettingsSchema,

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -114,6 +114,10 @@
         "label": "Enable backups",
         "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
       },
+      "maxVersions": {
+        "label": "Keep N backups",
+        "description": "Older snapshots beyond this count are deleted after each successful save."
+      },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
       }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -114,6 +114,10 @@
         "label": "Enable backups",
         "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
       },
+      "maxVersions": {
+        "label": "Keep N backups",
+        "description": "Older snapshots beyond this count are deleted after each successful save."
+      },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
       }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -114,6 +114,10 @@
         "label": "Enable backups",
         "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
       },
+      "maxVersions": {
+        "label": "Keep N backups",
+        "description": "Older snapshots beyond this count are deleted after each successful save."
+      },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
       }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -114,6 +114,10 @@
         "label": "Enable backups",
         "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
       },
+      "maxVersions": {
+        "label": "Keep N backups",
+        "description": "Older snapshots beyond this count are deleted after each successful save."
+      },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
       }

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -114,6 +114,10 @@
         "label": "Enable backups",
         "description": "Before saving, copy the previous vault bytes into a .kdbx-backups/ folder next to the file."
       },
+      "maxVersions": {
+        "label": "Keep N backups",
+        "description": "Older snapshots beyond this count are deleted after each successful save."
+      },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
       }


### PR DESCRIPTION
Closes #191.

## Summary
- Bound automatic snapshots per Vault with a new `max_versions` setting (default 10, validated 1..=500, frontend zod + Rust boundary checks).
- New `services/kdbx/backups/rotation.rs` keeps the newest N auto-snapshots; sorts newest-first by parsed timestamp (not mtime, which `fs::copy` preserves from source); excludes foreign-vault backups, `.backup.manual.` marker files, and any unrelated files in the backup directory.
- Trim runs only after the new snapshot has been written, so a failed snapshot never deletes existing backups. Two Vaults that share a backup directory rotate independently, keyed on basename.
- Settings → Backups exposes a preset dropdown (5 / 10 / 25 / 50 / 100) via shadcn Select; i18n keys added to en/de/es/fr/sr.

## Acceptance criteria
- [x] After 12 saves with `max_versions=10`, exactly 10 automatic backups remain — `rotation_caps_snapshots_at_max_versions`
- [x] Trim runs only after the new snapshot has been written — `rotation_does_not_run_when_snapshot_fails`
- [x] Rotation never touches files outside the glob — `rotation_preserves_foreign_files_in_backup_dir`
- [x] Settings → Backups exposes the preset dropdown; selection persists — `BackupsSettingsSection.test.tsx`
- [x] `max_versions = 0` or `> 500` rejected at the App Preferences boundary with `AppError::InvalidInput` (notational stand-in for `SettingsError::InvalidValue` — codebase uses `AppError` for all settings errors) — `update_rejects_max_versions_zero_and_preserves_state`, `update_rejects_max_versions_above_cap`
- [x] App Preferences reset restores `max_versions = 10` — `reset_restores_default_max_versions`
- [x] Integration tests cover the cap, the two-Vaults-share-a-directory case, and the post-add ordering of trim vs. write — `rotation_keeps_two_vaults_in_same_directory_independent`, `rotation_retains_newest_snapshots_not_oldest`, `rotation_does_not_run_when_snapshot_fails`
- [x] Unit tests cover the rotation glob: manual-exclusion, foreign-Vault-exclusion, unrelated-file-exclusion — `rotation::tests::{excludes_foreign_vault_backups, excludes_manual_marker_files, excludes_unrelated_files}`

## Test plan
- [x] `cargo test` — all Rust suites green (15 backup integration tests + 6 new rotation unit tests + 4 new settings validation tests)
- [x] `bun run test` — 338 frontend tests green (3 new BackupsSettingsSection tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bun run check` (eslint + prettier) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)