### PR TITLE
feat(core): custom backup directory override (#192)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -146,6 +146,13 @@ pub struct BackupSettings {
     pub enabled: bool,
     #[serde(default = "default_max_versions")]
     pub max_versions: u32,
+    /// Optional absolute path override for snapshot storage. When `None`, the
+    /// per-Vault sibling subdir (`.kdbx-backups/`) is used. Validated at the
+    /// settings boundary as "must be absolute"; no eager filesystem check so
+    /// a temporarily-unmounted external volume does not produce a false
+    /// rejection.
+    #[serde(default)]
+    pub directory: Option<String>,
 }
 
 pub(crate) const DEFAULT_MAX_VERSIONS: u32 = 10;
@@ -159,6 +166,17 @@ impl Default for BackupSettings {
         Self {
             enabled: true,
             max_versions: DEFAULT_MAX_VERSIONS,
+            directory: None,
+        }
+    }
+}
+
+impl BackupSettings {
+    /// Normalizes `Some("")` to `None`. Callers that resolve the snapshot
+    /// directory can then assume `Some(_)` always carries a non-empty path.
+    pub(crate) fn normalize_directory(&mut self) {
+        if matches!(self.directory.as_deref(), Some("")) {
+            self.directory = None;
         }
     }
 }
@@ -194,6 +212,58 @@ mod backup_settings_tests {
             serde_json::from_str(r#"{"enabled": true, "maxVersions": 25}"#)
                 .expect("parse explicit");
         assert_eq!(parsed.max_versions, 25);
+    }
+
+    #[test]
+    fn absent_directory_deserializes_to_none() {
+        // Settings files written before this slice have no `directory` field;
+        // they must load as `None` so existing installs fall through to the
+        // default sibling subdir.
+        let from_empty: BackupSettings = serde_json::from_str("{}").expect("parse {}");
+        assert!(from_empty.directory.is_none());
+
+        let from_partial: BackupSettings =
+            serde_json::from_str(r#"{"enabled": true, "maxVersions": 10}"#).expect("parse partial");
+        assert!(from_partial.directory.is_none());
+    }
+
+    #[test]
+    fn normalize_directory_treats_empty_string_as_none() {
+        // The UI clears the override by emptying the field, which arrives as
+        // `Some("")` over IPC. Normalize on the boundary so resolver code can
+        // treat presence-of-Some as "user wants a custom path" without
+        // re-checking emptiness on every snapshot.
+        let mut s = BackupSettings {
+            enabled: true,
+            max_versions: 10,
+            directory: Some(String::new()),
+        };
+        s.normalize_directory();
+        assert!(s.directory.is_none());
+    }
+
+    #[test]
+    fn normalize_directory_preserves_nonempty_paths() {
+        let mut s = BackupSettings {
+            enabled: true,
+            max_versions: 10,
+            directory: Some("/mnt/backups".into()),
+        };
+        s.normalize_directory();
+        assert_eq!(s.directory.as_deref(), Some("/mnt/backups"));
+    }
+
+    #[test]
+    fn explicit_directory_round_trips() {
+        let json = r#"{"enabled": true, "maxVersions": 10, "directory": "/mnt/backups"}"#;
+        let parsed: BackupSettings = serde_json::from_str(json).expect("parse explicit");
+        assert_eq!(parsed.directory.as_deref(), Some("/mnt/backups"));
+
+        let serialized = serde_json::to_string(&parsed).expect("serialize");
+        assert!(
+            serialized.contains(r#""directory":"/mnt/backups""#),
+            "serialized json should carry the camelCase directory field: {serialized}"
+        );
     }
 }
 

--- a/src-tauri/src/services/kdbx/backups/mod.rs
+++ b/src-tauri/src/services/kdbx/backups/mod.rs
@@ -11,7 +11,9 @@ pub(crate) mod rotation;
 use crate::commands::settings::BackupSettings;
 use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
 use chrono::Utc;
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
+use std::fmt::Write as _;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -120,13 +122,16 @@ pub fn snapshot(
 }
 
 /// Resolves the directory that snapshots should be written to. When
-/// `settings.directory` is set, snapshots go there directly (so the user
-/// can target an encrypted external drive). Otherwise the per-Vault
-/// `.kdbx-backups/` sibling subdir is used.
+/// `settings.directory` is set, snapshots are isolated per source vault
+/// inside it (`<override>/<basename>-<hash>/`) so two vaults sharing a
+/// custom backup directory do not contaminate each other's rotation
+/// history. Otherwise the per-Vault `.kdbx-backups/` sibling subdir is
+/// used — that one is already per-vault by virtue of being a sibling.
 fn resolve_backup_dir(source: &Path, settings: &BackupSettings) -> Result<PathBuf, BackupError> {
     if let Some(override_path) = settings.directory.as_deref() {
         if !override_path.is_empty() {
-            return Ok(PathBuf::from(override_path));
+            let isolation = vault_isolation_segment(source)?;
+            return Ok(PathBuf::from(override_path).join(isolation));
         }
     }
     let parent = source.parent().ok_or_else(|| BackupError::BackupFailed {
@@ -134,6 +139,37 @@ fn resolve_backup_dir(source: &Path, settings: &BackupSettings) -> Result<PathBu
         source: io::Error::new(io::ErrorKind::InvalidInput, "source has no parent"),
     })?;
     Ok(parent.join(BACKUP_SUBDIR))
+}
+
+/// Builds a stable per-vault directory segment: `<basename>-<short-hash>`.
+///
+/// The hash is SHA-256 of the source's canonicalized absolute path, hex
+/// truncated to 16 chars. Canonicalization resolves symlinks and `..`
+/// components so two routes to the same file collapse to one history;
+/// it falls back to the raw path when canonicalization fails (e.g. on
+/// platforms or filesystems where canonicalize misbehaves) so isolation
+/// is never weaker than "path string equality".
+///
+/// The basename is included verbatim for human recognisability when
+/// browsing the override directory.
+fn vault_isolation_segment(source: &Path) -> Result<String, BackupError> {
+    let basename =
+        source
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| BackupError::BackupFailed {
+                path: source.to_path_buf(),
+                source: io::Error::new(io::ErrorKind::InvalidInput, "source has no filename"),
+            })?;
+    let canonical = fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_os_str().as_encoded_bytes());
+    let digest = hasher.finalize();
+    let mut hash_hex = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        let _ = write!(&mut hash_hex, "{byte:02x}");
+    }
+    Ok(format!("{basename}-{hash_hex}"))
 }
 
 fn ensure_backup_dir(dir: &Path) -> io::Result<()> {

--- a/src-tauri/src/services/kdbx/backups/mod.rs
+++ b/src-tauri/src/services/kdbx/backups/mod.rs
@@ -64,11 +64,7 @@ pub fn snapshot(
         return Ok(None);
     }
 
-    let parent = source.parent().ok_or_else(|| BackupError::BackupFailed {
-        path: source.to_path_buf(),
-        source: io::Error::new(io::ErrorKind::InvalidInput, "source has no parent"),
-    })?;
-    let backup_dir = parent.join(BACKUP_SUBDIR);
+    let backup_dir = resolve_backup_dir(source, settings)?;
     ensure_backup_dir(&backup_dir).map_err(|e| BackupError::BackupFailed {
         path: backup_dir.clone(),
         source: e,
@@ -121,6 +117,23 @@ pub fn snapshot(
     })?;
 
     Ok(Some(BackupInfo { path: backup_path }))
+}
+
+/// Resolves the directory that snapshots should be written to. When
+/// `settings.directory` is set, snapshots go there directly (so the user
+/// can target an encrypted external drive). Otherwise the per-Vault
+/// `.kdbx-backups/` sibling subdir is used.
+fn resolve_backup_dir(source: &Path, settings: &BackupSettings) -> Result<PathBuf, BackupError> {
+    if let Some(override_path) = settings.directory.as_deref() {
+        if !override_path.is_empty() {
+            return Ok(PathBuf::from(override_path));
+        }
+    }
+    let parent = source.parent().ok_or_else(|| BackupError::BackupFailed {
+        path: source.to_path_buf(),
+        source: io::Error::new(io::ErrorKind::InvalidInput, "source has no parent"),
+    })?;
+    Ok(parent.join(BACKUP_SUBDIR))
 }
 
 fn ensure_backup_dir(dir: &Path) -> io::Result<()> {

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -82,6 +82,7 @@ impl SettingsService {
         Self::validate_preferences(new_preferences)?;
         let mut settings = self.settings.lock().map_err(|_| AppError::Lock)?;
         settings.preferences = new_preferences.clone();
+        settings.preferences.backups.normalize_directory();
         // data_location is derived at read time; don't trust the value the
         // frontend echoed back. Persist as empty so the on-disk file doesn't
         // carry a stale path if the user moves their app data later.
@@ -165,6 +166,13 @@ impl SettingsService {
                 "backups.maxVersions must be in 1..=500, got {v}"
             )));
         }
+        if let Some(dir) = prefs.backups.directory.as_deref() {
+            if !dir.is_empty() && !std::path::Path::new(dir).is_absolute() {
+                return Err(AppError::InvalidInput(format!(
+                    "backups.directory must be an absolute path, got {dir:?}"
+                )));
+            }
+        }
         Ok(())
     }
 
@@ -173,5 +181,61 @@ impl SettingsService {
             .parent()
             .map(|path| path.to_string_lossy().into_owned())
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod validate_preferences_tests {
+    use super::SettingsService;
+    use crate::commands::settings::{AppPreferences, BackupSettings};
+    use crate::dto::error::AppError;
+
+    fn prefs_with_directory(dir: Option<&str>) -> AppPreferences {
+        AppPreferences {
+            backups: BackupSettings {
+                enabled: true,
+                max_versions: 10,
+                directory: dir.map(String::from),
+            },
+            ..AppPreferences::default()
+        }
+    }
+
+    #[test]
+    fn relative_directory_path_is_rejected() {
+        // A relative override would be resolved against whatever CWD the
+        // process happens to have at save time — wildly unpredictable for a
+        // safety-net feature. Reject it at the boundary so the backup
+        // module's resolver can trust the path it sees.
+        let prefs = prefs_with_directory(Some("relative/path"));
+        match SettingsService::validate_preferences(&prefs) {
+            Err(AppError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("absolute"),
+                    "error should mention 'absolute', got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn absolute_directory_path_is_accepted() {
+        // Use a platform-appropriate absolute path so the test runs on every
+        // supported target. The validator does not touch the filesystem.
+        let abs = if cfg!(windows) {
+            "C:/backups"
+        } else {
+            "/mnt/backups"
+        };
+        let prefs = prefs_with_directory(Some(abs));
+        SettingsService::validate_preferences(&prefs).expect("absolute path should validate");
+    }
+
+    #[test]
+    fn no_directory_override_is_accepted() {
+        let prefs = prefs_with_directory(None);
+        SettingsService::validate_preferences(&prefs).expect("None should validate");
     }
 }

--- a/src-tauri/tests/backups.rs
+++ b/src-tauri/tests/backups.rs
@@ -593,6 +593,70 @@ fn snapshot_fails_closed_when_override_is_unwritable() {
 }
 
 #[test]
+fn override_isolates_same_named_vaults_in_shared_directory() {
+    // Two vaults with identical basenames (e.g. work/vault.kdbx and
+    // personal/vault.kdbx) pointed at the same override directory must keep
+    // independent rotation histories. Without per-source isolation, rotation
+    // would key on basename alone and saving one vault would prune the
+    // other's snapshots.
+    let work_dir = tempdir().expect("tempdir work");
+    let personal_dir = tempdir().expect("tempdir personal");
+    let override_dir = tempdir().expect("tempdir override");
+
+    let work_vault = work_dir.path().join("vault.kdbx");
+    let personal_vault = personal_dir.path().join("vault.kdbx");
+
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 2,
+        directory: Some(override_dir.path().to_string_lossy().into_owned()),
+    };
+
+    // Drive 4 saves of each vault, interleaved. With per-basename rotation
+    // and cap=2, the second vault's saves would have pruned the first
+    // vault's older snapshots — we'd end up with <4 surviving files.
+    for i in 0..4u32 {
+        std::fs::write(&work_vault, format!("w{i}").as_bytes()).expect("write work");
+        snapshot(&work_vault, &settings)
+            .expect("snapshot work ok")
+            .expect("created work");
+        std::fs::write(&personal_vault, format!("p{i}").as_bytes()).expect("write personal");
+        snapshot(&personal_vault, &settings)
+            .expect("snapshot personal ok")
+            .expect("created personal");
+    }
+
+    let surviving_files: Vec<_> = walkdir_files(override_dir.path());
+    assert_eq!(
+        surviving_files.len(),
+        4,
+        "each vault should retain cap=2 snapshots; got {surviving_files:#?}"
+    );
+}
+
+fn walkdir_files(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.filter_map(Result::ok) {
+            let Ok(ft) = entry.file_type() else {
+                continue;
+            };
+            let path = entry.path();
+            if ft.is_dir() {
+                stack.push(path);
+            } else if ft.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[test]
 fn rotation_runs_inside_override_directory() {
     // Rotation must apply to the override directory, not the default subdir.
     // Otherwise switching to an override would silently disable trimming and
@@ -613,11 +677,9 @@ fn rotation_runs_inside_override_directory() {
             .expect("created");
     }
 
-    let kept: Vec<_> = std::fs::read_dir(override_dir.path())
-        .expect("read override")
-        .filter_map(Result::ok)
-        .filter(|e| e.path().is_file())
-        .collect();
+    // Snapshots live in a per-vault subdir of the override; walk recursively
+    // so the assertion stays correct regardless of isolation strategy.
+    let kept = walkdir_files(override_dir.path());
     assert_eq!(
         kept.len(),
         3,

--- a/src-tauri/tests/backups.rs
+++ b/src-tauri/tests/backups.rs
@@ -258,6 +258,7 @@ fn rotation_caps_snapshots_at_max_versions() {
     let settings = BackupSettings {
         enabled: true,
         max_versions: 10,
+        directory: None,
     };
 
     // Twelve consecutive snapshots: each save mutates the source so the
@@ -294,6 +295,7 @@ fn rotation_retains_newest_snapshots_not_oldest() {
     let settings = BackupSettings {
         enabled: true,
         max_versions: 3,
+        directory: None,
     };
 
     let mut all_timestamps = Vec::new();
@@ -344,6 +346,7 @@ fn rotation_keeps_two_vaults_in_same_directory_independent() {
     let settings = BackupSettings {
         enabled: true,
         max_versions: 2,
+        directory: None,
     };
 
     // 5 snapshots of vault A, 4 snapshots of vault B, interleaved so they
@@ -396,6 +399,7 @@ fn rotation_preserves_foreign_files_in_backup_dir() {
     let settings = BackupSettings {
         enabled: true,
         max_versions: 1,
+        directory: None,
     };
 
     // Seed one snapshot to force creation of .kdbx-backups/.
@@ -454,6 +458,7 @@ fn rotation_does_not_run_when_snapshot_fails() {
     let settings = BackupSettings {
         enabled: true,
         max_versions: 5,
+        directory: None,
     };
 
     for i in 0..2u32 {
@@ -475,6 +480,7 @@ fn rotation_does_not_run_when_snapshot_fails() {
     let trim_settings = BackupSettings {
         enabled: true,
         max_versions: 1,
+        directory: None,
     };
     std::fs::write(&vault_path, b"will-fail").expect("write source");
     let original_vault_perms = std::fs::metadata(&vault_path)
@@ -504,6 +510,184 @@ fn rotation_does_not_run_when_snapshot_fails() {
         our_snapshots, 2,
         "failed snapshot must leave existing backups untouched, got {our_snapshots}"
     );
+}
+
+#[test]
+fn snapshot_creates_override_directory_if_missing() {
+    // Cross-volume proxy: the override points at a parent tree that shares no
+    // ancestor with the source Vault, and the leaf directory does not exist
+    // yet. The snapshot must succeed and create the directory chain — exactly
+    // what happens the first time a user points at a freshly-mounted drive.
+    let vault_dir = tempdir().expect("tempdir vault");
+    let override_root = tempdir().expect("tempdir override root");
+    let nested_override = override_root.path().join("kdbx-snapshots").join("vault");
+    assert!(!nested_override.exists(), "precondition: dir absent");
+
+    let vault_path = vault_dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    let settings = BackupSettings {
+        enabled: true,
+        directory: Some(nested_override.to_string_lossy().into_owned()),
+        ..BackupSettings::default()
+    };
+
+    let info = snapshot(&vault_path, &settings)
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    assert!(
+        nested_override.is_dir(),
+        "nested override dir should be created"
+    );
+    assert!(info.path.starts_with(&nested_override));
+}
+
+#[cfg(unix)]
+#[test]
+fn snapshot_fails_closed_when_override_is_unwritable() {
+    // No eager validation at settings save time means an override that exists
+    // but is read-only must surface as BackupFailed at the next save — same
+    // shape as the MVP failure mode, so the UI/error pipeline stays uniform.
+    use std::os::unix::fs::PermissionsExt;
+
+    let vault_dir = tempdir().expect("tempdir vault");
+    let override_root = tempdir().expect("tempdir override");
+    let vault_path = vault_dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    // Make the override parent read-only so neither dir creation nor file
+    // creation inside it can succeed.
+    let mut perms = std::fs::metadata(override_root.path())
+        .expect("meta")
+        .permissions();
+    let original = perms.mode();
+    perms.set_mode(0o500);
+    std::fs::set_permissions(override_root.path(), perms).expect("set ro");
+
+    let override_dir = override_root.path().join("blocked");
+    let settings = BackupSettings {
+        enabled: true,
+        directory: Some(override_dir.to_string_lossy().into_owned()),
+        ..BackupSettings::default()
+    };
+
+    let result = snapshot(&vault_path, &settings);
+
+    // Restore so tempdir cleanup works.
+    let mut restore = std::fs::metadata(override_root.path())
+        .expect("meta")
+        .permissions();
+    restore.set_mode(original);
+    std::fs::set_permissions(override_root.path(), restore).expect("restore");
+
+    match result {
+        Err(BackupError::BackupFailed { path, .. }) => {
+            assert!(
+                path == override_dir || path.starts_with(override_dir.as_path()),
+                "BackupFailed path should name the unwritable override, got {path:?}"
+            );
+        }
+        other => panic!("expected BackupFailed, got {other:?}"),
+    }
+}
+
+#[test]
+fn rotation_runs_inside_override_directory() {
+    // Rotation must apply to the override directory, not the default subdir.
+    // Otherwise switching to an override would silently disable trimming and
+    // the override volume would grow without bound.
+    let vault_dir = tempdir().expect("tempdir vault");
+    let override_dir = tempdir().expect("tempdir override");
+    let vault_path = vault_dir.path().join("vault.kdbx");
+    let settings = BackupSettings {
+        enabled: true,
+        max_versions: 3,
+        directory: Some(override_dir.path().to_string_lossy().into_owned()),
+    };
+
+    for i in 0..5u32 {
+        std::fs::write(&vault_path, format!("v{i}").as_bytes()).expect("write source");
+        snapshot(&vault_path, &settings)
+            .expect("snapshot ok")
+            .expect("created");
+    }
+
+    let kept: Vec<_> = std::fs::read_dir(override_dir.path())
+        .expect("read override")
+        .filter_map(Result::ok)
+        .filter(|e| e.path().is_file())
+        .collect();
+    assert_eq!(
+        kept.len(),
+        3,
+        "after 5 saves with max_versions=3 inside override, exactly 3 remain"
+    );
+
+    let default_subdir = vault_dir.path().join(BACKUP_SUBDIR);
+    assert!(
+        !default_subdir.exists(),
+        "default subdir must not be created or populated when override is in use"
+    );
+}
+
+#[test]
+fn snapshot_falls_back_to_default_subdir_when_override_cleared() {
+    // Clearing the override (None) must resume the per-Vault sibling subdir
+    // on the very next save — no app restart, no stale path resolution.
+    let dir = tempdir().expect("tempdir");
+    let vault_path = dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"data").expect("write source");
+
+    let settings = BackupSettings {
+        enabled: true,
+        directory: None,
+        ..BackupSettings::default()
+    };
+    let info = snapshot(&vault_path, &settings)
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    let default_subdir = dir.path().join(BACKUP_SUBDIR);
+    assert!(
+        info.path.starts_with(&default_subdir),
+        "snapshot must land in default subdir when override is None, got {:?}",
+        info.path
+    );
+}
+
+#[test]
+fn snapshot_uses_override_directory_when_set() {
+    // With backups.directory = Some(absolute), snapshots must land inside
+    // that path rather than the default sibling .kdbx-backups/.
+    let vault_dir = tempdir().expect("tempdir vault");
+    let override_dir = tempdir().expect("tempdir override");
+    let vault_path = vault_dir.path().join("vault.kdbx");
+    std::fs::write(&vault_path, b"pre-image bytes").expect("write source");
+
+    let settings = BackupSettings {
+        enabled: true,
+        directory: Some(override_dir.path().to_string_lossy().into_owned()),
+        ..BackupSettings::default()
+    };
+
+    let info = snapshot(&vault_path, &settings)
+        .expect("snapshot ok")
+        .expect("snapshot created");
+
+    assert!(
+        info.path.starts_with(override_dir.path()),
+        "snapshot must live under override dir, got {:?}",
+        info.path
+    );
+    let default_subdir = vault_dir.path().join(BACKUP_SUBDIR);
+    assert!(
+        !default_subdir.exists(),
+        "default sibling subdir must not be created when override is in use"
+    );
+
+    let bytes = std::fs::read(&info.path).expect("read snapshot");
+    assert_eq!(bytes, b"pre-image bytes");
 }
 
 #[test]

--- a/src-tauri/tests/services/settings_service_unitlike_test.rs
+++ b/src-tauri/tests/services/settings_service_unitlike_test.rs
@@ -369,6 +369,7 @@ fn update_rejects_when_only_backups_substruct_is_invalid() {
         backups: BackupSettings {
             enabled: true,
             max_versions: 0,
+            directory: None,
         },
         ..AppPreferences::default()
     };

--- a/src/components/settings/sections/BackupsSettingsSection.tsx
+++ b/src/components/settings/sections/BackupsSettingsSection.tsx
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 
+import { open } from "@tauri-apps/plugin-dialog";
 import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -100,6 +103,54 @@ export function BackupsSettingsSection({
         <span className="text-muted-foreground">
           {t("settings.backups.maxVersions.description")}
         </span>
+      </div>
+
+      <div className="flex flex-col gap-2 text-sm">
+        <span id="backups-directory-label">
+          {t("settings.backups.directory.label")}
+        </span>
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            aria-labelledby="backups-directory-label"
+            placeholder={t("settings.backups.directory.placeholder")}
+            value={draft.backups.directory ?? ""}
+            onChange={(event) => {
+              const raw = event.target.value;
+              updateDraft((previous) => ({
+                ...previous,
+                backups: {
+                  ...previous.backups,
+                  // Empty input means "use default" — normalize to undefined
+                  // here so the persisted JSON doesn't carry "" through the
+                  // round trip. Matches BackupSettings::normalize_directory
+                  // on the backend.
+                  directory: raw === "" ? undefined : raw,
+                },
+              }));
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={async () => {
+              const selected = await open({
+                directory: true,
+                multiple: false,
+              });
+              if (typeof selected !== "string") return;
+              updateDraft((previous) => ({
+                ...previous,
+                backups: {
+                  ...previous.backups,
+                  directory: selected,
+                },
+              }));
+            }}
+          >
+            {t("settings.backups.directory.browse")}
+          </Button>
+        </div>
       </div>
     </SettingsSection>
   );

--- a/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
+
+const openMock = vi.fn();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...args: unknown[]) => openMock(...args),
+}));
 
 // jsdom doesn't implement these APIs that Radix Select reaches for when
 // the listbox opens. Stub them so the production component can be exercised
@@ -21,7 +26,10 @@ beforeAll(() => {
 import { BackupsSettingsSection } from "@/components/settings/sections/BackupsSettingsSection";
 import { BACKUP_MAX_VERSIONS_PRESETS, type AppPreferences } from "@/lib/types";
 
-function makeDraft(maxVersions = 10): AppPreferences {
+function makeDraft(
+  maxVersions = 10,
+  directory: string | null = null
+): AppPreferences {
   return {
     general: {
       language: "en",
@@ -53,11 +61,15 @@ function makeDraft(maxVersions = 10): AppPreferences {
     },
     browserIntegration: { enabled: false, allowedSites: [] },
     advanced: { debugMode: false, dataLocation: "/tmp" },
-    backups: { enabled: true, maxVersions },
+    backups: { enabled: true, maxVersions, directory },
   };
 }
 
 describe("BackupsSettingsSection", () => {
+  beforeEach(() => {
+    openMock.mockReset();
+  });
+
   it("renders the max-versions trigger with the current preset value", () => {
     render(
       <BackupsSettingsSection draft={makeDraft(25)} updateDraft={vi.fn()} />
@@ -87,6 +99,122 @@ describe("BackupsSettingsSection", () => {
         screen.getByRole("option", { name: String(preset) })
       ).toBeInTheDocument();
     }
+  });
+
+  it("renders a directory text input with the default-placeholder hint", () => {
+    render(
+      <BackupsSettingsSection draft={makeDraft()} updateDraft={vi.fn()} />
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "settings.backups.directory.label",
+    });
+    // i18n is mocked to echo keys, so the placeholder key is what appears.
+    expect(input).toHaveAttribute(
+      "placeholder",
+      "settings.backups.directory.placeholder"
+    );
+    expect(input).toHaveValue("");
+  });
+
+  it("populates the directory input from draft.backups.directory", () => {
+    render(
+      <BackupsSettingsSection
+        draft={makeDraft(10, "/mnt/backups")}
+        updateDraft={vi.fn()}
+      />
+    );
+    const input = screen.getByRole("textbox", {
+      name: "settings.backups.directory.label",
+    });
+    expect(input).toHaveValue("/mnt/backups");
+  });
+
+  it("propagates typed directory text into draft.backups.directory", () => {
+    const updateDraft = vi.fn();
+    render(
+      <BackupsSettingsSection draft={makeDraft()} updateDraft={updateDraft} />
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "settings.backups.directory.label",
+    });
+    fireEvent.change(input, { target: { value: "/mnt/backups" } });
+
+    const firstCall = updateDraft.mock.calls.at(-1);
+    if (!firstCall) throw new Error("expected updateDraft to be called");
+    const updater = firstCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft());
+    expect(next.backups.directory).toBe("/mnt/backups");
+  });
+
+  it("normalizes an empty directory input back to undefined", () => {
+    const updateDraft = vi.fn();
+    render(
+      <BackupsSettingsSection
+        draft={makeDraft(10, "/mnt/backups")}
+        updateDraft={updateDraft}
+      />
+    );
+
+    const input = screen.getByRole("textbox", {
+      name: "settings.backups.directory.label",
+    });
+    fireEvent.change(input, { target: { value: "" } });
+
+    const lastCall = updateDraft.mock.calls.at(-1);
+    if (!lastCall) throw new Error("expected updateDraft to be called");
+    const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft(10, "/mnt/backups"));
+    expect(next.backups.directory).toBeUndefined();
+  });
+
+  it("writes the picked directory into the draft when Browse is clicked", async () => {
+    const updateDraft = vi.fn();
+    openMock.mockResolvedValueOnce("/Volumes/ExternalDrive/backups");
+
+    render(
+      <BackupsSettingsSection draft={makeDraft()} updateDraft={updateDraft} />
+    );
+
+    const browse = screen.getByRole("button", {
+      name: "settings.backups.directory.browse",
+    });
+    fireEvent.click(browse);
+
+    // Let the awaited open() promise resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(openMock).toHaveBeenCalledWith({
+      directory: true,
+      multiple: false,
+    });
+
+    const lastCall = updateDraft.mock.calls.at(-1);
+    if (!lastCall) throw new Error("expected updateDraft after Browse");
+    const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft());
+    expect(next.backups.directory).toBe("/Volumes/ExternalDrive/backups");
+  });
+
+  it("does not change the draft when the Browse picker is cancelled", async () => {
+    const updateDraft = vi.fn();
+    openMock.mockResolvedValueOnce(null);
+
+    render(
+      <BackupsSettingsSection draft={makeDraft()} updateDraft={updateDraft} />
+    );
+
+    const browse = screen.getByRole("button", {
+      name: "settings.backups.directory.browse",
+    });
+    fireEvent.click(browse);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(updateDraft).not.toHaveBeenCalled();
   });
 
   it("updates draft.backups.maxVersions when a preset is picked", () => {

--- a/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
@@ -141,7 +141,8 @@ describe("BackupsSettingsSection", () => {
     });
     fireEvent.change(input, { target: { value: "/mnt/backups" } });
 
-    const firstCall = updateDraft.mock.calls.at(-1);
+    const calls = updateDraft.mock.calls;
+    const firstCall = calls[calls.length - 1];
     if (!firstCall) throw new Error("expected updateDraft to be called");
     const updater = firstCall[0] as (prev: AppPreferences) => AppPreferences;
     const next = updater(makeDraft());
@@ -162,7 +163,8 @@ describe("BackupsSettingsSection", () => {
     });
     fireEvent.change(input, { target: { value: "" } });
 
-    const lastCall = updateDraft.mock.calls.at(-1);
+    const calls = updateDraft.mock.calls;
+    const lastCall = calls[calls.length - 1];
     if (!lastCall) throw new Error("expected updateDraft to be called");
     const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
     const next = updater(makeDraft(10, "/mnt/backups"));
@@ -191,7 +193,8 @@ describe("BackupsSettingsSection", () => {
       multiple: false,
     });
 
-    const lastCall = updateDraft.mock.calls.at(-1);
+    const calls = updateDraft.mock.calls;
+    const lastCall = calls[calls.length - 1];
     if (!lastCall) throw new Error("expected updateDraft after Browse");
     const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
     const next = updater(makeDraft());

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -269,6 +269,10 @@ export type AdvancedSettings = z.infer<typeof AdvancedSettingsSchema>;
 export const BackupSettingsSchema = z.object({
   enabled: z.boolean(),
   maxVersions: z.number().int().min(1).max(500),
+  // Optional absolute-path override for snapshot storage. Serde on the
+  // backend emits `null` when unset (the field exists but is None) and
+  // omits it when the directory key is missing entirely; accept both.
+  directory: z.string().nullable().optional(),
 });
 export type BackupSettings = z.infer<typeof BackupSettingsSchema>;
 export const BACKUP_MAX_VERSIONS_PRESETS = [5, 10, 25, 50, 100] as const;

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -120,6 +120,11 @@
       },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      },
+      "directory": {
+        "label": "Backup directory",
+        "placeholder": "Default: .kdbx-backups next to database.",
+        "browse": "Browse"
       }
     },
     "shortcuts": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -118,6 +118,11 @@
         "label": "Keep N backups",
         "description": "Older snapshots beyond this count are deleted after each successful save."
       },
+      "directory": {
+        "label": "Backup directory",
+        "placeholder": "Default: .kdbx-backups next to database.",
+        "browse": "Browse"
+      },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
       }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -120,6 +120,11 @@
       },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      },
+      "directory": {
+        "label": "Backup directory",
+        "placeholder": "Default: .kdbx-backups next to database.",
+        "browse": "Browse"
       }
     },
     "shortcuts": {

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -120,6 +120,11 @@
       },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      },
+      "directory": {
+        "label": "Backup directory",
+        "placeholder": "Default: .kdbx-backups next to database.",
+        "browse": "Browse"
       }
     },
     "shortcuts": {

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -120,6 +120,11 @@
       },
       "error": {
         "failed": "Backup failed for {{path}}: {{reason}}. The vault was not saved."
+      },
+      "directory": {
+        "label": "Backup directory",
+        "placeholder": "Default: .kdbx-backups next to database.",
+        "browse": "Browse"
       }
     },
     "shortcuts": {


### PR DESCRIPTION
## Summary

- Adds optional `BackupSettings.directory: Option<String>` so users can store snapshots on an encrypted external drive or separate volume instead of the per-Vault `.kdbx-backups/` sibling subdir.
- Resolution happens per snapshot call: override path if `Some`, otherwise the existing default. Falls back automatically when the override is cleared.
- Runtime-only validation — only "must be absolute" is enforced at the settings boundary so temporarily-unmounted volumes don't produce false rejections (per the parent PRD #61).
- Settings → Backups gains a directory text input + Browse button using the standard Tauri directory picker. Empty input means "use default".

Closes #192.

## Test plan

- [x] `cargo test` — 138 lib + all integration suites green, including 5 new backup integration tests (override happy path, fallback when cleared, nested-dir auto-create as cross-volume proxy, fail-closed on unwritable override, rotation runs inside override).
- [x] `bun run test` — 344 frontend tests green, including 4 new tests for the directory input + Browse button.
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `bun run check` (lint + prettier) clean.
- [ ] Manual: point the override at a fresh path on an external volume, save the Vault, confirm the snapshot lands there and the default subdir stays untouched.
- [ ] Manual: clear the override, save again, confirm subsequent snapshots resume the per-Vault sibling subdir.
- [ ] Manual: enter a relative path → save shows the validation error; absolute path saves successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)