### PR TITLE
docs(core): seed ADR-0001 and Audit glossary for #43

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,3 +56,26 @@ A read-only snapshot of properties intrinsic to a specific Vault (KDF parameters
 
 ### Secure String / Secure Bytes
 Wrappers around `String` / `Vec<u8>` that zeroize on drop and redact in Debug/Display output. Used for every value the code wants to keep out of accidental logs and core dumps — passwords, keyfile contents, derived keys.
+
+## Audit
+
+End-user awareness of security-relevant events. Developer debugging is a separate concern and is **not** what this section covers.
+
+### Audit Log
+A per-Vault append-only stream of security-relevant events recorded on **this device**. Lives in the app's local data dir, one file per Vault, filename keyed by the SHA-256 hash of the canonicalized Vault path so the on-disk layout doesn't leak which Vaults exist. Encrypted at rest with a key from the OS keychain (via `secure_storage`). Survives Vault locks — failed-unlock attempts append to the same log.
+
+### Audit Event
+A single record in an Audit Log. Carries a UTC timestamp, an Audit Event Kind, and the minimal kind-specific fields needed to tell the story. Deliberately does **not** carry passwords, Vault paths, or Entry titles — titles are resolved at view time by joining `entry_id` against the matching unlocked Vault, so an Audit Log without its Vault is intentionally less informative.
+
+### Audit Event Kind
+The namespaced enum of recordable events:
+- `vault.opened` — successful unlock
+- `vault.locked` — re-lock, with `reason` (`manual | auto_lock | app_quit | screen_lock`)
+- `vault.unlock_failed` — wrong password/keyfile, with `attempt_count` (resets on success, per-session)
+- `entry.password_revealed` — eye-icon click on the password field
+- `entry.password_copied` — clipboard write of an Entry's password
+- `entry.protected_field_revealed` — reveal on a protected custom field
+- `preferences.security_changed` — change to an allowlisted security-relevant App Preference, with `setting_name` only (no old/new values)
+- `audit.cleared` — user emptied the Audit Log; the record itself survives the clear
+
+Entry selection, group navigation, search, theme/language changes, and other non-security-relevant interactions are explicitly **not** Audit Event Kinds.

--- a/docs/adr/0001-audit-log-design.md
+++ b/docs/adr/0001-audit-log-design.md
@@ -1,0 +1,35 @@
+# Audit log: per-device, per-vault, keychain-encrypted JSONL
+
+We're adding an Audit Log (see CONTEXT.md "Audit") for end-user security awareness — "did anyone try to unlock my vault while I was away?", "when did the clipboard auto-copy fire?". Developer debugging is out of scope and remains a separate, unimplemented concern.
+
+## What we decided
+
+- **Audience:** end-user only. No mixing with developer tracing.
+- **Storage:** app-local data dir, one file per Vault, filename = SHA-256 of the canonicalized Vault path. Per-device, not per-Vault-file — the threat model "what happened on this machine?" is inherently per-device.
+- **Encryption at rest:** XChaCha20-Poly1305 with a key obtained from the OS keychain via the existing `secure_storage` service. Each Audit Event is its own AEAD frame (one JSONL line per record), so appends are O(1) and frames are independently decryptable.
+- **Event taxonomy:** the eight kinds enumerated in `CONTEXT.md` under Audit Event Kind. Entry selection, theme changes, language changes, and navigation are deliberately not events.
+- **Event fields:** minimal — timestamp, kind, and kind-specific extras. **No** Vault paths, **no** Entry titles, **no** old/new preference values. Entry titles resolved at view time against the unlocked Vault.
+- **Retention:** age-based, default 90 days, user-configurable in Settings. Secondary 10 MB hard size cap as defense-in-depth. Lazy compaction on append.
+- **Default state:** on by default. Single global Settings toggle to disable; disabling preserves the existing log.
+- **Manual clear:** allowed; emits a surviving `audit.cleared` event so a wipe is never silent.
+- **Write-failure behavior:** silent skip per event. The triggering user action always proceeds. Repeated failures flip a "degraded" indicator in Settings. The Audit Log must never become a DoS vector against the user's own Vault access.
+- **Concurrency:** intra-process `Mutex` + advisory file lock (`flock` on POSIX, `LockFileEx` on Windows) inside the audit service. Self-contained; doesn't require adopting `tauri-plugin-single-instance` app-wide.
+- **UI surface:** Settings → Audit Log panel, accessible any time the app is running. Vault picker sourced from `recent_databases`. Entry IDs render as UUID prefixes when the matching Vault is locked, resolved titles when unlocked.
+
+## Considered and rejected
+
+- **Storing the log inside the KDBX Vault.** Encrypted-by-vault-key for free, but a locked Vault can't append — failed-unlock events would have nowhere to go. Every write would also dirty the Vault, conflicting with the user's "do I have unsaved changes" model.
+- **Per-vault sidecar file next to the `.kdbx`.** Travels with the Vault when copied, but leaks Entry UUIDs and unlock timestamps in plaintext to anyone with filesystem access — defeats the privacy property the Vault provides.
+- **Plaintext JSONL log.** Cheapest, but the *behavioral* leak (unlock cadence, entry-access patterns, failed-attempt counts) is meaningful even though the Vault itself is encrypted. Shipping a security-awareness feature whose own data file undermines its threat model is wrong.
+- **Vault-password-derived encryption key.** Strongest privacy, but pre-unlock events have no key to encrypt with, forcing a hybrid scheme. The keychain key is good enough for "an attacker with filesystem access but not OS-session access."
+- **AES-256-GCM AEAD frames.** Hardware-accelerated, but a 96-bit nonce is too short for safe random-per-record generation at scale. XChaCha20-Poly1305's 192-bit nonce eliminates that concern.
+- **Hard-fail (block the user action) on write failure.** Strongest log integrity but turns the Audit Log into a DoS vector — an attacker who corrupts the log file could prevent password access.
+- **Global single-stream log across all Vaults.** Simpler UI picker, but requires a plaintext hash-→-name index to label streams — leaks which Vaults the user has.
+- **Per-event-category disable toggles.** Considered for v1, deferred as YAGNI. Single global on/off is sufficient until users ask for finer control.
+- **App-wide single-instance plugin.** A reasonable change on its own merits, but out of scope for this issue. The audit service's file lock works correctly with or without it.
+
+## Known limits accepted for v1
+
+- Moving a `.kdbx` to a new path orphans its Audit history (new hash → new file). Mitigation deferred: a future reconciliation tool keyed on the KDBX header UUID.
+- The OS keychain key gates *reading* the log but not its existence — an attacker with filesystem access can still observe that an audit file exists for a given hash, and its size and mtime.
+- Compaction (retention rewrite) is the one operation that holds the exclusive lock for the full file; rare by construction.


### PR DESCRIPTION
## Summary

- Adds **ADR-0001** (`docs/adr/0001-audit-log-design.md`) capturing the design decisions for the Audit Log feature: storage location, encryption-at-rest, file format, event taxonomy, retention, failure mode, concurrency, and rejected alternatives.
- Adds a new **Audit** section to `CONTEXT.md` defining the load-bearing domain terms (Audit Log, Audit Event, Audit Event Kind) so the implementation work has shared vocabulary before any code lands.
- Seeds `docs/adr/` with its first ADR.

This PR is docs-only — no behavioral changes. The implementation tracker for #43 is PRD #215, broken down into nine `ready-for-agent` slice issues (#216–#224).

References #43 (do not auto-close — close manually as superseded by #215 once this PR merges).

Related: #215 (PRD), #216–#224 (implementation slices)

## Test plan

- [ ] Skim `docs/adr/0001-audit-log-design.md` — does the decision record match what we agreed in the grilling session?
- [ ] Skim the new Audit section in `CONTEXT.md` — does the vocabulary match what you want appearing in module names, IPC commands, and code?
- [ ] Confirm the slice issues #216–#224 still make sense in light of the ADR as committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)