### PR TITLE
feat(core,ui): audit log tracer bullet for vault.unlock_failed (#216)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -924,6 +924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1651,6 +1652,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3071,7 +3082,9 @@ version = "0.2.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
+ "chacha20poly1305",
  "chrono",
+ "fs4",
  "image",
  "iota_stronghold",
  "keepass",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,8 @@ arboard = "3"
 tokio = { version = "1", features = ["time", "rt"] }
 chrono = { version = "0.4", features = ["serde"] } # Timestamp handling
 psl = "2"
+chacha20poly1305 = "0.10"
+fs4 = { version = "0.13", features = ["sync"] }
 
 [profile.dev.package.scrypt]
 opt-level = 3

--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use crate::dto::audit::{AuditEventDto, AuditFilterDto};
+use crate::dto::audit::{AuditEventDto, AuditEventsResponseDto, AuditFilterDto};
 use crate::dto::error::AppError;
 use crate::services::audit::{AuditFilter, AuditService};
 use std::path::Path;
@@ -8,20 +8,31 @@ use std::sync::Arc;
 use tauri::State;
 
 /// Returns the audit events recorded on this device for the Vault at
-/// `vault_path`, newest-first.
+/// `vault_path`, newest-first, alongside a session-wide `degraded` flag.
 ///
-/// The `_filter` argument is accepted but ignored in this tracer-bullet slice
-/// (kinds-based and time-range filtering land in a follow-up). The wire shape
-/// is in place so callers do not need to migrate later.
+/// Hard read failures (key source down, log file unreadable) surface as
+/// `AppError::AuditRead` so the UI renders a load-error state distinct
+/// from "no events yet". The `degraded` flag separately signals "earlier
+/// record calls failed; some history may be missing" — a state the read
+/// itself may have succeeded around.
+///
+/// The `filter` argument is accepted but ignored in this tracer-bullet
+/// slice (kinds-based and time-range filtering land in a follow-up); the
+/// wire shape is in place so callers do not need to migrate later.
 #[tauri::command]
 pub async fn get_audit_events(
     vault_path: String,
     filter: Option<AuditFilterDto>,
     audit: State<'_, Arc<AuditService>>,
-) -> Result<Vec<AuditEventDto>, AppError> {
+) -> Result<AuditEventsResponseDto, AppError> {
     let _ = filter; // permissive default in this slice
-    let events = audit.read(Path::new(&vault_path), &AuditFilter::default());
+    let events = audit
+        .read(Path::new(&vault_path), &AuditFilter::default())
+        .map_err(|e| AppError::AuditRead(e.to_string()))?;
     let mut dtos: Vec<AuditEventDto> = events.into_iter().map(AuditEventDto::from).collect();
     dtos.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
-    Ok(dtos)
+    Ok(AuditEventsResponseDto {
+        events: dtos,
+        degraded: audit.is_degraded(),
+    })
 }

--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+use crate::dto::audit::{AuditEventDto, AuditFilterDto};
+use crate::dto::error::AppError;
+use crate::services::audit::{AuditFilter, AuditService};
+use std::path::Path;
+use std::sync::Arc;
+use tauri::State;
+
+/// Returns the audit events recorded on this device for the Vault at
+/// `vault_path`, newest-first.
+///
+/// The `_filter` argument is accepted but ignored in this tracer-bullet slice
+/// (kinds-based and time-range filtering land in a follow-up). The wire shape
+/// is in place so callers do not need to migrate later.
+#[tauri::command]
+pub async fn get_audit_events(
+    vault_path: String,
+    filter: Option<AuditFilterDto>,
+    audit: State<'_, Arc<AuditService>>,
+) -> Result<Vec<AuditEventDto>, AppError> {
+    let _ = filter; // permissive default in this slice
+    let events = audit.read(Path::new(&vault_path), &AuditFilter::default());
+    let mut dtos: Vec<AuditEventDto> = events.into_iter().map(AuditEventDto::from).collect();
+    dtos.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    Ok(dtos)
+}

--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -22,6 +22,6 @@ pub async fn get_audit_events(
     let _ = filter; // permissive default in this slice
     let events = audit.read(Path::new(&vault_path), &AuditFilter::default());
     let mut dtos: Vec<AuditEventDto> = events.into_iter().map(AuditEventDto::from).collect();
-    dtos.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    dtos.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
     Ok(dtos)
 }

--- a/src-tauri/src/commands/database.rs
+++ b/src-tauri/src/commands/database.rs
@@ -4,12 +4,37 @@ use crate::dto::database::{
     CustomIconData, DatabaseConfigDto, DatabaseCreationOptions, DatabaseHeaderInfo, DatabaseInfo,
 };
 use crate::dto::error::AppError;
+use crate::services::audit::AuditService;
 use crate::services::auto_lock::AutoLockService;
 use crate::services::kdbx::backups::{BackupError, BackupInfo, BackupListEntry};
 use crate::services::kdbx::KdbxService;
 use serde::Serialize;
+use std::path::Path;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, Runtime, State};
+
+/// Maps the open/unlock result through the audit subsystem: a successful
+/// open resets the per-Vault failed-unlock counter, while an
+/// `InvalidPassword` failure records exactly one `vault.unlock_failed`
+/// event carrying the running consecutive-failure count.
+///
+/// Returns the original result unchanged. Audit failures cannot bubble up:
+/// `AuditService::record_vault_unlock_failed` flips an internal `degraded`
+/// flag and otherwise stays silent so the user's unlock-failure UX is
+/// unaffected.
+fn record_open_outcome<T>(
+    audit: &AuditService,
+    path: &str,
+    result: Result<T, AppError>,
+) -> Result<T, AppError> {
+    let vault_path = Path::new(path);
+    match &result {
+        Ok(_) => audit.reset_unlock_attempts(vault_path),
+        Err(AppError::InvalidPassword) => audit.record_vault_unlock_failed(vault_path),
+        Err(_) => {}
+    }
+    result
+}
 
 /// Payload of the `backup-warning` event. The frontend renders this as a
 /// non-blocking toast and never as a modal — open-side backup failures must
@@ -67,8 +92,9 @@ pub async fn open_database<R: Runtime>(
     password: String,
     app: AppHandle<R>,
     state: State<'_, Arc<KdbxService>>,
+    audit: State<'_, Arc<AuditService>>,
 ) -> Result<DatabaseInfo, AppError> {
-    let info = state.open(&path, &password)?;
+    let info = record_open_outcome(&audit, &path, state.open(&path, &password))?;
     emit_open_backup_hook(&app, &state, &path);
     Ok(info)
 }
@@ -140,8 +166,13 @@ pub async fn open_database_with_keyfile<R: Runtime>(
     keyfile_path: String,
     app: AppHandle<R>,
     state: State<'_, Arc<KdbxService>>,
+    audit: State<'_, Arc<AuditService>>,
 ) -> Result<DatabaseInfo, AppError> {
-    let info = state.open_with_keyfile(&path, &password, &keyfile_path)?;
+    let info = record_open_outcome(
+        &audit,
+        &path,
+        state.open_with_keyfile(&path, &password, &keyfile_path),
+    )?;
     emit_open_backup_hook(&app, &state, &path);
     Ok(info)
 }
@@ -153,8 +184,13 @@ pub async fn open_database_with_keyfile_only<R: Runtime>(
     keyfile_path: String,
     app: AppHandle<R>,
     state: State<'_, Arc<KdbxService>>,
+    audit: State<'_, Arc<AuditService>>,
 ) -> Result<DatabaseInfo, AppError> {
-    let info = state.open_with_keyfile_only(&path, &keyfile_path)?;
+    let info = record_open_outcome(
+        &audit,
+        &path,
+        state.open_with_keyfile_only(&path, &keyfile_path),
+    )?;
     emit_open_backup_hook(&app, &state, &path);
     Ok(info)
 }
@@ -175,6 +211,7 @@ pub async fn unlock_database<R: Runtime>(
     password: Option<String>,
     app: AppHandle<R>,
     state: State<'_, Arc<KdbxService>>,
+    audit: State<'_, Arc<AuditService>>,
 ) -> Result<DatabaseInfo, AppError> {
     // Snapshot the locked state BEFORE calling unlock so we can tell apart
     // an actual locked → unlocked transition from the no-op case where the
@@ -183,7 +220,7 @@ pub async fn unlock_database<R: Runtime>(
     // wasted work in the happy path, and a duplicated `backup-warning`
     // event whenever the backup dir is broken.
     let was_locked = state.is_database_locked(&db_id)?.unwrap_or(true);
-    let info = state.unlock(&db_id, password.as_deref())?;
+    let info = record_open_outcome(&audit, &db_id, state.unlock(&db_id, password.as_deref()))?;
     if was_locked {
         emit_open_backup_hook(&app, &state, &db_id);
     }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+pub mod audit;
 pub mod clipboard;
 pub mod database;
 pub mod entries;
@@ -9,6 +10,7 @@ pub mod secure_storage;
 pub mod settings;
 pub mod window;
 
+pub use audit::*;
 pub use clipboard::*;
 pub use database::{
     close_database, create_database, create_manual_backup, delete_backup, generate_keyfile,

--- a/src-tauri/src/dto/audit.rs
+++ b/src-tauri/src/dto/audit.rs
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+
+//! IPC-facing audit DTOs.
+//!
+//! Event kinds are serialised camelCase (`vaultUnlockFailed`) so the frontend
+//! never has to do string-keyed dispatch on dot-namespaced values.
+
+use crate::services::audit::format::AuditEvent;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AuditEventKindDto {
+    VaultUnlockFailed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEventDto {
+    pub kind: AuditEventKindDto,
+    pub timestamp: DateTime<Utc>,
+    pub attempt_count: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+pub struct AuditFilterDto {
+    /// Optional list of kinds to include. Today's command accepts but does
+    /// not enforce this — kept on the wire so the UI can stop sending all
+    /// events back to itself once #8 lands.
+    pub kinds: Option<Vec<AuditEventKindDto>>,
+}
+
+impl From<AuditEvent> for AuditEventDto {
+    fn from(event: AuditEvent) -> Self {
+        match event {
+            AuditEvent::VaultUnlockFailed {
+                timestamp,
+                attempt_count,
+            } => Self {
+                kind: AuditEventKindDto::VaultUnlockFailed,
+                timestamp,
+                attempt_count: Some(attempt_count),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn dto_uses_camel_case_kind_over_the_wire() {
+        let dto = AuditEventDto {
+            kind: AuditEventKindDto::VaultUnlockFailed,
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap(),
+            attempt_count: Some(2),
+        };
+        let json = serde_json::to_string(&dto).expect("ser");
+        assert!(json.contains("\"vaultUnlockFailed\""));
+        assert!(json.contains("\"attemptCount\":2"));
+    }
+
+    #[test]
+    fn event_converts_to_dto() {
+        let ts = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
+        let dto: AuditEventDto = AuditEvent::VaultUnlockFailed {
+            timestamp: ts,
+            attempt_count: 4,
+        }
+        .into();
+        assert!(matches!(dto.kind, AuditEventKindDto::VaultUnlockFailed));
+        assert_eq!(dto.timestamp, ts);
+        assert_eq!(dto.attempt_count, Some(4));
+    }
+
+    #[test]
+    fn filter_dto_defaults_to_everything() {
+        let f: AuditFilterDto = serde_json::from_str("{}").expect("parse");
+        assert!(f.kinds.is_none());
+    }
+}

--- a/src-tauri/src/dto/audit.rs
+++ b/src-tauri/src/dto/audit.rs
@@ -32,6 +32,19 @@ pub struct AuditFilterDto {
     pub kinds: Option<Vec<AuditEventKindDto>>,
 }
 
+/// IPC response from `get_audit_events`. Carries the list of events plus a
+/// session-wide `degraded` flag set by the backend whenever an audit
+/// `record` or `read` has failed internally. The frontend uses `degraded`
+/// to render a banner — without it, a soft failure would be visually
+/// indistinguishable from "no events yet" and a real audit-subsystem
+/// problem would never reach the user.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditEventsResponseDto {
+    pub events: Vec<AuditEventDto>,
+    pub degraded: bool,
+}
+
 impl From<AuditEvent> for AuditEventDto {
     fn from(event: AuditEvent) -> Self {
         match event {

--- a/src-tauri/src/dto/error.rs
+++ b/src-tauri/src/dto/error.rs
@@ -112,6 +112,9 @@ pub enum AppError {
 
     #[error("Backup failed for {path}: {reason}")]
     BackupFailed { path: String, reason: String },
+
+    #[error("Audit log read failed: {0}")]
+    AuditRead(String),
 }
 
 impl Serialize for AppError {

--- a/src-tauri/src/dto/mod.rs
+++ b/src-tauri/src/dto/mod.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+pub mod audit;
 pub mod database;
 pub mod entry;
 pub mod error;
 pub mod group;
 
+pub use audit::*;
 pub use database::*;
 pub use entry::*;
 pub use error::*;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,9 +13,9 @@ use commands::{
     copy_protected_field_to_clipboard, copy_text_to_clipboard, create_database, create_entry,
     create_group, create_manual_backup, delete_backup, delete_entry, delete_group, delete_tag,
     fetch_entry_favicon, generate_keyfile, generate_passphrase, generate_password,
-    get_app_preferences, get_custom_icons, get_database_config, get_database_info, get_entry,
-    get_entry_password, get_entry_protected_custom_field, get_group, get_group_entry_counts,
-    get_keyfile_for_database, get_recent_databases, get_recycle_bin_id,
+    get_app_preferences, get_audit_events, get_custom_icons, get_database_config,
+    get_database_info, get_entry, get_entry_password, get_entry_protected_custom_field, get_group,
+    get_group_entry_counts, get_keyfile_for_database, get_recent_databases, get_recycle_bin_id,
     get_window_content_protection_supported, has_session_key, inspect_database, list_backups,
     list_entries, list_groups, list_open_databases, lock_database, move_entry, move_group,
     open_database, open_database_with_keyfile, open_database_with_keyfile_only,
@@ -23,6 +23,8 @@ use commands::{
     restore_backup, save_database, set_entry_custom_icon, set_window_content_protected,
     store_session_key, unlock_database, update_app_preferences, update_entry, update_group,
 };
+use services::audit::key::FileBackedAuditKey;
+use services::audit::AuditService;
 use services::auto_lock::AutoLockService;
 use services::clipboard::ClipboardService;
 use services::kdbx::KdbxService;
@@ -87,6 +89,7 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             get_recycle_bin_id,
             generate_password,
             generate_passphrase,
+            get_audit_events,
             get_app_preferences,
             update_app_preferences,
             reset_app_preferences,
@@ -142,6 +145,15 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
 
     let auto_lock_service = AutoLockService::new();
     app.manage(Arc::new(auto_lock_service));
+
+    let data_dir = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| AppError::SecureStorage(e.to_string()))?;
+    let audit_root = data_dir.join("audit");
+    let key_source = Arc::new(FileBackedAuditKey::new(audit_root.join("key.bin")));
+    let audit_service = AuditService::new(audit_root, key_source);
+    app.manage(Arc::new(audit_service));
 
     Ok(())
 }

--- a/src-tauri/src/services/audit/crypto.rs
+++ b/src-tauri/src/services/audit/crypto.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+
+//! AEAD frame format for audit log entries.
+//!
+//! Each audit record is independently encrypted with XChaCha20-Poly1305 using
+//! a fresh random 24-byte nonce. The on-disk frame is `nonce || ciphertext`,
+//! base64-encoded so the log stays line-oriented JSONL.
+//!
+//! The 24-byte nonce makes random-per-record safe — at 192 bits, the birthday
+//! collision probability is negligible for any practical record count.
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use chacha20poly1305::aead::{Aead, KeyInit, OsRng};
+use chacha20poly1305::{AeadCore, XChaCha20Poly1305, XNonce};
+use thiserror::Error;
+
+pub const KEY_LEN: usize = 32;
+const NONCE_LEN: usize = 24;
+
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    #[error("invalid audit key length")]
+    InvalidKey,
+
+    #[error("frame too short")]
+    FrameTooShort,
+
+    #[error("frame base64-decode failed")]
+    Base64,
+
+    #[error("authentication failed (wrong key or tampered frame)")]
+    AuthFailed,
+}
+
+/// Encrypts a plaintext byte slice into a frame: `nonce || ciphertext+tag`.
+pub fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    let cipher = XChaCha20Poly1305::new_from_slice(key).map_err(|_| CryptoError::InvalidKey)?;
+    let nonce = XChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let mut ct = cipher
+        .encrypt(&nonce, plaintext)
+        .map_err(|_| CryptoError::AuthFailed)?;
+    let mut frame = Vec::with_capacity(NONCE_LEN + ct.len());
+    frame.extend_from_slice(nonce.as_slice());
+    frame.append(&mut ct);
+    Ok(frame)
+}
+
+/// Decrypts a frame produced by [`encrypt`] back to plaintext.
+pub fn decrypt(key: &[u8; KEY_LEN], frame: &[u8]) -> Result<Vec<u8>, CryptoError> {
+    if frame.len() < NONCE_LEN {
+        return Err(CryptoError::FrameTooShort);
+    }
+    let cipher = XChaCha20Poly1305::new_from_slice(key).map_err(|_| CryptoError::InvalidKey)?;
+    let (nonce_bytes, ciphertext) = frame.split_at(NONCE_LEN);
+    let nonce = XNonce::from_slice(nonce_bytes);
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| CryptoError::AuthFailed)
+}
+
+/// Encodes a binary frame as a base64 string suitable for JSONL.
+pub fn encode_frame(frame: &[u8]) -> String {
+    BASE64.encode(frame)
+}
+
+/// Decodes a base64-encoded frame string back to bytes.
+pub fn decode_frame(s: &str) -> Result<Vec<u8>, CryptoError> {
+    BASE64.decode(s.trim()).map_err(|_| CryptoError::Base64)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn test_key() -> [u8; KEY_LEN] {
+        let mut k = [0u8; KEY_LEN];
+        for (i, b) in k.iter_mut().enumerate() {
+            *b = u8::try_from(i & 0xff).unwrap();
+        }
+        k
+    }
+
+    #[test]
+    fn frame_round_trips() {
+        let key = test_key();
+        let pt = b"hello audit log";
+        let frame = encrypt(&key, pt).expect("encrypt");
+        let recovered = decrypt(&key, &frame).expect("decrypt");
+        assert_eq!(recovered, pt);
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        let key = test_key();
+        let mut frame = encrypt(&key, b"some plaintext").expect("encrypt");
+        // Flip a bit in the ciphertext (past the 24-byte nonce prefix).
+        let i = NONCE_LEN + 1;
+        frame[i] ^= 0x01;
+        assert!(matches!(
+            decrypt(&key, &frame),
+            Err(CryptoError::AuthFailed)
+        ));
+    }
+
+    #[test]
+    fn tampered_nonce_fails() {
+        let key = test_key();
+        let mut frame = encrypt(&key, b"some plaintext").expect("encrypt");
+        frame[0] ^= 0x01;
+        assert!(matches!(
+            decrypt(&key, &frame),
+            Err(CryptoError::AuthFailed)
+        ));
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let key = test_key();
+        let mut wrong = test_key();
+        wrong[0] ^= 0xff;
+        let frame = encrypt(&key, b"secret").expect("encrypt");
+        assert!(matches!(
+            decrypt(&wrong, &frame),
+            Err(CryptoError::AuthFailed)
+        ));
+    }
+
+    #[test]
+    fn nonces_differ_across_encryptions() {
+        let key = test_key();
+        let a = encrypt(&key, b"same plaintext").expect("encrypt");
+        let b = encrypt(&key, b"same plaintext").expect("encrypt");
+        assert_ne!(&a[..NONCE_LEN], &b[..NONCE_LEN]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn base64_round_trip() {
+        let key = test_key();
+        let frame = encrypt(&key, b"x").expect("encrypt");
+        let encoded = encode_frame(&frame);
+        let decoded = decode_frame(&encoded).expect("decode");
+        assert_eq!(decoded, frame);
+    }
+}

--- a/src-tauri/src/services/audit/format.rs
+++ b/src-tauri/src/services/audit/format.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+
+//! Serialize / parse audit events to the wire format used by the on-disk log
+//! (one JSON object per frame plaintext).
+//!
+//! Kept ignorant of crypto and I/O — this module decides only the shape of an
+//! `AuditEvent` and how it round-trips through bytes.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FormatError {
+    #[error("malformed audit event payload: {0}")]
+    Malformed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AuditEvent {
+    #[serde(rename = "vault.unlock_failed")]
+    VaultUnlockFailed {
+        timestamp: DateTime<Utc>,
+        attempt_count: u32,
+    },
+}
+
+impl AuditEvent {
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // serde_json::to_vec on a sound enum cannot fail; if it ever does, an
+        // empty buffer round-trips as a parse error rather than a panic.
+        serde_json::to_vec(self).unwrap_or_default()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, FormatError> {
+        serde_json::from_slice(bytes).map_err(|e| FormatError::Malformed(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn vault_unlock_failed_round_trips() {
+        let event = AuditEvent::VaultUnlockFailed {
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap(),
+            attempt_count: 3,
+        };
+
+        let bytes = event.to_bytes();
+        let parsed = AuditEvent::from_bytes(&bytes).expect("parse");
+
+        assert_eq!(parsed, event);
+    }
+
+    #[test]
+    fn malformed_input_is_rejected() {
+        let bogus = b"not-json";
+        assert!(matches!(
+            AuditEvent::from_bytes(bogus),
+            Err(FormatError::Malformed(_))
+        ));
+    }
+}

--- a/src-tauri/src/services/audit/key.rs
+++ b/src-tauri/src/services/audit/key.rs
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+
+//! Source of the audit AEAD key.
+//!
+//! The audit subsystem treats the key as opaque material: it asks for it once
+//! per `AuditService` construction. Two backings exist:
+//!
+//! * [`InMemoryAuditKey`] — used in tests; generates a random key on first
+//!   use and caches it for the process lifetime.
+//! * [`FileBackedAuditKey`] — production backing for this tracer-bullet
+//!   slice. Stores the 32-byte key as `audit/key.bin` under the app's local
+//!   data dir so it survives restarts.
+//!
+//! Both implement [`AuditKey`] so the rest of the audit code is testable
+//! without touching the filesystem.
+
+use crate::services::audit::crypto::KEY_LEN;
+use rand::rand_core::TryRng;
+use rand::rngs::SysRng;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use thiserror::Error;
+use zeroize::Zeroizing;
+
+#[derive(Debug, Error)]
+pub enum KeyError {
+    #[error("audit key source failed: {0}")]
+    Backend(String),
+}
+
+/// Source of the audit AEAD key. Implementations must return the same 32-byte
+/// key on every call within a process lifetime.
+pub trait AuditKey: Send + Sync {
+    fn get_or_create(&self) -> Result<[u8; KEY_LEN], KeyError>;
+}
+
+/// Process-local audit key. Generates a fresh random key on first call and
+/// returns the same bytes on every subsequent call.
+pub struct InMemoryAuditKey {
+    cached: Mutex<Option<[u8; KEY_LEN]>>,
+}
+
+impl InMemoryAuditKey {
+    pub fn new() -> Self {
+        Self {
+            cached: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for InMemoryAuditKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuditKey for InMemoryAuditKey {
+    fn get_or_create(&self) -> Result<[u8; KEY_LEN], KeyError> {
+        let mut guard = self
+            .cached
+            .lock()
+            .map_err(|_| KeyError::Backend("mutex poisoned".into()))?;
+        if let Some(k) = *guard {
+            return Ok(k);
+        }
+        let mut buf = Zeroizing::new([0u8; KEY_LEN]);
+        SysRng
+            .try_fill_bytes(&mut buf[..])
+            .map_err(|e| KeyError::Backend(e.to_string()))?;
+        *guard = Some(*buf);
+        Ok(*buf)
+    }
+}
+
+/// File-backed audit key used in production. Stores the 32 random bytes in a
+/// dedicated file under the audit subdir. On the first call generates a key
+/// and writes it; on subsequent calls — including those after process restart
+/// — reads the existing file and returns the same bytes.
+///
+/// The file is restricted to user-read/write on Unix; on Windows it relies on
+/// the user's home directory ACL.
+///
+/// NOTE: this is the tracer-bullet implementation. The ADR's long-term goal is
+/// to source the key from the OS keychain (Keychain / Credential Manager /
+/// Secret Service / Stronghold) so even read access to the filesystem alone
+/// does not yield the key. That work is tracked separately; the `AuditKey`
+/// trait keeps the swap local.
+pub struct FileBackedAuditKey {
+    path: PathBuf,
+    cached: Mutex<Option<[u8; KEY_LEN]>>,
+}
+
+impl FileBackedAuditKey {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cached: Mutex::new(None),
+        }
+    }
+}
+
+impl AuditKey for FileBackedAuditKey {
+    fn get_or_create(&self) -> Result<[u8; KEY_LEN], KeyError> {
+        let mut guard = self
+            .cached
+            .lock()
+            .map_err(|_| KeyError::Backend("mutex poisoned".into()))?;
+        if let Some(k) = *guard {
+            return Ok(k);
+        }
+
+        if let Ok(bytes) = fs::read(&self.path) {
+            if let Ok(arr) = <[u8; KEY_LEN]>::try_from(bytes.as_slice()) {
+                *guard = Some(arr);
+                return Ok(arr);
+            }
+            // Length mismatch — treat as missing and overwrite.
+        }
+
+        let mut buf = Zeroizing::new([0u8; KEY_LEN]);
+        SysRng
+            .try_fill_bytes(&mut buf[..])
+            .map_err(|e| KeyError::Backend(e.to_string()))?;
+
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| KeyError::Backend(e.to_string()))?;
+        }
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&self.path)
+            .map_err(|e| KeyError::Backend(e.to_string()))?;
+        f.write_all(&buf[..])
+            .map_err(|e| KeyError::Backend(e.to_string()))?;
+        f.sync_all().map_err(|e| KeyError::Backend(e.to_string()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = fs::set_permissions(&self.path, fs::Permissions::from_mode(0o600));
+        }
+
+        *guard = Some(*buf);
+        Ok(*buf)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn in_memory_key_returns_stable_value() {
+        let source = InMemoryAuditKey::new();
+        let a = source.get_or_create().expect("first");
+        let b = source.get_or_create().expect("second");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn in_memory_key_has_correct_length_and_entropy() {
+        let source = InMemoryAuditKey::new();
+        let k = source.get_or_create().expect("key");
+        assert_eq!(k.len(), KEY_LEN);
+        // Sanity: vanishingly unlikely to be all zeros.
+        assert!(k.iter().any(|&b| b != 0));
+    }
+
+    #[test]
+    fn file_backed_key_persists_across_instances() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("key.bin");
+
+        let first = FileBackedAuditKey::new(path.clone());
+        let a = first.get_or_create().expect("first");
+        drop(first);
+
+        // Simulate restart: brand new instance reads the persisted file.
+        let second = FileBackedAuditKey::new(path);
+        let b = second.get_or_create().expect("second");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn file_backed_key_creates_parent_directory() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("audit").join("key.bin");
+        let source = FileBackedAuditKey::new(path.clone());
+        let _ = source.get_or_create().expect("create");
+        assert!(path.exists());
+    }
+}

--- a/src-tauri/src/services/audit/key.rs
+++ b/src-tauri/src/services/audit/key.rs
@@ -22,6 +22,7 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use thiserror::Error;
+use uuid::Uuid;
 use zeroize::Zeroizing;
 
 #[derive(Debug, Error)]
@@ -125,20 +126,29 @@ impl AuditKey for FileBackedAuditKey {
             Err(e) => return Err(KeyError::Backend(e.to_string())),
         }
 
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).map_err(|e| KeyError::Backend(e.to_string()))?;
-        }
+        let parent = self
+            .path
+            .parent()
+            .ok_or_else(|| KeyError::Backend("audit key path has no parent directory".into()))?;
+        fs::create_dir_all(parent).map_err(|e| KeyError::Backend(e.to_string()))?;
 
         let mut buf = Zeroizing::new([0u8; KEY_LEN]);
         SysRng
             .try_fill_bytes(&mut buf[..])
             .map_err(|e| KeyError::Backend(e.to_string()))?;
 
-        // Atomic create-and-restrict-mode in one syscall: `create_new`
-        // closes the TOCTOU window where a concurrent process could see a
-        // half-written or default-permissioned file, and on Unix the
-        // restrictive mode is applied at file creation (subject to umask
-        // intersection, which can only further restrict the mode).
+        // Atomic publish: write the key into a uniquely-named temp file
+        // in the destination directory, fsync it, then hard-link it to
+        // the real path. `hard_link` is metadata-only and fails with
+        // `AlreadyExists` if the destination exists, so it functions as
+        // an atomic noclobber claim — and because the source bytes are
+        // fully written and fsync'd before the link, any concurrent
+        // reader that sees the destination sees complete content (no
+        // 0-byte race window). The temp file is created `create_new`
+        // with mode 0o600 on Unix so the restrictive permission is
+        // applied at file creation, not via a separate chmod.
+        let tmp_path = parent.join(format!(".audit-key.tmp.{}", Uuid::new_v4()));
+
         let mut open_opts = fs::OpenOptions::new();
         open_opts.write(true).create_new(true);
         #[cfg(unix)]
@@ -147,13 +157,37 @@ impl AuditKey for FileBackedAuditKey {
             open_opts.mode(0o600);
         }
 
-        let mut f = match open_opts.open(&self.path) {
-            Ok(f) => f,
+        let write_result = (|| -> Result<(), KeyError> {
+            let mut f = open_opts
+                .open(&tmp_path)
+                .map_err(|e| KeyError::Backend(e.to_string()))?;
+            f.write_all(&buf[..])
+                .map_err(|e| KeyError::Backend(e.to_string()))?;
+            f.sync_all().map_err(|e| KeyError::Backend(e.to_string()))?;
+            Ok(())
+        })();
+        if let Err(e) = write_result {
+            let _ = fs::remove_file(&tmp_path);
+            return Err(e);
+        }
+
+        let link_result = fs::hard_link(&tmp_path, &self.path);
+        // The temp inode is unlinked either way: on a win, the dest is
+        // now a separate name pointing at the same inode and the temp
+        // name is no longer needed; on a loss, the temp file is just
+        // litter.
+        let _ = fs::remove_file(&tmp_path);
+
+        match link_result {
+            Ok(()) => {
+                *guard = Some(*buf);
+                Ok(*buf)
+            }
             Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
                 // Lost a race with a concurrent creator. Read what they
                 // wrote and adopt their key — never overwrite, never
                 // rotate.
-                return match read_key_file(&self.path) {
+                match read_key_file(&self.path) {
                     Ok(Some(arr)) => {
                         *guard = Some(arr);
                         Ok(arr)
@@ -162,16 +196,10 @@ impl AuditKey for FileBackedAuditKey {
                         "audit key file appeared then vanished during creation race".into(),
                     )),
                     Err(e) => Err(KeyError::Backend(e.to_string())),
-                };
+                }
             }
-            Err(e) => return Err(KeyError::Backend(e.to_string())),
-        };
-        f.write_all(&buf[..])
-            .map_err(|e| KeyError::Backend(e.to_string()))?;
-        f.sync_all().map_err(|e| KeyError::Backend(e.to_string()))?;
-
-        *guard = Some(*buf);
-        Ok(*buf)
+            Err(e) => Err(KeyError::Backend(e.to_string())),
+        }
     }
 }
 
@@ -300,7 +328,10 @@ mod tests {
             }));
         }
 
-        let keys: Vec<[u8; KEY_LEN]> = handles.into_iter().map(|h| h.join().expect("join")).collect();
+        let keys: Vec<[u8; KEY_LEN]> = handles
+            .into_iter()
+            .map(|h| h.join().expect("join"))
+            .collect();
         let first = keys[0];
         for k in &keys[1..] {
             assert_eq!(*k, first, "concurrent creators diverged on the audit key");

--- a/src-tauri/src/services/audit/key.rs
+++ b/src-tauri/src/services/audit/key.rs
@@ -18,8 +18,8 @@ use crate::services::audit::crypto::KEY_LEN;
 use rand::rand_core::TryRng;
 use rand::rngs::SysRng;
 use std::fs;
-use std::io::Write;
-use std::path::PathBuf;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use thiserror::Error;
 use zeroize::Zeroizing;
@@ -111,12 +111,22 @@ impl AuditKey for FileBackedAuditKey {
             return Ok(k);
         }
 
-        if let Ok(bytes) = fs::read(&self.path) {
-            if let Ok(arr) = <[u8; KEY_LEN]>::try_from(bytes.as_slice()) {
+        // Read path: only `NotFound` means "create new". Any other error
+        // (`PermissionDenied`, transient I/O, …) propagates instead of
+        // silently rotating the key and orphaning the existing audit log.
+        // A malformed file (wrong length) is also a hard error — silently
+        // overwriting it would lose history just as decisively as rotation.
+        match read_key_file(&self.path) {
+            Ok(Some(arr)) => {
                 *guard = Some(arr);
                 return Ok(arr);
             }
-            // Length mismatch — treat as missing and overwrite.
+            Ok(None) => {} // file genuinely missing — fall through to create
+            Err(e) => return Err(KeyError::Backend(e.to_string())),
+        }
+
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| KeyError::Backend(e.to_string()))?;
         }
 
         let mut buf = Zeroizing::new([0u8; KEY_LEN]);
@@ -124,27 +134,66 @@ impl AuditKey for FileBackedAuditKey {
             .try_fill_bytes(&mut buf[..])
             .map_err(|e| KeyError::Backend(e.to_string()))?;
 
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).map_err(|e| KeyError::Backend(e.to_string()))?;
+        // Atomic create-and-restrict-mode in one syscall: `create_new`
+        // closes the TOCTOU window where a concurrent process could see a
+        // half-written or default-permissioned file, and on Unix the
+        // restrictive mode is applied at file creation (subject to umask
+        // intersection, which can only further restrict the mode).
+        let mut open_opts = fs::OpenOptions::new();
+        open_opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            open_opts.mode(0o600);
         }
-        let mut f = fs::OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(&self.path)
-            .map_err(|e| KeyError::Backend(e.to_string()))?;
+
+        let mut f = match open_opts.open(&self.path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                // Lost a race with a concurrent creator. Read what they
+                // wrote and adopt their key — never overwrite, never
+                // rotate.
+                return match read_key_file(&self.path) {
+                    Ok(Some(arr)) => {
+                        *guard = Some(arr);
+                        Ok(arr)
+                    }
+                    Ok(None) => Err(KeyError::Backend(
+                        "audit key file appeared then vanished during creation race".into(),
+                    )),
+                    Err(e) => Err(KeyError::Backend(e.to_string())),
+                };
+            }
+            Err(e) => return Err(KeyError::Backend(e.to_string())),
+        };
         f.write_all(&buf[..])
             .map_err(|e| KeyError::Backend(e.to_string()))?;
         f.sync_all().map_err(|e| KeyError::Backend(e.to_string()))?;
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = fs::set_permissions(&self.path, fs::Permissions::from_mode(0o600));
-        }
-
         *guard = Some(*buf);
         Ok(*buf)
+    }
+}
+
+/// Reads the audit key from `path`. Returns `Ok(None)` only when the file
+/// genuinely does not exist; any other I/O error propagates so the caller
+/// does not mistake a transient read failure for "first run, create new key"
+/// and rotate the user's audit history into oblivion.
+fn read_key_file(path: &Path) -> io::Result<Option<[u8; KEY_LEN]>> {
+    match fs::read(path) {
+        Ok(bytes) => match <[u8; KEY_LEN]>::try_from(bytes.as_slice()) {
+            Ok(arr) => Ok(Some(arr)),
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "audit key file at {} is {} bytes; expected {KEY_LEN}",
+                    path.display(),
+                    bytes.len()
+                ),
+            )),
+        },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
     }
 }
 
@@ -193,5 +242,89 @@ mod tests {
         let source = FileBackedAuditKey::new(path.clone());
         let _ = source.get_or_create().expect("create");
         assert!(path.exists());
+    }
+
+    /// Read errors other than `NotFound` must NOT rotate the key. Stage a
+    /// directory at the key path so `fs::read` returns a non-`NotFound`
+    /// error; the call must fail rather than silently regenerating.
+    #[test]
+    fn non_not_found_read_error_propagates_instead_of_rotating() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("key.bin");
+        // Stage a directory where the file should be: `fs::read` returns
+        // `IsADirectory` / `Other`, never `NotFound`.
+        fs::create_dir(&path).expect("stage dir");
+
+        let source = FileBackedAuditKey::new(path);
+        assert!(matches!(source.get_or_create(), Err(KeyError::Backend(_))));
+    }
+
+    /// A wrong-length key file is a hard error, never a silent overwrite —
+    /// the user's existing audit log would otherwise become permanently
+    /// unreadable on the next process start.
+    #[test]
+    fn malformed_key_file_propagates_instead_of_rotating() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("key.bin");
+        fs::write(&path, b"not 32 bytes").expect("stage malformed key");
+
+        let source = FileBackedAuditKey::new(path);
+        assert!(matches!(source.get_or_create(), Err(KeyError::Backend(_))));
+    }
+
+    /// Concurrent creators must converge on the same key. Spawn several
+    /// threads, each with its own `FileBackedAuditKey` instance pointing
+    /// at the same path so the per-instance Mutex cannot serialise them,
+    /// then assert every returned key matches.
+    #[test]
+    fn concurrent_creators_converge_on_one_key() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("key.bin");
+
+        let thread_count = 8;
+        let barrier = std::sync::Arc::new(Barrier::new(thread_count));
+
+        let mut handles = Vec::with_capacity(thread_count);
+        for _ in 0..thread_count {
+            let path = path.clone();
+            let barrier = std::sync::Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                let source = FileBackedAuditKey::new(path);
+                // Release all threads at roughly the same instant so at
+                // least some of them hit the `create_new` race window.
+                barrier.wait();
+                source.get_or_create().expect("get_or_create")
+            }));
+        }
+
+        let keys: Vec<[u8; KEY_LEN]> = handles.into_iter().map(|h| h.join().expect("join")).collect();
+        let first = keys[0];
+        for k in &keys[1..] {
+            assert_eq!(*k, first, "concurrent creators diverged on the audit key");
+        }
+
+        // On-disk state must match the in-memory consensus.
+        let on_disk = fs::read(&path).expect("read");
+        assert_eq!(on_disk.as_slice(), first.as_slice());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn newly_created_key_file_is_owner_read_write_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("key.bin");
+        let source = FileBackedAuditKey::new(path.clone());
+        let _ = source.get_or_create().expect("create");
+
+        let mode = fs::metadata(&path).expect("metadata").permissions().mode() & 0o777;
+        // The umask can only further restrict bits we requested; 0o600 is
+        // already the most-restrictive practical setting, so equality holds
+        // on every realistic CI host.
+        assert_eq!(mode, 0o600, "audit key file should be 0o600, was {mode:o}");
     }
 }

--- a/src-tauri/src/services/audit/mod.rs
+++ b/src-tauri/src/services/audit/mod.rs
@@ -1,0 +1,9 @@
+pub mod crypto;
+pub mod format;
+pub mod key;
+pub mod retention;
+pub mod service;
+pub mod storage;
+pub mod vault_id;
+
+pub use service::{AuditFilter, AuditService};

--- a/src-tauri/src/services/audit/retention.rs
+++ b/src-tauri/src/services/audit/retention.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+
+//! Retention policy for the audit log.
+//!
+//! Stub for the tracer-bullet slice. The real age-based + size-cap policy
+//! lands in a follow-up issue; for now [`apply_retention`] is a no-op so
+//! `AuditService::record` can call it without conditionals.
+
+use std::path::Path;
+
+/// Applies retention to the audit log file at `_path`. No-op until the
+/// follow-up implementation lands.
+pub fn apply_retention(_path: &Path) {
+    // intentionally empty
+}

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -89,14 +89,17 @@ impl AuditService {
     }
 
     /// Returns every recorded event for the Vault at `vault_path` that
-    /// matches `_filter`. Frames that fail to decrypt or parse are skipped so
-    /// one corrupt record cannot hide the rest.
+    /// matches `_filter`. Frames that fail to decrypt or parse are skipped
+    /// so one corrupt record cannot hide the rest — but skipping is no
+    /// longer silent: any malformed-base64 lines from storage or any
+    /// frames that fail AEAD auth / JSON parse flip the session-wide
+    /// `degraded` flag so the UI banner appears.
     ///
-    /// Hard failures (key source unavailable, log file unreadable) bubble up
-    /// as [`AuditReadError`] and also flip the session-wide `degraded` flag.
-    /// This is intentional asymmetry with [`AuditService::record`]: read is
-    /// called from a Settings panel where a swallowed error would silently
-    /// look identical to "no events yet" and hide a real problem.
+    /// Hard failures (key source unavailable, log file unreadable) bubble
+    /// up as [`AuditReadError`] and also flip `degraded`. This is the
+    /// intentional asymmetry with [`AuditService::record`]: read is called
+    /// from a Settings panel where a swallowed error would silently look
+    /// identical to "no events yet" and hide a real problem.
     pub fn read(
         &self,
         vault_path: &Path,
@@ -107,14 +110,26 @@ impl AuditService {
             AuditReadError::Key(e.to_string())
         })?;
         let log = AuditLogFile::new(self.log_path_for(vault_path));
-        let frames = log.read_all().map_err(|e| {
+        let outcome = log.read_all().map_err(|e| {
             self.degraded.store(true, Ordering::SeqCst);
             AuditReadError::Storage(e.to_string())
         })?;
-        Ok(frames
-            .iter()
-            .filter_map(|frame| decrypt_and_parse(&key, frame))
-            .collect())
+
+        let mut events = Vec::with_capacity(outcome.frames.len());
+        let mut undecryptable_frames: usize = 0;
+        for frame in &outcome.frames {
+            if let Some(event) = decrypt_and_parse(&key, frame) {
+                events.push(event);
+            } else {
+                undecryptable_frames = undecryptable_frames.saturating_add(1);
+            }
+        }
+
+        if outcome.malformed_lines > 0 || undecryptable_frames > 0 {
+            self.degraded.store(true, Ordering::SeqCst);
+        }
+
+        Ok(events)
     }
 
     fn log_path_for(&self, vault_path: &Path) -> PathBuf {
@@ -223,6 +238,56 @@ mod tests {
             .read(&vault, &AuditFilter::default())
             .expect("read")
             .is_empty());
+    }
+
+    /// A frame that AEAD-auth-fails (tampered, or written under a stale
+    /// key) must NOT be silently dropped — drop is fine for `DoS` safety,
+    /// but the user has to be told via the degraded banner that the log
+    /// has gaps.
+    #[test]
+    fn undecryptable_frame_in_log_flips_degraded_without_hiding_good_frames() {
+        let (service, _dir, vault) = fresh_service();
+
+        // Record one valid event.
+        service.record(&vault, &unlock_failed_event(1));
+        assert!(!service.is_degraded());
+
+        // Append a frame that won't decrypt — base64 of plain ASCII so
+        // storage decodes it cleanly but the AEAD check fails.
+        let log_path = service.log_path_for(&vault);
+        let log = AuditLogFile::new(log_path);
+        log.append(b"bogus-non-aead-bytes").expect("append junk");
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1, "the good event must still surface");
+        assert!(
+            service.is_degraded(),
+            "an undecryptable frame must flip degraded"
+        );
+    }
+
+    /// A non-base64 line in the log file flips degraded for the same
+    /// reason: storage continues (`DoS` safety) but the caller is told.
+    #[test]
+    fn malformed_base64_line_in_log_flips_degraded() {
+        use std::io::Write;
+
+        let (service, _dir, vault) = fresh_service();
+
+        service.record(&vault, &unlock_failed_event(1));
+
+        // Splice a raw non-base64 line into the log file.
+        let log_path = service.log_path_for(&vault);
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .expect("open log for splice");
+        f.write_all(b"!!!not-base64!!!\n").expect("splice");
+        drop(f);
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1);
+        assert!(service.is_degraded());
     }
 
     /// A non-NotFound storage error must NOT be reported back as "no events

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -22,6 +22,19 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use thiserror::Error;
+
+/// Errors surfaced from [`AuditService::read`]. Distinct from the
+/// internally-swallowed errors of [`AuditService::record`]: read is called
+/// from the Settings → Audit Log panel, where "failed to load" is a real
+/// state the UI must render differently from "no events yet".
+#[derive(Debug, Error)]
+pub enum AuditReadError {
+    #[error("audit key unavailable: {0}")]
+    Key(String),
+    #[error("audit log read failed: {0}")]
+    Storage(String),
+}
 
 /// Permissive filter applied by [`AuditService::read`]. Shape is in place so
 /// future issues can plug in `kinds` / time-range filtering without changing
@@ -78,20 +91,30 @@ impl AuditService {
     /// Returns every recorded event for the Vault at `vault_path` that
     /// matches `_filter`. Frames that fail to decrypt or parse are skipped so
     /// one corrupt record cannot hide the rest.
-    pub fn read(&self, vault_path: &Path, _filter: &AuditFilter) -> Vec<AuditEvent> {
-        let Ok(key) = self.key_source.get_or_create() else {
+    ///
+    /// Hard failures (key source unavailable, log file unreadable) bubble up
+    /// as [`AuditReadError`] and also flip the session-wide `degraded` flag.
+    /// This is intentional asymmetry with [`AuditService::record`]: read is
+    /// called from a Settings panel where a swallowed error would silently
+    /// look identical to "no events yet" and hide a real problem.
+    pub fn read(
+        &self,
+        vault_path: &Path,
+        _filter: &AuditFilter,
+    ) -> Result<Vec<AuditEvent>, AuditReadError> {
+        let key = self.key_source.get_or_create().map_err(|e| {
             self.degraded.store(true, Ordering::SeqCst);
-            return Vec::new();
-        };
+            AuditReadError::Key(e.to_string())
+        })?;
         let log = AuditLogFile::new(self.log_path_for(vault_path));
-        let Ok(frames) = log.read_all() else {
+        let frames = log.read_all().map_err(|e| {
             self.degraded.store(true, Ordering::SeqCst);
-            return Vec::new();
-        };
-        frames
+            AuditReadError::Storage(e.to_string())
+        })?;
+        Ok(frames
             .iter()
             .filter_map(|frame| decrypt_and_parse(&key, frame))
-            .collect()
+            .collect())
     }
 
     fn log_path_for(&self, vault_path: &Path) -> PathBuf {
@@ -169,7 +192,7 @@ mod tests {
         let (service, _dir, vault) = fresh_service();
 
         service.record(&vault, &unlock_failed_event(1));
-        let events = service.read(&vault, &AuditFilter::default());
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0], unlock_failed_event(1));
@@ -184,7 +207,7 @@ mod tests {
             service.record(&vault, &unlock_failed_event(count));
         }
 
-        let events = service.read(&vault, &AuditFilter::default());
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
         assert_eq!(events.len(), 3);
         for (i, evt) in events.iter().enumerate() {
             #[allow(clippy::cast_possible_truncation)]
@@ -196,7 +219,37 @@ mod tests {
     #[test]
     fn read_returns_empty_for_vault_with_no_events() {
         let (service, _dir, vault) = fresh_service();
-        assert!(service.read(&vault, &AuditFilter::default()).is_empty());
+        assert!(service
+            .read(&vault, &AuditFilter::default())
+            .expect("read")
+            .is_empty());
+    }
+
+    /// A non-NotFound storage error must NOT be reported back as "no events
+    /// yet" — that would mean a real subsystem failure looks identical to
+    /// the empty state in the Settings panel. Stage a directory at the
+    /// per-Vault log path so `fs::read` fails with `IsADirectory` /
+    /// non-NotFound; `read` must return an error AND flip `degraded`.
+    #[test]
+    fn hard_read_failure_surfaces_as_error_and_flags_degraded() {
+        use crate::services::audit::vault_id::hash_vault_path;
+
+        let dir = tempdir().expect("tempdir");
+        let base_dir = dir.path().join("audit");
+        std::fs::create_dir_all(&base_dir).expect("base dir");
+        let vault = dir.path().join("vault.kdbx");
+        std::fs::write(&vault, b"x").expect("write vault");
+
+        // Pre-compute the expected log file path and stage a directory
+        // there so the storage read trips a non-NotFound error.
+        let log_path = base_dir.join(format!("{}.jsonl", hash_vault_path(&vault)));
+        std::fs::create_dir(&log_path).expect("stage dir at log path");
+
+        let service = AuditService::new(base_dir, Arc::new(InMemoryAuditKey::new()));
+
+        let result = service.read(&vault, &AuditFilter::default());
+        assert!(matches!(result, Err(AuditReadError::Storage(_))));
+        assert!(service.is_degraded());
     }
 
     #[test]
@@ -207,7 +260,7 @@ mod tests {
         service.record_vault_unlock_failed(&vault);
         service.record_vault_unlock_failed(&vault);
 
-        let events = service.read(&vault, &AuditFilter::default());
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
         let counts: Vec<u32> = events
             .iter()
             .map(|e| match e {
@@ -226,7 +279,7 @@ mod tests {
         service.reset_unlock_attempts(&vault);
         service.record_vault_unlock_failed(&vault);
 
-        let events = service.read(&vault, &AuditFilter::default());
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
         let counts: Vec<u32> = events
             .iter()
             .map(|e| match e {
@@ -250,8 +303,12 @@ mod tests {
         service.record_vault_unlock_failed(&vault_a);
         service.record_vault_unlock_failed(&vault_b);
 
-        let a_events = service.read(&vault_a, &AuditFilter::default());
-        let b_events = service.read(&vault_b, &AuditFilter::default());
+        let a_events = service
+            .read(&vault_a, &AuditFilter::default())
+            .expect("read a");
+        let b_events = service
+            .read(&vault_b, &AuditFilter::default())
+            .expect("read b");
         let a_counts: Vec<u32> = a_events
             .iter()
             .map(|e| match e {

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: MIT
+
+//! Composing facade for the audit subsystem.
+//!
+//! Wires the five deep modules (`format`, `crypto`, `storage`, `key`,
+//! `vault_id`) plus the retention stub into the public surface used by the
+//! rest of the app:
+//!
+//! * [`AuditService::record`] — append an event. Infallible by contract:
+//!   internal errors are swallowed and flip a `degraded` flag so a broken
+//!   audit log cannot become a `DoS` vector against the user's own Vault flows.
+//! * [`AuditService::read`] — list events for a Vault path.
+
+use crate::services::audit::crypto::{decrypt, encrypt, KEY_LEN};
+use crate::services::audit::format::AuditEvent;
+use crate::services::audit::key::AuditKey;
+use crate::services::audit::retention::apply_retention;
+use crate::services::audit::storage::AuditLogFile;
+use crate::services::audit::vault_id::hash_vault_path;
+use chrono::Utc;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Permissive filter applied by [`AuditService::read`]. Shape is in place so
+/// future issues can plug in `kinds` / time-range filtering without changing
+/// callers; today it returns everything.
+#[derive(Debug, Default, Clone)]
+pub struct AuditFilter {}
+
+pub struct AuditService {
+    base_dir: PathBuf,
+    key_source: Arc<dyn AuditKey>,
+    degraded: AtomicBool,
+    /// Per-Vault consecutive-failed-unlock counters, keyed by canonicalized
+    /// path. Lives in memory only — resets on process restart per the AC's
+    /// "per session" wording.
+    attempts: Mutex<HashMap<PathBuf, u32>>,
+}
+
+impl AuditService {
+    pub fn new(base_dir: PathBuf, key_source: Arc<dyn AuditKey>) -> Self {
+        Self {
+            base_dir,
+            key_source,
+            degraded: AtomicBool::new(false),
+            attempts: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Reports whether a previous `record` call failed internally. Surfaced
+    /// in Settings → Audit Log as a banner; the failed user action itself is
+    /// never affected.
+    pub fn is_degraded(&self) -> bool {
+        self.degraded.load(Ordering::SeqCst)
+    }
+
+    /// Appends `event` to the per-Vault audit log. Infallible by contract:
+    /// every failure path swallows the error and flips the `degraded` flag.
+    pub fn record(&self, vault_path: &Path, event: &AuditEvent) {
+        if let Err(()) = self.try_record(vault_path, event) {
+            self.degraded.store(true, Ordering::SeqCst);
+        }
+    }
+
+    fn try_record(&self, vault_path: &Path, event: &AuditEvent) -> Result<(), ()> {
+        let key = self.key_source.get_or_create().map_err(|_| ())?;
+        let plaintext = event.to_bytes();
+        let frame = encrypt(&key, &plaintext).map_err(|_| ())?;
+        let log_path = self.log_path_for(vault_path);
+        let log = AuditLogFile::new(log_path.clone());
+        log.append(&frame).map_err(|_| ())?;
+        apply_retention(&log_path);
+        Ok(())
+    }
+
+    /// Returns every recorded event for the Vault at `vault_path` that
+    /// matches `_filter`. Frames that fail to decrypt or parse are skipped so
+    /// one corrupt record cannot hide the rest.
+    pub fn read(&self, vault_path: &Path, _filter: &AuditFilter) -> Vec<AuditEvent> {
+        let Ok(key) = self.key_source.get_or_create() else {
+            self.degraded.store(true, Ordering::SeqCst);
+            return Vec::new();
+        };
+        let log = AuditLogFile::new(self.log_path_for(vault_path));
+        let Ok(frames) = log.read_all() else {
+            self.degraded.store(true, Ordering::SeqCst);
+            return Vec::new();
+        };
+        frames
+            .iter()
+            .filter_map(|frame| decrypt_and_parse(&key, frame))
+            .collect()
+    }
+
+    fn log_path_for(&self, vault_path: &Path) -> PathBuf {
+        let name = hash_vault_path(vault_path);
+        self.base_dir.join(format!("{name}.jsonl"))
+    }
+
+    /// Increments the per-Vault consecutive-failed-unlock counter and appends
+    /// one `vault.unlock_failed` event carrying the new count. Called from
+    /// the command layer whenever an open/unlock returns `InvalidPassword`.
+    pub fn record_vault_unlock_failed(&self, vault_path: &Path) {
+        let Ok(mut map) = self.attempts.lock() else {
+            self.degraded.store(true, Ordering::SeqCst);
+            return;
+        };
+        let entry = map.entry(attempts_key(vault_path)).or_insert(0);
+        *entry = entry.saturating_add(1);
+        let count = *entry;
+        drop(map);
+
+        let event = AuditEvent::VaultUnlockFailed {
+            timestamp: Utc::now(),
+            attempt_count: count,
+        };
+        self.record(vault_path, &event);
+    }
+
+    /// Resets the per-Vault failed-unlock counter — called on successful
+    /// open/unlock so the next failure starts the count back at 1.
+    pub fn reset_unlock_attempts(&self, vault_path: &Path) {
+        if let Ok(mut map) = self.attempts.lock() {
+            map.remove(&attempts_key(vault_path));
+        }
+    }
+}
+
+fn attempts_key(vault_path: &Path) -> PathBuf {
+    vault_path
+        .canonicalize()
+        .unwrap_or_else(|_| vault_path.to_path_buf())
+}
+
+fn decrypt_and_parse(key: &[u8; KEY_LEN], frame: &[u8]) -> Option<AuditEvent> {
+    let plaintext = decrypt(key, frame).ok()?;
+    AuditEvent::from_bytes(&plaintext).ok()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::services::audit::key::InMemoryAuditKey;
+    use chrono::{TimeZone, Utc};
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn unlock_failed_event(count: u32) -> AuditEvent {
+        AuditEvent::VaultUnlockFailed {
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap(),
+            attempt_count: count,
+        }
+    }
+
+    fn fresh_service() -> (AuditService, tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("vault.kdbx");
+        std::fs::write(&vault, b"x").expect("write vault");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+        (service, dir, vault)
+    }
+
+    #[test]
+    fn tracer_bullet_one_record_appears_in_read() {
+        let (service, _dir, vault) = fresh_service();
+
+        service.record(&vault, &unlock_failed_event(1));
+        let events = service.read(&vault, &AuditFilter::default());
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0], unlock_failed_event(1));
+        assert!(!service.is_degraded());
+    }
+
+    #[test]
+    fn multiple_records_returned_in_order() {
+        let (service, _dir, vault) = fresh_service();
+
+        for count in 1..=3 {
+            service.record(&vault, &unlock_failed_event(count));
+        }
+
+        let events = service.read(&vault, &AuditFilter::default());
+        assert_eq!(events.len(), 3);
+        for (i, evt) in events.iter().enumerate() {
+            #[allow(clippy::cast_possible_truncation)]
+            let want = unlock_failed_event(u32::try_from(i + 1).unwrap());
+            assert_eq!(evt, &want);
+        }
+    }
+
+    #[test]
+    fn read_returns_empty_for_vault_with_no_events() {
+        let (service, _dir, vault) = fresh_service();
+        assert!(service.read(&vault, &AuditFilter::default()).is_empty());
+    }
+
+    #[test]
+    fn consecutive_failed_unlocks_increment_attempt_count() {
+        let (service, _dir, vault) = fresh_service();
+
+        service.record_vault_unlock_failed(&vault);
+        service.record_vault_unlock_failed(&vault);
+        service.record_vault_unlock_failed(&vault);
+
+        let events = service.read(&vault, &AuditFilter::default());
+        let counts: Vec<u32> = events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::VaultUnlockFailed { attempt_count, .. } => *attempt_count,
+            })
+            .collect();
+        assert_eq!(counts, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn reset_starts_counter_from_one_again() {
+        let (service, _dir, vault) = fresh_service();
+
+        service.record_vault_unlock_failed(&vault);
+        service.record_vault_unlock_failed(&vault);
+        service.reset_unlock_attempts(&vault);
+        service.record_vault_unlock_failed(&vault);
+
+        let events = service.read(&vault, &AuditFilter::default());
+        let counts: Vec<u32> = events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::VaultUnlockFailed { attempt_count, .. } => *attempt_count,
+            })
+            .collect();
+        assert_eq!(counts, vec![1, 2, 1]);
+    }
+
+    #[test]
+    fn counters_are_per_vault() {
+        let dir = tempdir().expect("tempdir");
+        let vault_a = dir.path().join("a.kdbx");
+        let vault_b = dir.path().join("b.kdbx");
+        std::fs::write(&vault_a, b"a").expect("write a");
+        std::fs::write(&vault_b, b"b").expect("write b");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+
+        service.record_vault_unlock_failed(&vault_a);
+        service.record_vault_unlock_failed(&vault_a);
+        service.record_vault_unlock_failed(&vault_b);
+
+        let a_events = service.read(&vault_a, &AuditFilter::default());
+        let b_events = service.read(&vault_b, &AuditFilter::default());
+        let a_counts: Vec<u32> = a_events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::VaultUnlockFailed { attempt_count, .. } => *attempt_count,
+            })
+            .collect();
+        let b_counts: Vec<u32> = b_events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::VaultUnlockFailed { attempt_count, .. } => *attempt_count,
+            })
+            .collect();
+        assert_eq!(a_counts, vec![1, 2]);
+        assert_eq!(b_counts, vec![1]);
+    }
+
+    #[test]
+    fn record_against_unwritable_dir_does_not_panic_and_flags_degraded() {
+        // Point the base_dir at a path that cannot be created (a regular
+        // file masquerading as a directory). `record` must swallow the
+        // error and flip `degraded`.
+        let dir = tempdir().expect("tempdir");
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"x").expect("write blocker file");
+
+        let base_dir = blocker.join("audit"); // can't mkdir under a regular file
+        let service = AuditService::new(base_dir, Arc::new(InMemoryAuditKey::new()));
+
+        let vault = dir.path().join("vault.kdbx");
+        std::fs::write(&vault, b"x").expect("write vault");
+
+        service.record(&vault, &unlock_failed_event(1));
+        assert!(service.is_degraded());
+    }
+}

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -79,28 +79,45 @@ impl AuditLogFile {
         result.map_err(StorageError::from)
     }
 
-    /// Reads all frames in append order. Missing file returns an empty Vec.
-    /// Malformed lines are skipped so a single bad write does not poison reads
-    /// (the audit log must never become a `DoS` vector).
-    pub fn read_all(&self) -> Result<Vec<Vec<u8>>, StorageError> {
+    /// Reads all frames in append order. Missing file returns an empty
+    /// outcome. Lines that fail base64 decode are *counted* in
+    /// [`LogReadOutcome::malformed_lines`] rather than dropped silently:
+    /// the read continues past a bad line (the audit log must never become
+    /// a `DoS` vector), but the caller can now flip the session-wide
+    /// degraded indicator so the UI surfaces "some entries unreadable"
+    /// instead of pretending nothing was wrong.
+    pub fn read_all(&self) -> Result<LogReadOutcome, StorageError> {
         let file = match File::open(&self.path) {
             Ok(f) => f,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(LogReadOutcome::default());
+            }
             Err(e) => return Err(e.into()),
         };
         let reader = BufReader::new(file);
-        let mut frames = Vec::new();
+        let mut outcome = LogReadOutcome::default();
         for line in reader.lines() {
             let line = line?;
             if line.trim().is_empty() {
                 continue;
             }
-            if let Ok(frame) = decode_frame(&line) {
-                frames.push(frame);
+            match decode_frame(&line) {
+                Ok(frame) => outcome.frames.push(frame),
+                Err(_) => outcome.malformed_lines = outcome.malformed_lines.saturating_add(1),
             }
         }
-        Ok(frames)
+        Ok(outcome)
     }
+}
+
+/// Result of [`AuditLogFile::read_all`]. `frames` is in append order and
+/// excludes lines that could not be base64-decoded; `malformed_lines` is
+/// the count of those skipped lines so the caller can decide whether to
+/// flag the audit subsystem as degraded.
+#[derive(Debug, Default)]
+pub struct LogReadOutcome {
+    pub frames: Vec<Vec<u8>>,
+    pub malformed_lines: usize,
 }
 
 #[cfg(test)]
@@ -120,18 +137,48 @@ mod tests {
         log.append(b"second").expect("append second");
         log.append(b"third").expect("append third");
 
-        let frames = log.read_all().expect("read");
+        let outcome = log.read_all().expect("read");
         assert_eq!(
-            frames,
+            outcome.frames,
             vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
         );
+        assert_eq!(outcome.malformed_lines, 0);
     }
 
     #[test]
     fn missing_file_reads_as_empty() {
         let dir = tempdir().expect("tempdir");
         let log = AuditLogFile::new(dir.path().join("missing.jsonl"));
-        assert!(log.read_all().expect("read").is_empty());
+        let outcome = log.read_all().expect("read");
+        assert!(outcome.frames.is_empty());
+        assert_eq!(outcome.malformed_lines, 0);
+    }
+
+    /// A line that is not valid base64 is skipped (so one bad line does
+    /// not poison the rest of the log) but is *counted* so the caller can
+    /// flag the subsystem as degraded.
+    #[test]
+    fn malformed_lines_are_skipped_but_counted() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("v.jsonl");
+        let log = AuditLogFile::new(path.clone());
+
+        log.append(b"first").expect("append first");
+
+        // Splice in a line that is not base64-decodable — `!!!` is not
+        // in the standard base64 alphabet.
+        let mut f = OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("reopen for raw append");
+        f.write_all(b"!!!not-base64!!!\n").expect("write junk");
+        drop(f);
+
+        log.append(b"third").expect("append third");
+
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames, vec![b"first".to_vec(), b"third".to_vec()]);
+        assert_eq!(outcome.malformed_lines, 1);
     }
 
     #[test]
@@ -160,12 +207,13 @@ mod tests {
         }
 
         let log = AuditLogFile::new(path);
-        let frames = log.read_all().expect("read");
-        assert_eq!(frames.len(), thread_count * writers_per_thread);
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames.len(), thread_count * writers_per_thread);
+        assert_eq!(outcome.malformed_lines, 0);
 
         // Every frame must decode back to a well-formed "t<n>-i<m>" string —
         // a torn write would produce garbage that fails the format check.
-        for frame in &frames {
+        for frame in &outcome.frames {
             let s = std::str::from_utf8(frame).expect("utf8");
             assert!(s.starts_with('t'));
             assert!(s.contains("-i"));

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+
+//! Append-only on-disk JSONL store of encrypted audit frames.
+//!
+//! One file per Vault, filename derived from [`super::vault_id::hash_vault_path`].
+//! Each line is one base64-encoded XChaCha20-Poly1305 frame so appends are
+//! O(1) and frames are independently decryptable.
+//!
+//! Concurrency: each [`AuditLogFile`] owns a process-local mutex. Across
+//! processes (and across threads via separate `AuditLogFile` instances), an
+//! advisory `flock` on the underlying file serialises writers so a concurrent
+//! appender cannot corrupt an in-progress line.
+
+use crate::services::audit::crypto::{decode_frame, encode_frame};
+use fs4::fs_std::FileExt;
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum StorageError {
+    #[error("audit log I/O: {0}")]
+    Io(String),
+}
+
+impl From<std::io::Error> for StorageError {
+    fn from(value: std::io::Error) -> Self {
+        Self::Io(value.to_string())
+    }
+}
+
+/// A single per-Vault audit log file.
+pub struct AuditLogFile {
+    path: PathBuf,
+    write_lock: Mutex<()>,
+}
+
+impl AuditLogFile {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            write_lock: Mutex::new(()),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Appends a single encrypted frame as one base64 JSONL line. Takes the
+    /// intra-process mutex and an advisory exclusive lock on the file.
+    pub fn append(&self, frame: &[u8]) -> Result<(), StorageError> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|_| StorageError::Io("audit append mutex poisoned".into()))?;
+
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        FileExt::lock_exclusive(&file)?;
+
+        let line = encode_frame(frame);
+        let result = (|| -> std::io::Result<()> {
+            file.write_all(line.as_bytes())?;
+            file.write_all(b"\n")?;
+            file.sync_data()?;
+            Ok(())
+        })();
+
+        let _ = FileExt::unlock(&file);
+        result.map_err(StorageError::from)
+    }
+
+    /// Reads all frames in append order. Missing file returns an empty Vec.
+    /// Malformed lines are skipped so a single bad write does not poison reads
+    /// (the audit log must never become a `DoS` vector).
+    pub fn read_all(&self) -> Result<Vec<Vec<u8>>, StorageError> {
+        let file = match File::open(&self.path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
+        let reader = BufReader::new(file);
+        let mut frames = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(frame) = decode_frame(&line) {
+                frames.push(frame);
+            }
+        }
+        Ok(frames)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::thread;
+    use tempfile::tempdir;
+
+    #[test]
+    fn append_then_read_returns_frames_in_order() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("v.jsonl"));
+
+        log.append(b"first").expect("append first");
+        log.append(b"second").expect("append second");
+        log.append(b"third").expect("append third");
+
+        let frames = log.read_all().expect("read");
+        assert_eq!(
+            frames,
+            vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
+        );
+    }
+
+    #[test]
+    fn missing_file_reads_as_empty() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("missing.jsonl"));
+        assert!(log.read_all().expect("read").is_empty());
+    }
+
+    #[test]
+    fn concurrent_appenders_do_not_corrupt_lines() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("v.jsonl");
+        let writers_per_thread = 30usize;
+        let thread_count = 4usize;
+
+        let mut handles = Vec::new();
+        for tid in 0..thread_count {
+            let path = path.clone();
+            handles.push(thread::spawn(move || {
+                // Each thread uses its own AuditLogFile instance so the
+                // process-mutex is NOT shared — the advisory file lock is the
+                // only thing standing between them.
+                let log = Arc::new(AuditLogFile::new(path));
+                for i in 0..writers_per_thread {
+                    let payload = format!("t{tid}-i{i}");
+                    log.append(payload.as_bytes()).expect("append");
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("join");
+        }
+
+        let log = AuditLogFile::new(path);
+        let frames = log.read_all().expect("read");
+        assert_eq!(frames.len(), thread_count * writers_per_thread);
+
+        // Every frame must decode back to a well-formed "t<n>-i<m>" string —
+        // a torn write would produce garbage that fails the format check.
+        for frame in &frames {
+            let s = std::str::from_utf8(frame).expect("utf8");
+            assert!(s.starts_with('t'));
+            assert!(s.contains("-i"));
+        }
+    }
+}

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -86,6 +86,14 @@ impl AuditLogFile {
     /// a `DoS` vector), but the caller can now flip the session-wide
     /// degraded indicator so the UI surfaces "some entries unreadable"
     /// instead of pretending nothing was wrong.
+    ///
+    /// Takes a shared advisory lock for the duration of the scan so the
+    /// reader participates in the same locking protocol as
+    /// [`AuditLogFile::append`]. Advisory locks only hold if every
+    /// participant cooperates — a lock-free reader would observe partial
+    /// state during in-progress writes (and, crucially, during the
+    /// exclusive-lock-held rewrites that retention/compaction will
+    /// perform in a follow-up).
     pub fn read_all(&self) -> Result<LogReadOutcome, StorageError> {
         let file = match File::open(&self.path) {
             Ok(f) => f,
@@ -94,19 +102,28 @@ impl AuditLogFile {
             }
             Err(e) => return Err(e.into()),
         };
-        let reader = BufReader::new(file);
-        let mut outcome = LogReadOutcome::default();
-        for line in reader.lines() {
-            let line = line?;
-            if line.trim().is_empty() {
-                continue;
+        FileExt::lock_shared(&file)?;
+
+        let result = (|| -> Result<LogReadOutcome, StorageError> {
+            let reader = BufReader::new(&file);
+            let mut outcome = LogReadOutcome::default();
+            for line in reader.lines() {
+                let line = line?;
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match decode_frame(&line) {
+                    Ok(frame) => outcome.frames.push(frame),
+                    Err(_) => {
+                        outcome.malformed_lines = outcome.malformed_lines.saturating_add(1);
+                    }
+                }
             }
-            match decode_frame(&line) {
-                Ok(frame) => outcome.frames.push(frame),
-                Err(_) => outcome.malformed_lines = outcome.malformed_lines.saturating_add(1),
-            }
-        }
-        Ok(outcome)
+            Ok(outcome)
+        })();
+
+        let _ = FileExt::unlock(&file);
+        result
     }
 }
 
@@ -179,6 +196,57 @@ mod tests {
         let outcome = log.read_all().expect("read");
         assert_eq!(outcome.frames, vec![b"first".to_vec(), b"third".to_vec()]);
         assert_eq!(outcome.malformed_lines, 1);
+    }
+
+    /// `read_all` must participate in the advisory locking protocol —
+    /// otherwise a concurrent writer (or future retention rewriter) can
+    /// hold its exclusive lock and the lock-free reader will sail past it
+    /// and read partial state. Verify by holding an exclusive lock on a
+    /// separate handle and asserting the reader is gated on its release.
+    #[test]
+    fn read_all_blocks_while_exclusive_lock_is_held() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("v.jsonl");
+        let log = AuditLogFile::new(path.clone());
+        log.append(b"first").expect("append");
+
+        // Hold an exclusive lock from this thread via a separate handle.
+        // The reader thread should NOT be able to complete its read
+        // until the lock is released.
+        let blocker = OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .expect("open for lock");
+        FileExt::lock_exclusive(&blocker).expect("lock exclusive");
+
+        let (tx, rx) = mpsc::channel();
+        let reader_path = path.clone();
+        let reader = std::thread::spawn(move || {
+            let log = AuditLogFile::new(reader_path);
+            let outcome = log.read_all().expect("read");
+            tx.send(outcome).expect("send");
+        });
+
+        // While the exclusive lock is held, the reader must not deliver
+        // a result. recv_timeout of a generous interval should hit the
+        // deadline, not the message.
+        let early = rx.recv_timeout(Duration::from_millis(200));
+        assert!(
+            early.is_err(),
+            "reader returned while exclusive lock was held: {early:?}"
+        );
+
+        // Release the lock; the reader must now make progress quickly.
+        FileExt::unlock(&blocker).expect("unlock");
+        let outcome = rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("reader did not finish after lock release");
+        assert_eq!(outcome.frames, vec![b"first".to_vec()]);
+        assert_eq!(outcome.malformed_lines, 0);
+        reader.join().expect("reader join");
     }
 
     #[test]

--- a/src-tauri/src/services/audit/vault_id.rs
+++ b/src-tauri/src/services/audit/vault_id.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+
+//! Stable per-Vault identifier derived from the canonicalized filesystem path.
+//!
+//! Used as the on-disk filename for the per-Vault audit log so the directory
+//! layout doesn't leak which Vaults exist (the file name is a 64-char hex
+//! digest, not the readable path). Two paths that resolve to the same canonical
+//! file — symlink and target, `./foo.kdbx` and `/abs/foo.kdbx` — produce the
+//! same hash.
+
+use sha2::{Digest, Sha256};
+use std::fmt::Write;
+use std::path::Path;
+
+/// Hex-encoded SHA-256 of the canonicalized form of `path`, used as the
+/// per-Vault audit log filename stem.
+pub fn hash_vault_path(path: &Path) -> String {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.to_string_lossy().as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        // write! into a String cannot fail.
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn hash_is_stable_for_same_canonical_path() {
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("vault.kdbx");
+        fs::write(&target, b"x").expect("write");
+
+        let a = hash_vault_path(&target);
+        let b = hash_vault_path(&target);
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn symlink_hashes_to_same_value_as_target() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().expect("tempdir");
+        let target = dir.path().join("vault.kdbx");
+        fs::write(&target, b"x").expect("write");
+
+        let link = dir.path().join("link.kdbx");
+        symlink(&target, &link).expect("symlink");
+
+        let target_hash = hash_vault_path(&target);
+        let link_hash = hash_vault_path(&link);
+        assert_eq!(target_hash, link_hash);
+    }
+}

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+pub mod audit;
 pub mod auto_lock;
 pub mod clipboard;
 pub mod crypto;

--- a/src-tauri/tests/command_handlers_test.rs
+++ b/src-tauri/tests/command_handlers_test.rs
@@ -144,6 +144,7 @@ fn database_commands_handle_missing_database() {
         "password".into(),
         app.handle().clone(),
         app.state(),
+        app.state(),
     ))
     .expect_err("expected invalid path");
     assert!(matches!(err, AppError::InvalidPath(_)));
@@ -162,6 +163,7 @@ fn database_commands_handle_missing_database() {
         "missing.kdbx".to_string(),
         Some("password".into()),
         app.handle().clone(),
+        app.state(),
         app.state(),
     ))
     .expect_err("expected database not found");
@@ -391,6 +393,7 @@ fn database_commands_cover_success_paths() {
         keyfile_path_str.clone(),
         app.handle().clone(),
         app.state(),
+        app.state(),
     ))
     .expect("open database with keyfile");
 
@@ -417,6 +420,7 @@ fn database_commands_cover_success_paths() {
         key_only_path_str.clone(),
         keyfile_path_str.clone(),
         app.handle().clone(),
+        app.state(),
         app.state(),
     ))
     .expect("open with keyfile only");

--- a/src/components/settings/SettingsEditor.tsx
+++ b/src/components/settings/SettingsEditor.tsx
@@ -26,6 +26,7 @@ import {
 import { isColorPresetId } from "@/lib/theme-presets";
 import { AdvancedSettingsSection } from "@/components/settings/sections/AdvancedSettingsSection";
 import { AppearanceSettingsSection } from "@/components/settings/sections/AppearanceSettingsSection";
+import { AuditLogSection } from "@/components/settings/sections/AuditLogSection";
 import { BackupsListSection } from "@/components/settings/sections/BackupsListSection";
 import { BackupsSettingsSection } from "@/components/settings/sections/BackupsSettingsSection";
 import { BrowserIntegrationSettingsSection } from "@/components/settings/sections/BrowserIntegrationSettingsSection";
@@ -281,6 +282,7 @@ export function SettingsEditor({
       <AdvancedSettingsSection draft={draft} updateDraft={updateDraft} />
       <BackupsSettingsSection draft={draft} updateDraft={updateDraft} />
       <BackupsListSection dbId={dbId} backupsEnabled={draft.backups.enabled} />
+      <AuditLogSection dbId={dbId} />
       <DatabaseSettingsSection
         dbId={dbId}
         databaseConfig={databaseConfig}

--- a/src/components/settings/sections/AuditLogSection.tsx
+++ b/src/components/settings/sections/AuditLogSection.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { queryKeys } from "@/lib/query-keys";
 import { audit } from "@/lib/tauri";
-import type { AuditEvent } from "@/lib/types";
+import type { AuditEvent, AuditEventsResponse } from "@/lib/types";
 
 interface AuditLogSectionProps {
   dbId: string | null;
@@ -40,14 +40,18 @@ function AuditRow({ event }: Readonly<{ event: AuditEvent }>) {
   );
 }
 
+const EMPTY_RESPONSE: AuditEventsResponse = { events: [], degraded: false };
+
 export function AuditLogSection({ dbId }: Readonly<AuditLogSectionProps>) {
   const { t } = useTranslation();
 
-  const query = useQuery<AuditEvent[], Error>({
+  const query = useQuery<AuditEventsResponse, Error>({
     queryKey: queryKeys.audit.list(dbId ?? "none"),
-    queryFn: () => (dbId ? audit.list(dbId) : Promise.resolve([])),
+    queryFn: () => (dbId ? audit.list(dbId) : Promise.resolve(EMPTY_RESPONSE)),
     enabled: Boolean(dbId),
   });
+
+  const data = query.data ?? EMPTY_RESPONSE;
 
   return (
     <SettingsSection
@@ -65,14 +69,26 @@ export function AuditLogSection({ dbId }: Readonly<AuditLogSectionProps>) {
         <p className="text-sm text-destructive">
           {t("audit.loadError", { error: String(query.error) })}
         </p>
-      ) : (query.data ?? []).length === 0 ? (
-        <p className="text-sm text-muted-foreground">{t("audit.empty")}</p>
       ) : (
-        <ul className="flex flex-col gap-2">
-          {(query.data ?? []).map((event, index) => (
-            <AuditRow key={`${event.timestamp}-${index}`} event={event} />
-          ))}
-        </ul>
+        <>
+          {data.degraded ? (
+            <p
+              role="status"
+              className="rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-sm text-amber-900 dark:text-amber-200"
+            >
+              {t("audit.degradedWarning")}
+            </p>
+          ) : null}
+          {data.events.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{t("audit.empty")}</p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {data.events.map((event, index) => (
+                <AuditRow key={`${event.timestamp}-${index}`} event={event} />
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </SettingsSection>
   );

--- a/src/components/settings/sections/AuditLogSection.tsx
+++ b/src/components/settings/sections/AuditLogSection.tsx
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { queryKeys } from "@/lib/query-keys";
+import { audit } from "@/lib/tauri";
+import type { AuditEvent } from "@/lib/types";
+
+interface AuditLogSectionProps {
+  dbId: string | null;
+}
+
+function formatTimestamp(timestamp: string, locale: string): string {
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return timestamp;
+  return parsed.toLocaleString(locale, {
+    dateStyle: "medium",
+    timeStyle: "medium",
+  });
+}
+
+function AuditRow({ event }: Readonly<{ event: AuditEvent }>) {
+  const { t, i18n } = useTranslation();
+  // Today only `vaultUnlockFailed` exists; rendering is keyed on `kind` so
+  // future kinds can plug in without rearranging the row layout.
+  return (
+    <li
+      data-kind={event.kind}
+      className="flex flex-col gap-1 rounded-md border bg-card/50 p-3 text-sm md:flex-row md:items-center md:justify-between"
+    >
+      <span className="font-medium">{t(`audit.kind.${event.kind}`)}</span>
+      <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        {typeof event.attemptCount === "number" ? (
+          <span>{t("audit.attemptCount", { count: event.attemptCount })}</span>
+        ) : null}
+        <span>{formatTimestamp(event.timestamp, i18n.language)}</span>
+      </div>
+    </li>
+  );
+}
+
+export function AuditLogSection({ dbId }: Readonly<AuditLogSectionProps>) {
+  const { t } = useTranslation();
+
+  const query = useQuery<AuditEvent[], Error>({
+    queryKey: queryKeys.audit.list(dbId ?? "none"),
+    queryFn: () => (dbId ? audit.list(dbId) : Promise.resolve([])),
+    enabled: Boolean(dbId),
+  });
+
+  return (
+    <SettingsSection
+      id="audit-log"
+      title={t("audit.title")}
+      description={t("audit.description")}
+    >
+      {!dbId ? (
+        <p className="text-sm text-muted-foreground">
+          {t("audit.emptyNoVault")}
+        </p>
+      ) : query.isLoading ? (
+        <p className="text-sm text-muted-foreground">{t("common.loading")}</p>
+      ) : query.error ? (
+        <p className="text-sm text-destructive">
+          {t("audit.loadError", { error: String(query.error) })}
+        </p>
+      ) : (query.data ?? []).length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t("audit.empty")}</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {(query.data ?? []).map((event, index) => (
+            <AuditRow key={`${event.timestamp}-${index}`} event={event} />
+          ))}
+        </ul>
+      )}
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
@@ -47,7 +47,7 @@ describe("AuditLogSection", () => {
   });
 
   it("renders the empty state when the open vault has no events", async () => {
-    listMock.mockResolvedValueOnce([]);
+    listMock.mockResolvedValueOnce({ events: [], degraded: false });
 
     const Wrapper = createWrapper();
     render(
@@ -60,21 +60,26 @@ describe("AuditLogSection", () => {
       expect(listMock).toHaveBeenCalledWith("/tmp/vault.kdbx");
     });
     expect(await screen.findByText("audit.empty")).toBeInTheDocument();
+    // The degraded banner must NOT appear when degraded is false.
+    expect(screen.queryByText("audit.degradedWarning")).toBeNull();
   });
 
   it("renders one row per vault.unlock_failed event with kind and attempt count", async () => {
-    listMock.mockResolvedValueOnce([
-      {
-        kind: "vaultUnlockFailed",
-        timestamp: "2026-05-15T12:00:00.000Z",
-        attemptCount: 2,
-      },
-      {
-        kind: "vaultUnlockFailed",
-        timestamp: "2026-05-15T11:59:00.000Z",
-        attemptCount: 1,
-      },
-    ]);
+    listMock.mockResolvedValueOnce({
+      events: [
+        {
+          kind: "vaultUnlockFailed",
+          timestamp: "2026-05-15T12:00:00.000Z",
+          attemptCount: 2,
+        },
+        {
+          kind: "vaultUnlockFailed",
+          timestamp: "2026-05-15T11:59:00.000Z",
+          attemptCount: 1,
+        },
+      ],
+      degraded: false,
+    });
 
     const Wrapper = createWrapper();
     render(
@@ -93,6 +98,47 @@ describe("AuditLogSection", () => {
     expect(labels.length).toBe(2);
   });
 
+  it("renders the degraded banner above the empty state when degraded is true", async () => {
+    listMock.mockResolvedValueOnce({ events: [], degraded: true });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    expect(
+      await screen.findByText("audit.degradedWarning")
+    ).toBeInTheDocument();
+    expect(screen.getByText("audit.empty")).toBeInTheDocument();
+  });
+
+  it("renders the degraded banner alongside events when degraded is true", async () => {
+    listMock.mockResolvedValueOnce({
+      events: [
+        {
+          kind: "vaultUnlockFailed",
+          timestamp: "2026-05-15T12:00:00.000Z",
+          attemptCount: 1,
+        },
+      ],
+      degraded: true,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    expect(
+      await screen.findByText("audit.degradedWarning")
+    ).toBeInTheDocument();
+    expect((await screen.findAllByRole("listitem")).length).toBe(1);
+  });
+
   it("renders the loadError state when the backend fails", async () => {
     listMock.mockRejectedValueOnce(new Error("boom"));
 
@@ -104,5 +150,7 @@ describe("AuditLogSection", () => {
     );
 
     expect(await screen.findByText("audit.loadError")).toBeInTheDocument();
+    // No empty-state copy when the load itself failed — distinct UX state.
+    expect(screen.queryByText("audit.empty")).toBeNull();
   });
 });

--- a/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+const listMock = vi.fn();
+
+vi.mock("@/lib/tauri", () => ({
+  audit: {
+    list: (...args: unknown[]) => listMock(...args),
+  },
+}));
+
+import { AuditLogSection } from "@/components/settings/sections/AuditLogSection";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("AuditLogSection", () => {
+  beforeEach(() => {
+    listMock.mockReset();
+  });
+
+  it("renders a no-vault empty state and does not query when no vault is open", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId={null} />
+      </Wrapper>
+    );
+
+    expect(screen.getByText("audit.emptyNoVault")).toBeInTheDocument();
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the empty state when the open vault has no events", async () => {
+    listMock.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(listMock).toHaveBeenCalledWith("/tmp/vault.kdbx");
+    });
+    expect(await screen.findByText("audit.empty")).toBeInTheDocument();
+  });
+
+  it("renders one row per vault.unlock_failed event with kind and attempt count", async () => {
+    listMock.mockResolvedValueOnce([
+      {
+        kind: "vaultUnlockFailed",
+        timestamp: "2026-05-15T12:00:00.000Z",
+        attemptCount: 2,
+      },
+      {
+        kind: "vaultUnlockFailed",
+        timestamp: "2026-05-15T11:59:00.000Z",
+        attemptCount: 1,
+      },
+    ]);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    const rows = await screen.findAllByRole("listitem");
+    expect(rows.length).toBe(2);
+    rows.forEach((row) => {
+      expect(row.getAttribute("data-kind")).toBe("vaultUnlockFailed");
+    });
+    // i18n is mocked to echo keys; each row carries the kind label.
+    const labels = screen.getAllByText("audit.kind.vaultUnlockFailed");
+    expect(labels.length).toBe(2);
+  });
+
+  it("renders the loadError state when the backend fails", async () => {
+    listMock.mockRejectedValueOnce(new Error("boom"));
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    expect(await screen.findByText("audit.loadError")).toBeInTheDocument();
+  });
+});

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -27,6 +27,11 @@ export const queryKeys = {
     all: ["backups"] as const,
     list: (dbId: string) => [...queryKeys.backups.all, dbId, "list"] as const,
   },
+  audit: {
+    all: ["audit"] as const,
+    list: (vaultPath: string) =>
+      [...queryKeys.audit.all, vaultPath, "list"] as const,
+  },
   groups: {
     all: ["groups"] as const,
     list: (dbId: string, parentId?: string | null) =>

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { invoke } from "@tauri-apps/api/core";
 import {
+  audit,
   backups,
   database,
   entries,
@@ -320,6 +321,39 @@ describe("tauri wrappers validation", () => {
     expect(invoke).toHaveBeenCalledWith("create_manual_backup", {
       databasePath: dbPath,
     });
+  });
+
+  it("audit.list parses get_audit_events into typed events", async () => {
+    const payload = [
+      {
+        kind: "vaultUnlockFailed",
+        timestamp: "2026-05-15T12:00:00.000Z",
+        attemptCount: 2,
+      },
+      {
+        kind: "vaultUnlockFailed",
+        timestamp: "2026-05-15T11:59:00.000Z",
+        attemptCount: 1,
+      },
+    ];
+    vi.mocked(invoke).mockResolvedValueOnce(payload);
+
+    await expect(audit.list("/tmp/vault.kdbx")).resolves.toEqual(payload);
+    expect(invoke).toHaveBeenCalledWith("get_audit_events", {
+      vaultPath: "/tmp/vault.kdbx",
+      filter: null,
+    });
+  });
+
+  it("audit.list rejects payloads with an unknown kind", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([
+      {
+        kind: "vaultDeleted",
+        timestamp: "2026-05-15T12:00:00.000Z",
+        attemptCount: 1,
+      },
+    ]);
+    await expect(audit.list("/tmp/vault.kdbx")).rejects.toThrow();
   });
 
   it("invokes delete_backup with the supplied path", async () => {

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -323,19 +323,22 @@ describe("tauri wrappers validation", () => {
     });
   });
 
-  it("audit.list parses get_audit_events into typed events", async () => {
-    const payload = [
-      {
-        kind: "vaultUnlockFailed",
-        timestamp: "2026-05-15T12:00:00.000Z",
-        attemptCount: 2,
-      },
-      {
-        kind: "vaultUnlockFailed",
-        timestamp: "2026-05-15T11:59:00.000Z",
-        attemptCount: 1,
-      },
-    ];
+  it("audit.list parses get_audit_events into a typed response", async () => {
+    const payload = {
+      events: [
+        {
+          kind: "vaultUnlockFailed",
+          timestamp: "2026-05-15T12:00:00.000Z",
+          attemptCount: 2,
+        },
+        {
+          kind: "vaultUnlockFailed",
+          timestamp: "2026-05-15T11:59:00.000Z",
+          attemptCount: 1,
+        },
+      ],
+      degraded: false,
+    };
     vi.mocked(invoke).mockResolvedValueOnce(payload);
 
     await expect(audit.list("/tmp/vault.kdbx")).resolves.toEqual(payload);
@@ -345,14 +348,34 @@ describe("tauri wrappers validation", () => {
     });
   });
 
+  it("audit.list surfaces a degraded flag from the backend", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce({
+      events: [],
+      degraded: true,
+    });
+
+    await expect(audit.list("/tmp/vault.kdbx")).resolves.toEqual({
+      events: [],
+      degraded: true,
+    });
+  });
+
   it("audit.list rejects payloads with an unknown kind", async () => {
-    vi.mocked(invoke).mockResolvedValueOnce([
-      {
-        kind: "vaultDeleted",
-        timestamp: "2026-05-15T12:00:00.000Z",
-        attemptCount: 1,
-      },
-    ]);
+    vi.mocked(invoke).mockResolvedValueOnce({
+      events: [
+        {
+          kind: "vaultDeleted",
+          timestamp: "2026-05-15T12:00:00.000Z",
+          attemptCount: 1,
+        },
+      ],
+      degraded: false,
+    });
+    await expect(audit.list("/tmp/vault.kdbx")).rejects.toThrow();
+  });
+
+  it("audit.list rejects payloads missing the degraded flag", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce({ events: [] });
     await expect(audit.list("/tmp/vault.kdbx")).rejects.toThrow();
   });
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -4,7 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { z } from "zod/v4";
 import type {
   AppPreferences,
-  AuditEvent,
+  AuditEventsResponse,
   AuditFilter,
   BackupInfo,
   BackupListEntry,
@@ -27,7 +27,7 @@ import type {
 } from "./types";
 import {
   AppPreferencesSchema,
-  AuditEventSchema,
+  AuditEventsResponseSchema,
   BackupInfoSchema,
   BackupListEntrySchema,
   CreateEntryDataSchema,
@@ -651,15 +651,18 @@ export const backups = {
 
 export const audit = {
   /// Lists the audit events recorded on this device for the given Vault,
-  /// newest-first. `filter` is accepted but currently ignored on the backend
-  /// — wire shape is in place so a UI filter can be added without a command
-  /// rename.
-  async list(vaultPath: string, filter?: AuditFilter): Promise<AuditEvent[]> {
+  /// newest-first, plus a session-wide `degraded` flag. `filter` is
+  /// accepted but currently ignored on the backend — wire shape is in
+  /// place so a UI filter can be added without a command rename.
+  async list(
+    vaultPath: string,
+    filter?: AuditFilter
+  ): Promise<AuditEventsResponse> {
     const result = await invoke("get_audit_events", {
       vaultPath,
       filter: filter ?? null,
     });
-    return z.array(AuditEventSchema).parse(result);
+    return AuditEventsResponseSchema.parse(result);
   },
 };
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -4,6 +4,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { z } from "zod/v4";
 import type {
   AppPreferences,
+  AuditEvent,
+  AuditFilter,
   BackupInfo,
   BackupListEntry,
   CreateEntryData,
@@ -25,6 +27,7 @@ import type {
 } from "./types";
 import {
   AppPreferencesSchema,
+  AuditEventSchema,
   BackupInfoSchema,
   BackupListEntrySchema,
   CreateEntryDataSchema,
@@ -643,6 +646,20 @@ export const backups = {
   async restore(backupPath: string): Promise<void> {
     PathOnlySchema.parse({ path: backupPath });
     return invoke("restore_backup", { backupPath });
+  },
+};
+
+export const audit = {
+  /// Lists the audit events recorded on this device for the given Vault,
+  /// newest-first. `filter` is accepted but currently ignored on the backend
+  /// — wire shape is in place so a UI filter can be added without a command
+  /// rename.
+  async list(vaultPath: string, filter?: AuditFilter): Promise<AuditEvent[]> {
+    const result = await invoke("get_audit_events", {
+      vaultPath,
+      filter: filter ?? null,
+    });
+    return z.array(AuditEventSchema).parse(result);
   },
 };
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -331,6 +331,17 @@ export const AuditFilterSchema = z.object({
 });
 export type AuditFilter = z.infer<typeof AuditFilterSchema>;
 
+/// Response from the `get_audit_events` IPC. `degraded` is the
+/// session-wide flag set by the backend whenever an audit record or read
+/// has failed internally. The UI uses it to surface a "some history may
+/// be missing" banner so a soft failure is never visually identical to
+/// "no events yet".
+export const AuditEventsResponseSchema = z.object({
+  events: z.array(AuditEventSchema),
+  degraded: z.boolean(),
+});
+export type AuditEventsResponse = z.infer<typeof AuditEventsResponseSchema>;
+
 export const EntrySortFieldSchema = z.enum([
   "title",
   "username",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -313,6 +313,24 @@ export const BackupInfoSchema = z.object({
 });
 export type BackupInfo = z.infer<typeof BackupInfoSchema>;
 
+/// Audit log event — security-relevant action recorded on this device. Today
+/// only `vaultUnlockFailed` is emitted; the union shape is set up so future
+/// kinds can be added without changing call sites.
+export const AuditEventKindSchema = z.enum(["vaultUnlockFailed"]);
+export type AuditEventKind = z.infer<typeof AuditEventKindSchema>;
+
+export const AuditEventSchema = z.object({
+  kind: AuditEventKindSchema,
+  timestamp: z.string().min(1),
+  attemptCount: z.number().int().positive().nullable().optional(),
+});
+export type AuditEvent = z.infer<typeof AuditEventSchema>;
+
+export const AuditFilterSchema = z.object({
+  kinds: z.array(AuditEventKindSchema).optional(),
+});
+export type AuditFilter = z.infer<typeof AuditFilterSchema>;
+
 export const EntrySortFieldSchema = z.enum([
   "title",
   "username",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -24,6 +24,7 @@
     "empty": "No audit events for this vault yet.",
     "emptyNoVault": "Open a vault to see its audit log.",
     "loadError": "Failed to load audit events: {{error}}",
+    "degradedWarning": "The audit subsystem has reported one or more internal failures this session. Some events may be missing.",
     "attemptCount_one": "Attempt {{count}}",
     "attemptCount_other": "Attempt {{count}}",
     "kind": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -18,6 +18,18 @@
   "clipboard": {
     "countdown": "Clipboard clears in {{seconds}}s"
   },
+  "audit": {
+    "title": "Audit log",
+    "description": "Security-relevant events recorded on this device for the currently open vault.",
+    "empty": "No audit events for this vault yet.",
+    "emptyNoVault": "Open a vault to see its audit log.",
+    "loadError": "Failed to load audit events: {{error}}",
+    "attemptCount_one": "Attempt {{count}}",
+    "attemptCount_other": "Attempt {{count}}",
+    "kind": {
+      "vaultUnlockFailed": "Failed unlock attempt"
+    }
+  },
   "settings": {
     "title": "Settings",
     "description": "Application preferences and database configuration.",


### PR DESCRIPTION
## Summary

- Tracer-bullet vertical slice from PRD #215 / issue #216: a single Audit Event Kind (`vault.unlock_failed`) flows end-to-end from a failed unlock, through five deep backend modules + retention stub + composing `AuditService`, over a new IPC command, into a Settings → Audit Log panel.
- Introduces the `chacha20poly1305` and `fs4` crates (both MIT/Apache-2.0); `bun run licenses:rust` passes.
- ADR-0001 and the Audit section of `CONTEXT.md` already shipped on this branch via #225.

## What's in the slice

**Backend (`src-tauri/src/services/audit/`)** — each module has its own unit tests:

- `format` — `AuditEvent::VaultUnlockFailed { timestamp, attempt_count }` JSON round-trip + malformed-input rejection.
- `crypto` — XChaCha20-Poly1305 frame: round-trip, tampered ciphertext, tampered nonce, wrong key, and per-encryption nonce uniqueness.
- `storage` — append-only base64 JSONL with intra-process mutex + advisory `flock`; concurrency test against 4 threads × 30 appends asserts no torn lines.
- `key` — `AuditKey` trait; `InMemoryAuditKey` (tests) and `FileBackedAuditKey` (production, persists across restarts under app data dir).
- `vault_id` — stable SHA-256 of canonicalized path; symlink resolves to target's hash.
- `retention` — no-op stub for now; real policy lands in a follow-up.
- `service` — composes the above. `record()` is **infallible by contract**: every internal failure path swallows the error and flips an in-process `degraded` flag so a broken audit log can never become a DoS vector against the user's unlock.

**Wiring** — `commands/database.rs::record_open_outcome` records `vault.unlock_failed` on `AppError::InvalidPassword` and resets the per-Vault session counter on success. Applied uniformly to `open_database`, `open_database_with_keyfile`, `open_database_with_keyfile_only`, and `unlock_database`.

**IPC** — `dto/audit.rs` (`AuditEventDto`/`AuditEventKindDto`/`AuditFilterDto`, event kind serialized camelCase as `vaultUnlockFailed`); `commands/audit.rs::get_audit_events` accepts a filter but applies a permissive default for this slice.

**Frontend** — `lib/types.ts` zod schemas; `lib/tauri.ts::audit.list(vaultPath, filter)` wrapper; `components/settings/sections/AuditLogSection.tsx` rendered between Backups and Database in `SettingsEditor`; i18n keys under `audit.*` in `en/common.json` (other locales follow in #9).

## Deviation from the AC to flag

The issue says the AEAD key comes \"via the existing `secure_storage` service.\" That service is built around a single TTL'd Stronghold record and **wipes its snapshot file on every startup** — incompatible with the AC's \"persists across restarts.\" I shipped `FileBackedAuditKey` (32 random bytes at `audit/key.bin`, `0o600` on Unix) behind the `AuditKey` trait. A future change can swap to a real OS-keychain backing (e.g. `keyring` crate or a persistent Stronghold snapshot) without touching `AuditService` or its callers.

## Test plan

- [x] `cd src-tauri && cargo test` — 179 lib + integration tests pass (24 new audit tests)
- [x] `cd src-tauri && cargo clippy --all-targets` — clean
- [x] `cd src-tauri && cargo fmt --check` — clean
- [x] `bun run test` — 370 frontend tests pass (6 new: 2 IPC wrapper + 4 section)
- [x] `bun run check` — lint + prettier clean
- [x] `bun run licenses:rust` — `chacha20poly1305`, `fs4` both allowed
- [ ] Manual smoke: open a vault with the wrong password from the unlock screen, then open Settings → Audit Log; confirm a row with timestamp + attempt count appears, and confirm the unlock-failure UX is unaffected when the audit dir is read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)