### PR TITLE
feat(core,ui): audit settings with enabled toggle and retention days (#219)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::dto::error::AppError;
+use crate::services::audit::AuditService;
 use crate::services::kdbx::KdbxService;
 use crate::services::settings::SettingsService;
 use serde::{Deserialize, Serialize};
@@ -294,6 +295,76 @@ mod backup_settings_tests {
     }
 }
 
+/// Audit log preferences. `enabled` controls whether `AuditService::record`
+/// writes events; flipping it off does not delete the existing log file.
+/// `retention_days` bounds how long records are kept once the retention
+/// policy lands (#6); validated at the settings boundary to `1..=365`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct AuditSettings {
+    pub enabled: bool,
+    #[serde(default = "default_audit_retention_days")]
+    pub retention_days: u32,
+}
+
+pub(crate) const DEFAULT_AUDIT_RETENTION_DAYS: u32 = 90;
+
+fn default_audit_retention_days() -> u32 {
+    DEFAULT_AUDIT_RETENTION_DAYS
+}
+
+impl Default for AuditSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            retention_days: DEFAULT_AUDIT_RETENTION_DAYS,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod audit_settings_tests {
+    use super::AuditSettings;
+
+    #[test]
+    fn defaults_are_enabled_and_ninety_day_retention() {
+        // PRD AC: `enabled` defaults to true (opt-out, not opt-in) and
+        // retention defaults to 90 days. Hard-coding the assertion locks
+        // the documented user contract — changing it would be a behavior
+        // change that has to be considered, not a silent edit.
+        let s = AuditSettings::default();
+        assert!(s.enabled);
+        assert_eq!(s.retention_days, 90);
+    }
+
+    #[test]
+    fn absent_audit_section_deserializes_to_defaults() {
+        // Users with a settings.json written before this slice have no
+        // audit section. serde defaults must fill it in (AC: no migration
+        // required) so audit recording starts immediately, with the
+        // documented retention.
+        let from_empty: AuditSettings = serde_json::from_str("{}").expect("parse {}");
+        assert!(from_empty.enabled);
+        assert_eq!(from_empty.retention_days, 90);
+    }
+
+    #[test]
+    fn explicit_values_round_trip() {
+        let json = r#"{"enabled": false, "retentionDays": 30}"#;
+        let parsed: AuditSettings = serde_json::from_str(json).expect("parse explicit");
+        assert!(!parsed.enabled);
+        assert_eq!(parsed.retention_days, 30);
+
+        let serialized = serde_json::to_string(&parsed).expect("serialize");
+        assert!(
+            serialized.contains(r#""retentionDays":30"#),
+            "serialized json should carry the camelCase retentionDays field: {serialized}"
+        );
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
@@ -304,6 +375,7 @@ pub struct AppPreferences {
     pub browser_integration: BrowserIntegrationSettings,
     pub advanced: AdvancedSettings,
     pub backups: BackupSettings,
+    pub audit: AuditSettings,
 }
 
 /// Persisted shape written to `settings.json`. Combines the editable
@@ -329,9 +401,11 @@ pub async fn update_app_preferences(
     new_preferences: AppPreferences,
     settings_service: State<'_, Arc<SettingsService>>,
     kdbx_service: State<'_, Arc<KdbxService>>,
+    audit_service: State<'_, Arc<AuditService>>,
 ) -> Result<(), AppError> {
     settings_service.update_app_preferences(&new_preferences)?;
     kdbx_service.set_backup_settings(new_preferences.backups)?;
+    audit_service.set_enabled(new_preferences.audit.enabled);
     Ok(())
 }
 
@@ -339,9 +413,11 @@ pub async fn update_app_preferences(
 pub async fn reset_app_preferences(
     settings_service: State<'_, Arc<SettingsService>>,
     kdbx_service: State<'_, Arc<KdbxService>>,
+    audit_service: State<'_, Arc<AuditService>>,
 ) -> Result<AppPreferences, AppError> {
     let prefs = settings_service.reset_app_preferences()?;
     kdbx_service.set_backup_settings(prefs.backups.clone())?;
+    audit_service.set_enabled(prefs.audit.enabled);
     Ok(prefs)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,11 +142,10 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     // so we can apply it to AuditService below.
     let initial_audit_enabled = settings_service
         .get_app_preferences()
-        .map(|prefs| {
+        .map_or(true, |prefs| {
             let _ = kdbx_arc.set_backup_settings(prefs.backups);
             prefs.audit.enabled
-        })
-        .unwrap_or(true);
+        });
     app.manage(Arc::new(settings_service));
 
     let auto_lock_service = AutoLockService::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,10 +138,15 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
 
     let settings_service = SettingsService::new(app)?;
     // Push the persisted backup config into the KDBX service so the save
-    // hook honours it from first save onward.
-    if let Ok(prefs) = settings_service.get_app_preferences() {
-        let _ = kdbx_arc.set_backup_settings(prefs.backups);
-    }
+    // hook honours it from first save onward. Capture the audit gate too
+    // so we can apply it to AuditService below.
+    let initial_audit_enabled = settings_service
+        .get_app_preferences()
+        .map(|prefs| {
+            let _ = kdbx_arc.set_backup_settings(prefs.backups);
+            prefs.audit.enabled
+        })
+        .unwrap_or(true);
     app.manage(Arc::new(settings_service));
 
     let auto_lock_service = AutoLockService::new();
@@ -154,6 +159,7 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     let audit_root = data_dir.join("audit");
     let key_source = Arc::new(FileBackedAuditKey::new(audit_root.join("key.bin")));
     let audit_service = AuditService::new(audit_root, key_source);
+    audit_service.set_enabled(initial_audit_enabled);
     app.manage(Arc::new(audit_service));
 
     Ok(())

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -46,6 +46,12 @@ pub struct AuditService {
     base_dir: PathBuf,
     key_source: Arc<dyn AuditKey>,
     degraded: AtomicBool,
+    /// Master gate. When false, [`AuditService::record`] short-circuits
+    /// before any key fetch or file I/O; the existing log file is left
+    /// untouched so the user can re-enable later without losing history.
+    /// Pushed in from `update_app_preferences` and at startup; defaults
+    /// to true so a fresh `AuditService` records out of the box.
+    enabled: AtomicBool,
     /// Per-Vault consecutive-failed-unlock counters, keyed by canonicalized
     /// path. Lives in memory only — resets on process restart per the AC's
     /// "per session" wording.
@@ -58,8 +64,24 @@ impl AuditService {
             base_dir,
             key_source,
             degraded: AtomicBool::new(false),
+            enabled: AtomicBool::new(true),
             attempts: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Flips the master logging gate. Off => [`AuditService::record`]
+    /// short-circuits without touching the key source or storage. On =>
+    /// subsequent records append to the existing per-Vault file. Never
+    /// modifies the on-disk log — disabling preserves history.
+    pub fn set_enabled(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::SeqCst);
+    }
+
+    /// Reports the current state of the master logging gate. Used by the
+    /// Settings panel to render the toggle and by tests to assert the
+    /// short-circuit behavior.
+    pub fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::SeqCst)
     }
 
     /// Reports whether a previous `record` call failed internally. Surfaced
@@ -71,7 +93,13 @@ impl AuditService {
 
     /// Appends `event` to the per-Vault audit log. Infallible by contract:
     /// every failure path swallows the error and flips the `degraded` flag.
+    /// When the master gate is off this is a complete no-op — no key fetch,
+    /// no file I/O — so a disabled audit log adds zero overhead to the
+    /// vault flows it instruments.
     pub fn record(&self, vault_path: &Path, event: &AuditEvent) {
+        if !self.is_enabled() {
+            return;
+        }
         if let Err(()) = self.try_record(vault_path, event) {
             self.degraded.store(true, Ordering::SeqCst);
         }
@@ -611,6 +639,71 @@ mod tests {
             }
             other => panic!("expected VaultUnlockFailed, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn record_short_circuits_when_disabled_no_file_no_events() {
+        // AC: `AuditService::record` consults the current `enabled` flag
+        // and short-circuits when disabled; no file write, no key fetch.
+        let (service, _dir, vault) = fresh_service();
+
+        service.set_enabled(false);
+        service.record(&vault, &unlock_failed_event(1));
+
+        // No log file should have been created on disk.
+        let log_path = service.log_path_for(&vault);
+        assert!(
+            !log_path.exists(),
+            "no audit file should exist when logging is disabled, found: {log_path:?}"
+        );
+        // And read() must report empty (file genuinely missing, not just
+        // hidden by the gate — read() does not consult the enabled flag).
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert!(events.is_empty());
+        assert!(!service.is_degraded());
+    }
+
+    #[test]
+    fn re_enabling_resumes_appending_to_same_file() {
+        // AC: Re-enabling logging resumes appending to the same file.
+        let (service, _dir, vault) = fresh_service();
+
+        // Record one event while enabled (default).
+        service.record(&vault, &unlock_failed_event(1));
+
+        // Disable, attempt to record — must not write.
+        service.set_enabled(false);
+        service.record(&vault, &unlock_failed_event(2));
+
+        // Re-enable and record again — must append to the existing file.
+        service.set_enabled(true);
+        service.record(&vault, &unlock_failed_event(3));
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        let counts: Vec<u32> = events.iter().map(unlock_failed_count).collect();
+        assert_eq!(counts, vec![1, 3]);
+    }
+
+    #[test]
+    fn disable_preserves_existing_log_file_unchanged() {
+        // AC: Disabling logging preserves the existing log file unchanged.
+        // Capture the file bytes before disabling and again after; they
+        // must be byte-identical (set_enabled must not touch storage).
+        let (service, _dir, vault) = fresh_service();
+        service.record(&vault, &unlock_failed_event(1));
+        let log_path = service.log_path_for(&vault);
+        let before = std::fs::read(&log_path).expect("read log before disable");
+
+        service.set_enabled(false);
+        let after = std::fs::read(&log_path).expect("read log after disable");
+        assert_eq!(
+            before, after,
+            "set_enabled(false) must not modify the log file"
+        );
+
+        // The previously-recorded event must still come back through read().
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -194,6 +194,7 @@ impl SettingsService {
     /// cannot push the backup module into invariant violations.
     fn validate_preferences(prefs: &AppPreferences) -> Result<(), AppError> {
         const MAX_VERSIONS_RANGE: std::ops::RangeInclusive<u32> = 1..=500;
+        const AUDIT_RETENTION_RANGE: std::ops::RangeInclusive<u32> = 1..=365;
         let v = prefs.backups.max_versions;
         if !MAX_VERSIONS_RANGE.contains(&v) {
             return Err(AppError::InvalidInput(format!(
@@ -206,6 +207,12 @@ impl SettingsService {
                     "backups.directory must be an absolute path, got {dir:?}"
                 )));
             }
+        }
+        let r = prefs.audit.retention_days;
+        if !AUDIT_RETENTION_RANGE.contains(&r) {
+            return Err(AppError::InvalidInput(format!(
+                "audit.retentionDays must be in 1..=365, got {r}"
+            )));
         }
         Ok(())
     }
@@ -222,7 +229,7 @@ impl SettingsService {
 #[allow(clippy::expect_used, clippy::panic)]
 mod validate_preferences_tests {
     use super::SettingsService;
-    use crate::commands::settings::{AppPreferences, BackupSettings};
+    use crate::commands::settings::{AppPreferences, AuditSettings, BackupSettings};
     use crate::dto::error::AppError;
 
     fn prefs_with_directory(dir: Option<&str>) -> AppPreferences {
@@ -232,6 +239,16 @@ mod validate_preferences_tests {
                 max_versions: 10,
                 directory: dir.map(String::from),
                 on_open: false,
+            },
+            ..AppPreferences::default()
+        }
+    }
+
+    fn prefs_with_audit_retention(days: u32) -> AppPreferences {
+        AppPreferences {
+            audit: AuditSettings {
+                enabled: true,
+                retention_days: days,
             },
             ..AppPreferences::default()
         }
@@ -272,5 +289,46 @@ mod validate_preferences_tests {
     fn no_directory_override_is_accepted() {
         let prefs = prefs_with_directory(None);
         SettingsService::validate_preferences(&prefs).expect("None should validate");
+    }
+
+    #[test]
+    fn audit_retention_zero_is_rejected() {
+        // Zero would mean "drop every event the moment it is written" once
+        // the retention policy lands in #6 — silently neutralizing the
+        // audit log. Reject at the boundary so a hand-edited settings.json
+        // cannot push the retention task into that state.
+        let prefs = prefs_with_audit_retention(0);
+        match SettingsService::validate_preferences(&prefs) {
+            Err(AppError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("audit.retentionDays") && msg.contains("1..=365"),
+                    "error should name the field and range, got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_retention_above_max_is_rejected() {
+        let prefs = prefs_with_audit_retention(366);
+        match SettingsService::validate_preferences(&prefs) {
+            Err(AppError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("audit.retentionDays"),
+                    "error should mention 'audit.retentionDays', got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn audit_retention_boundary_values_are_accepted() {
+        for days in [1_u32, 90, 365] {
+            let prefs = prefs_with_audit_retention(days);
+            SettingsService::validate_preferences(&prefs)
+                .unwrap_or_else(|_| panic!("retention_days={days} should validate"));
+        }
     }
 }

--- a/src-tauri/tests/commands/settings_test.rs
+++ b/src-tauri/tests/commands/settings_test.rs
@@ -8,6 +8,8 @@ use mithril_vault_lib::commands::settings::{
     get_recent_databases, remove_recent_database, reset_app_preferences, update_app_preferences,
     StartupBehavior,
 };
+use mithril_vault_lib::services::audit::key::InMemoryAuditKey;
+use mithril_vault_lib::services::audit::AuditService;
 use mithril_vault_lib::services::kdbx::KdbxService;
 use mithril_vault_lib::services::settings::SettingsService;
 use std::sync::Arc;
@@ -19,6 +21,19 @@ fn setup_app() -> tauri::App<tauri::test::MockRuntime> {
     let settings_service = SettingsService::new(app.handle()).expect("create settings service");
     app.manage(Arc::new(settings_service));
     app.manage(Arc::new(KdbxService::new()));
+    // update_app_preferences now also pushes the audit.enabled gate into
+    // AuditService, so the command surface needs one in state. Use an
+    // in-memory key + tempdir-style base so the test doesn't touch the
+    // user's real audit log.
+    let audit_root = app
+        .path()
+        .app_local_data_dir()
+        .expect("app local data dir")
+        .join("audit-test");
+    app.manage(Arc::new(AuditService::new(
+        audit_root,
+        Arc::new(InMemoryAuditKey::new()),
+    )));
     app
 }
 
@@ -45,8 +60,13 @@ fn get_and_update_preferences_commands() {
     updated.appearance.theme = "light".into();
     updated.security.prevent_screen_capture = false;
 
-    tauri::async_runtime::block_on(update_app_preferences(updated, app.state(), app.state()))
-        .expect("update preferences");
+    tauri::async_runtime::block_on(update_app_preferences(
+        updated,
+        app.state(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("update preferences");
 
     let refreshed =
         tauri::async_runtime::block_on(get_app_preferences(app.state())).expect("get preferences");
@@ -129,6 +149,7 @@ fn app_preferences_commands() {
         prefs.clone(),
         app.state(),
         app.state(),
+        app.state(),
     ))
     .expect("update preferences");
 
@@ -150,8 +171,12 @@ fn app_preferences_commands() {
     );
     assert!(refreshed.advanced.debug_mode);
 
-    let reset = tauri::async_runtime::block_on(reset_app_preferences(app.state(), app.state()))
-        .expect("reset prefs");
+    let reset = tauri::async_runtime::block_on(reset_app_preferences(
+        app.state(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("reset prefs");
     assert_eq!(reset.general.language, "en");
     assert_eq!(reset.security.clipboard_clear_timeout, 30);
     assert!(!reset.security.auto_download_favicons);
@@ -180,6 +205,7 @@ fn update_app_preferences_propagates_backups_to_kdbx_service() {
     prefs.backups.enabled = false;
     tauri::async_runtime::block_on(update_app_preferences(
         prefs.clone(),
+        app.state(),
         app.state(),
         app.state(),
     ))

--- a/src/components/settings/SettingsEditor.tsx
+++ b/src/components/settings/SettingsEditor.tsx
@@ -27,6 +27,7 @@ import { isColorPresetId } from "@/lib/theme-presets";
 import { AdvancedSettingsSection } from "@/components/settings/sections/AdvancedSettingsSection";
 import { AppearanceSettingsSection } from "@/components/settings/sections/AppearanceSettingsSection";
 import { AuditLogSection } from "@/components/settings/sections/AuditLogSection";
+import { AuditLogSettingsSection } from "@/components/settings/sections/AuditLogSettingsSection";
 import { BackupsListSection } from "@/components/settings/sections/BackupsListSection";
 import { BackupsSettingsSection } from "@/components/settings/sections/BackupsSettingsSection";
 import { BrowserIntegrationSettingsSection } from "@/components/settings/sections/BrowserIntegrationSettingsSection";
@@ -284,6 +285,7 @@ export function SettingsEditor({
       <AdvancedSettingsSection draft={draft} updateDraft={updateDraft} />
       <BackupsSettingsSection draft={draft} updateDraft={updateDraft} />
       <BackupsListSection dbId={dbId} backupsEnabled={draft.backups.enabled} />
+      <AuditLogSettingsSection draft={draft} updateDraft={updateDraft} />
       <AuditLogSection dbId={dbId} isLocked={isLocked} />
       <DatabaseSettingsSection
         dbId={dbId}

--- a/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/src/components/settings/__tests__/SettingsView.test.tsx
@@ -123,6 +123,10 @@ function makePreferences(): AppPreferences {
       maxVersions: 10,
       onOpen: false,
     },
+    audit: {
+      enabled: true,
+      retentionDays: 90,
+    },
   };
 }
 

--- a/src/components/settings/sections/AuditLogSettingsSection.tsx
+++ b/src/components/settings/sections/AuditLogSettingsSection.tsx
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+
+import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import type { AppPreferences } from "@/lib/types";
+
+interface AuditLogSettingsSectionProps {
+  draft: AppPreferences;
+  updateDraft: (updater: (previous: AppPreferences) => AppPreferences) => void;
+}
+
+const RETENTION_MIN = 1;
+const RETENTION_MAX = 365;
+
+export function AuditLogSettingsSection({
+  draft,
+  updateDraft,
+}: Readonly<AuditLogSettingsSectionProps>) {
+  const { t } = useTranslation();
+
+  return (
+    <SettingsSection
+      id="audit-settings"
+      title={t("settings.audit.title")}
+      description={t("settings.audit.description")}
+    >
+      <label className="flex items-start gap-2 text-sm">
+        <Checkbox
+          aria-label={t("settings.audit.enabled.label")}
+          checked={draft.audit.enabled}
+          onCheckedChange={(checked) =>
+            updateDraft((previous) => ({
+              ...previous,
+              audit: {
+                ...previous.audit,
+                enabled: checked === true,
+              },
+            }))
+          }
+        />
+        <span className="flex flex-col gap-1">
+          <span>{t("settings.audit.enabled.label")}</span>
+          <span className="text-muted-foreground">
+            {t("settings.audit.enabled.description")}
+          </span>
+        </span>
+      </label>
+
+      <div className="flex flex-col gap-2 text-sm">
+        <label htmlFor="audit-retention-days" className="flex flex-col gap-1">
+          <span>{t("settings.audit.retentionDays.label")}</span>
+          <span className="text-muted-foreground">
+            {t("settings.audit.retentionDays.description")}
+          </span>
+        </label>
+        <Input
+          id="audit-retention-days"
+          aria-label={t("settings.audit.retentionDays.label")}
+          type="number"
+          inputMode="numeric"
+          min={RETENTION_MIN}
+          max={RETENTION_MAX}
+          className="w-32"
+          value={draft.audit.retentionDays}
+          onChange={(event) => {
+            const raw = Number.parseInt(event.target.value, 10);
+            if (Number.isNaN(raw)) return;
+            updateDraft((previous) => ({
+              ...previous,
+              audit: {
+                ...previous.audit,
+                retentionDays: raw,
+              },
+            }));
+          }}
+        />
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/sections/__tests__/AuditLogSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSettingsSection.test.tsx
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { AuditLogSettingsSection } from "@/components/settings/sections/AuditLogSettingsSection";
+import type { AppPreferences } from "@/lib/types";
+
+function makeDraft(
+  audit: { enabled: boolean; retentionDays: number } = {
+    enabled: true,
+    retentionDays: 90,
+  }
+): AppPreferences {
+  return {
+    general: {
+      language: "en",
+      startupBehavior: "showUnlockScreen",
+      defaultDatabasePath: null,
+    },
+    security: {
+      autoLockTimeout: 300,
+      clipboardClearTimeout: 30,
+      clearClipboardOnLock: true,
+      showClipboardCountdown: false,
+      showPasswordByDefault: false,
+      minimizeToTray: true,
+      startMinimized: false,
+      preventScreenCapture: true,
+      autoDownloadFavicons: false,
+      allowThirdPartyFaviconFallbacks: false,
+    },
+    appearance: {
+      theme: "system",
+      colorPreset: "default",
+      fontSize: 14,
+      entryListColumns: {
+        username: true,
+        url: true,
+        modifiedAt: true,
+        tags: true,
+      },
+    },
+    browserIntegration: { enabled: false, allowedSites: [] },
+    advanced: { debugMode: false, dataLocation: "/tmp" },
+    backups: { enabled: true, maxVersions: 10, onOpen: false },
+    audit,
+  };
+}
+
+describe("AuditLogSettingsSection", () => {
+  it("renders the enable toggle reflecting draft.audit.enabled", () => {
+    render(
+      <AuditLogSettingsSection
+        draft={makeDraft({ enabled: true, retentionDays: 90 })}
+        updateDraft={vi.fn()}
+      />
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "settings.audit.enabled.label",
+    });
+    expect(checkbox).toBeChecked();
+  });
+
+  it("renders unchecked when draft.audit.enabled is false", () => {
+    render(
+      <AuditLogSettingsSection
+        draft={makeDraft({ enabled: false, retentionDays: 90 })}
+        updateDraft={vi.fn()}
+      />
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "settings.audit.enabled.label",
+    });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("toggles draft.audit.enabled when the checkbox is clicked", () => {
+    // Acceptance criterion: a single toggle in Settings drives
+    // draft.audit.enabled. The functional-updater shape matches the rest
+    // of the settings sections so SettingsEditor can compose updates
+    // without per-section special-casing.
+    const updateDraft = vi.fn();
+    render(
+      <AuditLogSettingsSection draft={makeDraft()} updateDraft={updateDraft} />
+    );
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: "settings.audit.enabled.label",
+    });
+    fireEvent.click(checkbox);
+
+    const calls = updateDraft.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (!lastCall) throw new Error("expected updateDraft to be called");
+    const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft());
+    expect(next.audit.enabled).toBe(false);
+    // Unrelated audit fields stay intact.
+    expect(next.audit.retentionDays).toBe(90);
+  });
+
+  it("renders the retention-days input with the current value", () => {
+    render(
+      <AuditLogSettingsSection
+        draft={makeDraft({ enabled: true, retentionDays: 30 })}
+        updateDraft={vi.fn()}
+      />
+    );
+    const input = screen.getByRole("spinbutton", {
+      name: "settings.audit.retentionDays.label",
+    });
+    expect(input).toHaveValue(30);
+  });
+
+  it("updates draft.audit.retentionDays when the input changes", () => {
+    const updateDraft = vi.fn();
+    render(
+      <AuditLogSettingsSection draft={makeDraft()} updateDraft={updateDraft} />
+    );
+
+    const input = screen.getByRole("spinbutton", {
+      name: "settings.audit.retentionDays.label",
+    });
+    fireEvent.change(input, { target: { value: "180" } });
+
+    const calls = updateDraft.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (!lastCall) throw new Error("expected updateDraft to be called");
+    const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft());
+    expect(next.audit.retentionDays).toBe(180);
+    expect(next.audit.enabled).toBe(true);
+  });
+
+  it("declares the documented retention range on the input", () => {
+    // Mirroring the backend's 1..=365 boundary keeps invalid drafts from
+    // ever reaching validate_preferences. The spinbutton's min/max
+    // attributes communicate the range to assistive tech and stop browser
+    // up/down arrows from stepping past it.
+    render(
+      <AuditLogSettingsSection draft={makeDraft()} updateDraft={vi.fn()} />
+    );
+    const input = screen.getByRole("spinbutton", {
+      name: "settings.audit.retentionDays.label",
+    });
+    expect(input).toHaveAttribute("min", "1");
+    expect(input).toHaveAttribute("max", "365");
+  });
+});

--- a/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
@@ -63,6 +63,7 @@ function makeDraft(
     browserIntegration: { enabled: false, allowedSites: [] },
     advanced: { debugMode: false, dataLocation: "/tmp" },
     backups: { enabled: true, maxVersions, directory, onOpen },
+    audit: { enabled: true, retentionDays: 90 },
   };
 }
 

--- a/src/hooks/__tests__/use-app-preferences.test.tsx
+++ b/src/hooks/__tests__/use-app-preferences.test.tsx
@@ -63,6 +63,10 @@ function makePreferences(): AppPreferences {
       maxVersions: 10,
       onOpen: false,
     },
+    audit: {
+      enabled: true,
+      retentionDays: 90,
+    },
   };
 }
 

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -174,6 +174,10 @@ describe("tauri wrappers validation", () => {
         maxVersions: 10,
         onOpen: false,
       },
+      audit: {
+        enabled: true,
+        retentionDays: 90,
+      },
     } as const;
 
     vi.mocked(invoke)
@@ -238,6 +242,10 @@ describe("tauri wrappers validation", () => {
           enabled: true,
           maxVersions: 10,
           onOpen: false,
+        },
+        audit: {
+          enabled: true,
+          retentionDays: 90,
         },
       })
     ).rejects.toThrow();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -281,6 +281,17 @@ export type BackupSettings = z.infer<typeof BackupSettingsSchema>;
 export const BACKUP_MAX_VERSIONS_PRESETS = [5, 10, 25, 50, 100] as const;
 export const DEFAULT_BACKUP_MAX_VERSIONS = 10;
 
+/// Audit-log preferences. `enabled` is the master gate (off => the backend
+/// `AuditService::record` becomes a no-op, existing log file untouched).
+/// `retentionDays` is bounded `1..=365` on the backend boundary; the UI
+/// must mirror the same range so an invalid value never leaves the form.
+export const AppPreferencesAuditSchema = z.object({
+  enabled: z.boolean(),
+  retentionDays: z.number().int().min(1).max(365),
+});
+export type AuditPreferences = z.infer<typeof AppPreferencesAuditSchema>;
+export const DEFAULT_AUDIT_RETENTION_DAYS = 90;
+
 export const AppPreferencesSchema = z.object({
   general: GeneralSettingsSchema,
   security: SecuritySettingsSchema,
@@ -288,6 +299,7 @@ export const AppPreferencesSchema = z.object({
   browserIntegration: BrowserIntegrationSettingsSchema,
   advanced: AdvancedSettingsSchema,
   backups: BackupSettingsSchema,
+  audit: AppPreferencesAuditSchema,
 });
 export type AppPreferences = z.infer<typeof AppPreferencesSchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -107,6 +107,19 @@
       "enableDebugMode": "Debug-Modus aktivieren",
       "dataLocation": "Datenspeicherort"
     },
+    "audit": {
+      "title": "Audit log",
+      "description": "Record security-relevant events for your vaults on this device.",
+      "enabled": {
+        "label": "Enable audit logging",
+        "description": "When off, no new events are written. Your existing log file is preserved."
+      },
+      "retentionDays": {
+        "label": "Retention (days)",
+        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
+        "validation": "Retention must be between 1 and 365 days."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -140,7 +140,7 @@
       },
       "retentionDays": {
         "label": "Retention (days)",
-        "description": "Events older than this are dropped on the next write. Valid range: 1 to 365 days.",
+        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
         "validation": "Retention must be between 1 and 365 days."
       }
     },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -131,6 +131,19 @@
       "enableDebugMode": "Enable debug mode",
       "dataLocation": "Data location"
     },
+    "audit": {
+      "title": "Audit log",
+      "description": "Record security-relevant events for your vaults on this device.",
+      "enabled": {
+        "label": "Enable audit logging",
+        "description": "When off, no new events are written. Your existing log file is preserved."
+      },
+      "retentionDays": {
+        "label": "Retention (days)",
+        "description": "Events older than this are dropped on the next write. Valid range: 1 to 365 days.",
+        "validation": "Retention must be between 1 and 365 days."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -107,6 +107,19 @@
       "enableDebugMode": "Habilitar modo de depuración",
       "dataLocation": "Ubicación de datos"
     },
+    "audit": {
+      "title": "Audit log",
+      "description": "Record security-relevant events for your vaults on this device.",
+      "enabled": {
+        "label": "Enable audit logging",
+        "description": "When off, no new events are written. Your existing log file is preserved."
+      },
+      "retentionDays": {
+        "label": "Retention (days)",
+        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
+        "validation": "Retention must be between 1 and 365 days."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -107,6 +107,19 @@
       "enableDebugMode": "Activer le mode débogage",
       "dataLocation": "Emplacement des données"
     },
+    "audit": {
+      "title": "Audit log",
+      "description": "Record security-relevant events for your vaults on this device.",
+      "enabled": {
+        "label": "Enable audit logging",
+        "description": "When off, no new events are written. Your existing log file is preserved."
+      },
+      "retentionDays": {
+        "label": "Retention (days)",
+        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
+        "validation": "Retention must be between 1 and 365 days."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -107,6 +107,19 @@
       "enableDebugMode": "Omogući režim za otklanjanje grešaka",
       "dataLocation": "Lokacija podataka"
     },
+    "audit": {
+      "title": "Audit log",
+      "description": "Record security-relevant events for your vaults on this device.",
+      "enabled": {
+        "label": "Enable audit logging",
+        "description": "When off, no new events are written. Your existing log file is preserved."
+      },
+      "retentionDays": {
+        "label": "Retention (days)",
+        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
+        "validation": "Retention must be between 1 and 365 days."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",


### PR DESCRIPTION
## Summary

- Adds `AuditSettings { enabled, retentionDays }` to `AppPreferences` with defaults `enabled = true` / `retentionDays = 90`; serde defaults so existing `settings.json` files migrate transparently.
- `SettingsService::validate_preferences` enforces `retentionDays ∈ 1..=365` with the same shape as the existing `backups.maxVersions` check.
- `AuditService` gains an `AtomicBool enabled` gate. `record()` short-circuits when off — no key fetch, no file I/O — and the on-disk log is left untouched, so disabling preserves history and re-enabling resumes appending to the same file.
- `update_app_preferences` / `reset_app_preferences` and the startup wiring push the current `audit.enabled` flag into `AuditService`.
- New Settings → Audit log section with a toggle and a numeric input bound to the documented range. `settings.audit.*` i18n keys added to `en/common.json`.

Closes #219.

## Test plan

- [x] `cargo test` — 225 unit + 50 integration tests pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean.
- [x] `bun run test` — 387 frontend tests pass, including the new `AuditLogSettingsSection` cases (toggle reflects + drives `draft.audit.enabled`, retention input mirrors `1..=365`, functional-updater shape matches sibling sections).
- [x] `bun run check` — ESLint and Prettier clean.
- [ ] Manual smoke: toggle Audit Log off in Settings, trigger a failed unlock, verify nothing is appended to the `audit/<vault_hash>.jsonl` file; toggle back on and confirm a new failure produces one record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)