### PR TITLE
feat(core,ui): manual audit log clear with surviving audit.cleared event (#220)

### DIFF
--- a/src-tauri/src/commands/audit.rs
+++ b/src-tauri/src/commands/audit.rs
@@ -36,3 +36,18 @@ pub async fn get_audit_events(
         degraded: audit.is_degraded(),
     })
 }
+
+/// Truncates the per-Vault audit log and leaves behind a single
+/// `audit.cleared` event so the wipe is visible in the panel. The
+/// underlying service performs the rewrite atomically so a mid-write
+/// failure leaves the original file untouched; the caller sees that as
+/// `AppError::AuditClear`.
+#[tauri::command]
+pub async fn clear_audit_log(
+    vault_path: String,
+    audit: State<'_, Arc<AuditService>>,
+) -> Result<(), AppError> {
+    audit
+        .clear(Path::new(&vault_path))
+        .map_err(|e| AppError::AuditClear(e.to_string()))
+}

--- a/src-tauri/src/dto/audit.rs
+++ b/src-tauri/src/dto/audit.rs
@@ -18,6 +18,7 @@ pub enum AuditEventKindDto {
     EntryPasswordRevealed,
     EntryPasswordCopied,
     EntryProtectedFieldRevealed,
+    AuditCleared,
 }
 
 /// Why a Vault transitioned from unlocked to locked, mirrored from
@@ -138,6 +139,13 @@ impl From<AuditEvent> for AuditEventDto {
                 reason: None,
                 entry_id: Some(entry_id),
             },
+            AuditEvent::AuditCleared { timestamp } => Self {
+                kind: AuditEventKindDto::AuditCleared,
+                timestamp,
+                attempt_count: None,
+                reason: None,
+                entry_id: None,
+            },
         }
     }
 }
@@ -245,6 +253,29 @@ mod tests {
         assert!(
             !json.contains("attemptCount"),
             "attemptCount must be omitted for entry kinds: {json}"
+        );
+    }
+
+    /// The clear-log surviving event reaches the UI as a camelCase
+    /// `auditCleared` kind with no payload beyond the timestamp. The DTO
+    /// translation has to mirror the wire-format rename done in
+    /// `services::audit::format` so the row renderer can dispatch on a
+    /// clean camelCase variant.
+    #[test]
+    fn audit_cleared_event_converts_to_dto_with_camel_case_kind() {
+        let ts = Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap();
+        let dto: AuditEventDto = AuditEvent::AuditCleared { timestamp: ts }.into();
+
+        assert!(matches!(dto.kind, AuditEventKindDto::AuditCleared));
+        assert_eq!(dto.timestamp, ts);
+        assert!(dto.attempt_count.is_none());
+        assert!(dto.reason.is_none());
+        assert!(dto.entry_id.is_none());
+
+        let json = serde_json::to_string(&dto).expect("ser");
+        assert!(
+            json.contains("\"auditCleared\""),
+            "kind must serialize as camelCase, got: {json}",
         );
     }
 

--- a/src-tauri/src/dto/error.rs
+++ b/src-tauri/src/dto/error.rs
@@ -115,6 +115,9 @@ pub enum AppError {
 
     #[error("Audit log read failed: {0}")]
     AuditRead(String),
+
+    #[error("Audit log clear failed: {0}")]
+    AuditClear(String),
 }
 
 impl Serialize for AppError {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,8 +8,8 @@ pub mod utils;
 
 use crate::dto::error::AppError;
 use commands::{
-    add_recent_database, clear_clipboard, clear_entry_custom_icon, clear_recent_databases,
-    clear_session_key, close_database, copy_password_to_clipboard,
+    add_recent_database, clear_audit_log, clear_clipboard, clear_entry_custom_icon,
+    clear_recent_databases, clear_session_key, close_database, copy_password_to_clipboard,
     copy_protected_field_to_clipboard, copy_text_to_clipboard, create_database, create_entry,
     create_group, create_manual_backup, delete_backup, delete_entry, delete_group, delete_tag,
     fetch_entry_favicon, generate_keyfile, generate_passphrase, generate_password,
@@ -91,6 +91,7 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             generate_password,
             generate_passphrase,
             get_audit_events,
+            clear_audit_log,
             get_app_preferences,
             update_app_preferences,
             reset_app_preferences,

--- a/src-tauri/src/services/audit/format.rs
+++ b/src-tauri/src/services/audit/format.rs
@@ -46,6 +46,8 @@ pub enum AuditEvent {
         timestamp: DateTime<Utc>,
         entry_id: String,
     },
+    #[serde(rename = "audit.cleared")]
+    AuditCleared { timestamp: DateTime<Utc> },
 }
 
 /// Why a Vault transitioned from unlocked to locked. Serialised as
@@ -216,6 +218,34 @@ mod tests {
         let json = String::from_utf8(event.to_bytes()).expect("utf8");
         assert!(json.contains("\"kind\":\"entry.protected_field_revealed\""));
         assert!(json.contains("\"entry_id\":\"uuid-3\""));
+    }
+
+    /// Manual clear of the audit log emits exactly one surviving event
+    /// (`audit.cleared`) so a wipe is never silent. The wire tag is pinned
+    /// to the dotted, snake-case form used by every other kind so already-
+    /// written log files stay readable across refactors of the Rust enum.
+    #[test]
+    fn audit_cleared_round_trips_with_dotted_kind() {
+        let event = AuditEvent::AuditCleared {
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap(),
+        };
+        let bytes = event.to_bytes();
+        let parsed = AuditEvent::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, event);
+
+        let json = std::str::from_utf8(&bytes).expect("utf8");
+        assert!(
+            json.contains("\"kind\":\"audit.cleared\""),
+            "kind must serialize as `audit.cleared`, got: {json}",
+        );
+        assert!(
+            !json.contains("entry_id"),
+            "audit.cleared must not carry entry_id: {json}",
+        );
+        assert!(
+            !json.contains("attempt_count"),
+            "audit.cleared must not carry attempt_count: {json}",
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -36,6 +36,18 @@ pub enum AuditReadError {
     Storage(String),
 }
 
+/// Errors surfaced from [`AuditService::clear`]. Like [`AuditReadError`]
+/// and unlike the infallible [`AuditService::record`], clear is a user-
+/// initiated action and a failure must be visible — the UI toasts it so
+/// the user knows the wipe did not actually happen.
+#[derive(Debug, Error)]
+pub enum AuditClearError {
+    #[error("audit key unavailable: {0}")]
+    Key(String),
+    #[error("audit clear failed: {0}")]
+    Storage(String),
+}
+
 /// Permissive filter applied by [`AuditService::read`]. Shape is in place so
 /// future issues can plug in `kinds` / time-range filtering without changing
 /// callers; today it returns everything.
@@ -249,6 +261,32 @@ impl AuditService {
             entry_id: entry_id.to_string(),
         };
         self.record(vault_path, &event);
+    }
+
+    /// Wipes the per-Vault audit log and leaves behind exactly one
+    /// `audit.cleared` event so the wipe is never silent. The storage
+    /// layer performs the rewrite atomically (temp file + rename under
+    /// an exclusive advisory lock) so a failure mid-write leaves the
+    /// original file untouched rather than producing a partial log.
+    ///
+    /// Unlike [`AuditService::record`], `clear` is user-initiated and
+    /// surfaces hard errors so the caller can render a failure state
+    /// rather than silently flipping the `degraded` flag.
+    pub fn clear(&self, vault_path: &Path) -> Result<(), AuditClearError> {
+        let key = self
+            .key_source
+            .get_or_create()
+            .map_err(|e| AuditClearError::Key(e.to_string()))?;
+        let event = AuditEvent::AuditCleared {
+            timestamp: Utc::now(),
+        };
+        let plaintext = event.to_bytes();
+        let frame =
+            encrypt(&key, &plaintext).map_err(|e| AuditClearError::Storage(e.to_string()))?;
+        let log = AuditLogFile::new(self.log_path_for(vault_path));
+        log.replace_with_single(&frame)
+            .map_err(|e| AuditClearError::Storage(e.to_string()))?;
+        Ok(())
     }
 
     /// Resets the per-Vault failed-unlock counter — called on successful
@@ -704,6 +742,65 @@ mod tests {
         // The previously-recorded event must still come back through read().
         let events = service.read(&vault, &AuditFilter::default()).expect("read");
         assert_eq!(events.len(), 1);
+    }
+
+    /// Acceptance-criteria integration test for issue #220: populate a
+    /// log with several events, `clear` it, then assert `read` returns
+    /// exactly one `audit.cleared` event with no surviving history.
+    #[test]
+    fn clear_replaces_history_with_single_audit_cleared_event() {
+        let (service, _dir, vault) = fresh_service();
+
+        // Populate with a mix of kinds so we know clear doesn't just
+        // affect one variant.
+        service.record_vault_unlock_failed(&vault);
+        service.record_vault_opened(&vault);
+        service.record_vault_locked(&vault, Reason::Manual);
+        service.record_entry_password_revealed(&vault, "uuid-x");
+
+        service.clear(&vault).expect("clear");
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1, "exactly one surviving event after clear");
+        assert!(
+            matches!(events[0], AuditEvent::AuditCleared { .. }),
+            "surviving event must be AuditCleared, got {:?}",
+            events[0]
+        );
+    }
+
+    /// Clearing an audit log that has never been written to still emits
+    /// the surviving event — otherwise a "clear" on a fresh Vault would
+    /// silently leave an empty file and the audit panel would look
+    /// identical to "never logged anything", hiding the user action.
+    #[test]
+    fn clear_on_empty_vault_writes_audit_cleared_event() {
+        let (service, _dir, vault) = fresh_service();
+
+        service.clear(&vault).expect("clear");
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], AuditEvent::AuditCleared { .. }));
+    }
+
+    /// `clear` is user-initiated from the Settings panel — its failure
+    /// mode is a hard error, not the infallible swallow that `record`
+    /// uses. A bad `base_dir` must surface as `Err(_)` so the UI can toast
+    /// the failure instead of silently leaving the original log in place.
+    #[test]
+    fn clear_against_unwritable_dir_returns_error() {
+        let dir = tempdir().expect("tempdir");
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"x").expect("write blocker file");
+
+        let base_dir = blocker.join("audit");
+        let service = AuditService::new(base_dir, Arc::new(InMemoryAuditKey::new()));
+        let vault = dir.path().join("vault.kdbx");
+        std::fs::write(&vault, b"x").expect("write vault");
+
+        let result = service.clear(&vault);
+        assert!(result.is_err(), "clear under unwritable dir must error");
     }
 
     #[test]

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -79,6 +79,59 @@ impl AuditLogFile {
         result.map_err(StorageError::from)
     }
 
+    /// Atomically replaces the audit log file with a single encrypted
+    /// frame. Used by `AuditService::clear` to wipe history while leaving
+    /// behind a surviving `audit.cleared` event so a manual clear is
+    /// never silent.
+    ///
+    /// Atomicity strategy: write the new sole-content line to a sibling
+    /// temp file under exclusive lock on the destination, then atomically
+    /// rename it over the destination. If the temp write fails mid-way
+    /// (e.g. disk full) the destination file is left untouched, so the
+    /// caller never observes a partial state — either the original log
+    /// is intact or the new one-frame log is in place.
+    pub fn replace_with_single(&self, frame: &[u8]) -> Result<(), StorageError> {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|_| StorageError::Io("audit replace mutex poisoned".into()))?;
+
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Hold an exclusive advisory lock on the (possibly-empty)
+        // destination file for the whole rename window so concurrent
+        // readers/appenders gate on us — same protocol as `append`.
+        let dest_handle = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)?;
+        FileExt::lock_exclusive(&dest_handle)?;
+
+        let result = (|| -> std::io::Result<()> {
+            let tmp_path = tmp_path_for(&self.path);
+            // O_CREATE | O_TRUNC | O_WRONLY semantics — clean slate per
+            // call so a leftover temp from a crashed prior call doesn't
+            // contaminate the new content.
+            let mut tmp = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp_path)?;
+            let line = encode_frame(frame);
+            tmp.write_all(line.as_bytes())?;
+            tmp.write_all(b"\n")?;
+            tmp.sync_data()?;
+            drop(tmp);
+            std::fs::rename(&tmp_path, &self.path)?;
+            Ok(())
+        })();
+
+        let _ = FileExt::unlock(&dest_handle);
+        result.map_err(StorageError::from)
+    }
+
     /// Reads all frames in append order. Missing file returns an empty
     /// outcome. Lines that fail base64 decode are *counted* in
     /// [`LogReadOutcome::malformed_lines`] rather than dropped silently:
@@ -125,6 +178,12 @@ impl AuditLogFile {
         let _ = FileExt::unlock(&file);
         result
     }
+}
+
+fn tmp_path_for(path: &Path) -> PathBuf {
+    let mut s = path.as_os_str().to_owned();
+    s.push(".tmp");
+    PathBuf::from(s)
 }
 
 /// Result of [`AuditLogFile::read_all`]. `frames` is in append order and
@@ -247,6 +306,44 @@ mod tests {
         assert_eq!(outcome.frames, vec![b"first".to_vec()]);
         assert_eq!(outcome.malformed_lines, 0);
         reader.join().expect("reader join");
+    }
+
+    /// `replace_with_single` is the storage operation that backs
+    /// `AuditService::clear`: every previously-appended frame is dropped
+    /// and the file ends with exactly the single frame the caller
+    /// supplied. The rest of the slice depends on this being a clean
+    /// rewrite — multiple lines or stray bytes around the new frame would
+    /// surface in `read_all` and break the integration assertion.
+    #[test]
+    fn replace_with_single_leaves_exactly_one_frame() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("v.jsonl"));
+
+        log.append(b"first").expect("append first");
+        log.append(b"second").expect("append second");
+        log.append(b"third").expect("append third");
+
+        log.replace_with_single(b"surviving").expect("replace");
+
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames, vec![b"surviving".to_vec()]);
+        assert_eq!(outcome.malformed_lines, 0);
+    }
+
+    /// Calling `replace_with_single` on a Vault that never logged anything
+    /// has to still leave the log file holding exactly that one frame —
+    /// otherwise a "clear" against a never-logged Vault would silently
+    /// produce an empty file and the surviving-event guarantee from the
+    /// PRD evaporates.
+    #[test]
+    fn replace_with_single_on_missing_file_creates_file_with_that_frame() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("nested").join("v.jsonl"));
+
+        log.replace_with_single(b"only").expect("replace");
+
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames, vec![b"only".to_vec()]);
     }
 
     #[test]

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -49,33 +49,62 @@ impl AuditLogFile {
         &self.path
     }
 
-    /// Appends a single encrypted frame as one base64 JSONL line. Takes the
-    /// intra-process mutex and an advisory exclusive lock on the file.
+    /// Path of the sidecar lockfile used to serialise append / read /
+    /// replace across processes. The lockfile is a stable inode that
+    /// outlives any rename of the log file itself, so a blocked
+    /// participant always opens the post-rename log inode on wake-up.
+    fn lock_path(&self) -> PathBuf {
+        let mut s = self.path.as_os_str().to_owned();
+        s.push(".lock");
+        PathBuf::from(s)
+    }
+
+    /// Opens the sidecar lockfile (creating it if needed) and returns it.
+    /// The caller is responsible for `lock_exclusive` / `lock_shared`
+    /// before touching the real log file and `unlock` after.
+    ///
+    /// The sidecar is the *only* lock target shared by append, read, and
+    /// replace — locking the log file inode directly would race with
+    /// `rename`, leaving concurrent participants blocked on the orphaned
+    /// pre-rename inode (see
+    /// `append_during_replace_does_not_get_lost_to_orphaned_inode`).
+    fn open_sidecar_lock(&self) -> std::io::Result<File> {
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(self.lock_path())
+    }
+
+    /// Appends a single encrypted frame as one base64 JSONL line. Takes
+    /// the intra-process mutex and an exclusive advisory lock on the
+    /// sidecar lockfile BEFORE opening the log file — that ordering is
+    /// what makes a blocked appender always see the post-replace inode.
     pub fn append(&self, frame: &[u8]) -> Result<(), StorageError> {
         let _guard = self
             .write_lock
             .lock()
             .map_err(|_| StorageError::Io("audit append mutex poisoned".into()))?;
 
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
+        let lock = self.open_sidecar_lock()?;
+        FileExt::lock_exclusive(&lock)?;
 
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
-        FileExt::lock_exclusive(&file)?;
-
-        let line = encode_frame(frame);
         let result = (|| -> std::io::Result<()> {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&self.path)?;
+            let line = encode_frame(frame);
             file.write_all(line.as_bytes())?;
             file.write_all(b"\n")?;
             file.sync_data()?;
             Ok(())
         })();
 
-        let _ = FileExt::unlock(&file);
+        let _ = FileExt::unlock(&lock);
         result.map_err(StorageError::from)
     }
 
@@ -84,30 +113,26 @@ impl AuditLogFile {
     /// behind a surviving `audit.cleared` event so a manual clear is
     /// never silent.
     ///
-    /// Atomicity strategy: write the new sole-content line to a sibling
-    /// temp file under exclusive lock on the destination, then atomically
+    /// Atomicity strategy: under the sidecar exclusive lock, write the
+    /// new sole-content line to a sibling temp file and atomically
     /// rename it over the destination. If the temp write fails mid-way
     /// (e.g. disk full) the destination file is left untouched, so the
     /// caller never observes a partial state — either the original log
     /// is intact or the new one-frame log is in place.
+    ///
+    /// The sidecar lockfile (not the log file itself) is the lock
+    /// target: locking the log file directly would race with the rename
+    /// — a concurrent appender that opened the pre-rename inode would
+    /// block on the orphan's lock and then silently write into an
+    /// unlinked file once the lock dropped.
     pub fn replace_with_single(&self, frame: &[u8]) -> Result<(), StorageError> {
         let _guard = self
             .write_lock
             .lock()
             .map_err(|_| StorageError::Io("audit replace mutex poisoned".into()))?;
 
-        if let Some(parent) = self.path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        // Hold an exclusive advisory lock on the (possibly-empty)
-        // destination file for the whole rename window so concurrent
-        // readers/appenders gate on us — same protocol as `append`.
-        let dest_handle = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&self.path)?;
-        FileExt::lock_exclusive(&dest_handle)?;
+        let lock = self.open_sidecar_lock()?;
+        FileExt::lock_exclusive(&lock)?;
 
         let result = (|| -> std::io::Result<()> {
             let tmp_path = tmp_path_for(&self.path);
@@ -128,7 +153,7 @@ impl AuditLogFile {
             Ok(())
         })();
 
-        let _ = FileExt::unlock(&dest_handle);
+        let _ = FileExt::unlock(&lock);
         result.map_err(StorageError::from)
     }
 
@@ -140,24 +165,26 @@ impl AuditLogFile {
     /// degraded indicator so the UI surfaces "some entries unreadable"
     /// instead of pretending nothing was wrong.
     ///
-    /// Takes a shared advisory lock for the duration of the scan so the
+    /// Takes a shared advisory lock on the sidecar lockfile so the
     /// reader participates in the same locking protocol as
-    /// [`AuditLogFile::append`]. Advisory locks only hold if every
-    /// participant cooperates — a lock-free reader would observe partial
-    /// state during in-progress writes (and, crucially, during the
-    /// exclusive-lock-held rewrites that retention/compaction will
-    /// perform in a follow-up).
+    /// [`AuditLogFile::append`] and
+    /// [`AuditLogFile::replace_with_single`]. Locking the sidecar
+    /// rather than the log file itself means a reader that arrives mid-
+    /// replace blocks until the rename completes and then opens the new
+    /// inode — there's no chance of reading the orphaned pre-rename
+    /// file.
     pub fn read_all(&self) -> Result<LogReadOutcome, StorageError> {
-        let file = match File::open(&self.path) {
-            Ok(f) => f,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Ok(LogReadOutcome::default());
-            }
-            Err(e) => return Err(e.into()),
-        };
-        FileExt::lock_shared(&file)?;
+        let lock = self.open_sidecar_lock()?;
+        FileExt::lock_shared(&lock)?;
 
         let result = (|| -> Result<LogReadOutcome, StorageError> {
+            let file = match File::open(&self.path) {
+                Ok(f) => f,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Ok(LogReadOutcome::default());
+                }
+                Err(e) => return Err(e.into()),
+            };
             let reader = BufReader::new(&file);
             let mut outcome = LogReadOutcome::default();
             for line in reader.lines() {
@@ -175,7 +202,7 @@ impl AuditLogFile {
             Ok(outcome)
         })();
 
-        let _ = FileExt::unlock(&file);
+        let _ = FileExt::unlock(&lock);
         result
     }
 }
@@ -260,8 +287,9 @@ mod tests {
     /// `read_all` must participate in the advisory locking protocol —
     /// otherwise a concurrent writer (or future retention rewriter) can
     /// hold its exclusive lock and the lock-free reader will sail past it
-    /// and read partial state. Verify by holding an exclusive lock on a
-    /// separate handle and asserting the reader is gated on its release.
+    /// and read partial state. Verify by holding an exclusive lock on
+    /// the shared sidecar lockfile and asserting the reader is gated on
+    /// its release.
     #[test]
     fn read_all_blocks_while_exclusive_lock_is_held() {
         use std::sync::mpsc;
@@ -272,13 +300,16 @@ mod tests {
         let log = AuditLogFile::new(path.clone());
         log.append(b"first").expect("append");
 
-        // Hold an exclusive lock from this thread via a separate handle.
-        // The reader thread should NOT be able to complete its read
-        // until the lock is released.
+        // Hold an exclusive lock on the sidecar lockfile (the stable
+        // coordination point — locking the log file directly would race
+        // with `replace_with_single`'s rename). The reader thread MUST
+        // NOT complete its read until this lock is released.
         let blocker = OpenOptions::new()
-            .read(true)
-            .open(&path)
-            .expect("open for lock");
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(log.lock_path())
+            .expect("open sidecar lock");
         FileExt::lock_exclusive(&blocker).expect("lock exclusive");
 
         let (tx, rx) = mpsc::channel();
@@ -344,6 +375,106 @@ mod tests {
 
         let outcome = log.read_all().expect("read");
         assert_eq!(outcome.frames, vec![b"only".to_vec()]);
+    }
+
+    /// Regression test for the locking race in `replace_with_single`:
+    /// the original implementation took an advisory lock on the
+    /// destination file *before* renaming a sibling temp file over it,
+    /// which means a concurrent appender that had already opened the
+    /// (about-to-be-unlinked) inode would block on the lock attached to
+    /// that orphan, then write to it after the rename completed. The
+    /// late append would silently land in the orphaned inode and be lost
+    /// once the file handle dropped — a missing audit event the user
+    /// would never see.
+    ///
+    /// Fix: serialize append/read/replace through a stable sidecar
+    /// `<log>.lock` file that is never renamed or unlinked, and acquire
+    /// the sidecar lock BEFORE opening the log file in `append`, so a
+    /// blocked appender always opens the post-replace inode.
+    ///
+    /// This test orchestrates the race deterministically: a foreground
+    /// thread holds the sidecar lock and does a replace, while a
+    /// background appender races to call `append`. After both finish,
+    /// the on-disk log must contain BOTH the replacement frame and the
+    /// late append — proving the late write did not vanish into an
+    /// orphan.
+    #[test]
+    fn append_during_replace_does_not_get_lost_to_orphaned_inode() {
+        use std::sync::{Arc, Barrier};
+        use std::time::Duration;
+
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("v.jsonl");
+        let log = Arc::new(AuditLogFile::new(path.clone()));
+
+        // Seed the file so the "old inode" is a real, written-to file.
+        log.append(b"seed").expect("seed append");
+
+        // Manually acquire the sidecar lock from the foreground so we
+        // can release it deterministically AFTER the rename — this is
+        // exactly the window during which a concurrent appender would
+        // have been racing in the buggy implementation.
+        let lock_path = log.lock_path();
+        let held_lock = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .write(true)
+            .open(&lock_path)
+            .expect("open sidecar");
+        FileExt::lock_exclusive(&held_lock).expect("acquire sidecar lock");
+
+        let barrier = Arc::new(Barrier::new(2));
+        let log_for_thread = Arc::clone(&log);
+        let barrier_for_thread = Arc::clone(&barrier);
+        let appender = std::thread::spawn(move || {
+            barrier_for_thread.wait();
+            log_for_thread
+                .append(b"late-append")
+                .expect("late append must succeed");
+        });
+
+        // Release the appender to start racing — it will block trying
+        // to acquire the sidecar lock since we still hold it.
+        barrier.wait();
+        // Give the appender a moment to reach the lock-wait.
+        std::thread::sleep(Duration::from_millis(50));
+
+        // Now perform the equivalent of a replace under our held lock:
+        // write the new content to a temp file and rename over the log.
+        // This swaps the inode at `path` to a brand-new one — the inode
+        // the appender may have observed earlier is now anonymous.
+        let tmp_path = tmp_path_for(&path);
+        let mut tmp = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&tmp_path)
+            .expect("open tmp");
+        let line = encode_frame(b"surviving");
+        tmp.write_all(line.as_bytes()).expect("tmp write");
+        tmp.write_all(b"\n").expect("tmp newline");
+        tmp.sync_data().expect("tmp sync");
+        drop(tmp);
+        std::fs::rename(&tmp_path, &path).expect("rename swap");
+
+        // Release the sidecar lock so the appender can make progress.
+        FileExt::unlock(&held_lock).expect("release sidecar");
+        drop(held_lock);
+
+        appender.join().expect("appender join");
+
+        // Both frames must be present — the late append must NOT have
+        // landed in the orphaned inode.
+        let outcome = log.read_all().expect("read");
+        let frames: Vec<Vec<u8>> = outcome.frames;
+        assert!(
+            frames.contains(&b"surviving".to_vec()),
+            "post-replace 'surviving' frame missing: {frames:?}"
+        );
+        assert!(
+            frames.contains(&b"late-append".to_vec()),
+            "late append was lost to orphaned inode: {frames:?}"
+        );
     }
 
     #[test]

--- a/src/components/settings/sections/AuditLogSection.tsx
+++ b/src/components/settings/sections/AuditLogSection.tsx
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ask } from "@tauri-apps/plugin-dialog";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
 import { SettingsSection } from "@/components/settings/SettingsSection";
 import { queryKeys } from "@/lib/query-keys";
 import { audit, entries as entriesIpc } from "@/lib/tauri";
@@ -85,6 +88,7 @@ export function AuditLogSection({
 }: Readonly<AuditLogSectionProps>) {
   const { t } = useTranslation();
   const resolveTitle = useResolveEntryTitle(dbId, isLocked);
+  const queryClient = useQueryClient();
 
   const query = useQuery<AuditEventsResponse, Error>({
     queryKey: queryKeys.audit.list(dbId ?? "none"),
@@ -92,7 +96,29 @@ export function AuditLogSection({
     enabled: Boolean(dbId),
   });
 
+  const clearMutation = useMutation<void, Error, string>({
+    mutationFn: (vaultPath) => audit.clear(vaultPath),
+    onSuccess: (_data, vaultPath) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.audit.list(vaultPath),
+      });
+    },
+    onError: (error) => {
+      toast.error(t("audit.clearError", { error: String(error) }));
+    },
+  });
+
   const data = query.data ?? EMPTY_RESPONSE;
+
+  async function handleClear() {
+    if (!dbId) return;
+    const confirmed = await ask(t("audit.clearConfirm"), {
+      title: t("audit.clearConfirmTitle"),
+      kind: "warning",
+    });
+    if (!confirmed) return;
+    clearMutation.mutate(dbId);
+  }
 
   return (
     <SettingsSection
@@ -100,6 +126,21 @@ export function AuditLogSection({
       title={t("audit.title")}
       description={t("audit.description")}
     >
+      {dbId ? (
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={() => {
+              void handleClear();
+            }}
+            disabled={clearMutation.isPending}
+          >
+            {t("audit.clearButton")}
+          </Button>
+        </div>
+      ) : null}
       {!dbId ? (
         <p className="text-sm text-muted-foreground">
           {t("audit.emptyNoVault")}

--- a/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
@@ -513,7 +513,7 @@ describe("AuditLogSection", () => {
     await waitFor(() => {
       const rows = screen.getAllByRole("listitem");
       expect(rows.length).toBe(1);
-      expect(rows[0].getAttribute("data-kind")).toBe("auditCleared");
+      expect(rows[0]?.getAttribute("data-kind")).toBe("auditCleared");
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
@@ -549,7 +549,7 @@ describe("AuditLogSection", () => {
     });
     // Pre-clear event still visible — the original log was preserved.
     const rows = screen.getAllByRole("listitem");
-    expect(rows[0].getAttribute("data-kind")).toBe("vaultUnlockFailed");
+    expect(rows[0]?.getAttribute("data-kind")).toBe("vaultUnlockFailed");
   });
 
   it("renders an auditCleared row with the localized kind label", async () => {

--- a/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
@@ -2,19 +2,35 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { queryKeys } from "@/lib/query-keys";
 
 const listMock = vi.fn();
+const clearMock = vi.fn();
 const entriesListMock = vi.fn().mockResolvedValue([]);
+const askMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
 
 vi.mock("@/lib/tauri", () => ({
   audit: {
     list: (...args: unknown[]) => listMock(...args),
+    clear: (...args: unknown[]) => clearMock(...args),
   },
   entries: {
     list: (...args: unknown[]) => entriesListMock(...args),
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  ask: (...args: unknown[]) => askMock(...args),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
   },
 }));
 
@@ -42,8 +58,12 @@ function createWrapper(setup?: (queryClient: QueryClient) => void) {
 describe("AuditLogSection", () => {
   beforeEach(() => {
     listMock.mockReset();
+    clearMock.mockReset();
     entriesListMock.mockReset();
     entriesListMock.mockResolvedValue([]);
+    askMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
   });
 
   it("renders a no-vault empty state and does not query when no vault is open", () => {
@@ -394,6 +414,165 @@ describe("AuditLogSection", () => {
       const row = screen.getByRole("listitem");
       expect(row.textContent).toContain("Late");
     });
+  });
+
+  it("hides the Clear Audit Log button when no vault is open", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId={null} />
+      </Wrapper>
+    );
+
+    expect(screen.queryByText("audit.clearButton")).toBeNull();
+  });
+
+  it("renders the Clear Audit Log button when a vault is open", async () => {
+    listMock.mockResolvedValueOnce({ events: [], degraded: false });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "audit.clearButton" })
+    ).toBeInTheDocument();
+  });
+
+  it("does not call clear when the confirmation dialog is dismissed", async () => {
+    listMock.mockResolvedValueOnce({ events: [], degraded: false });
+    askMock.mockResolvedValueOnce(false);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    const btn = await screen.findByRole("button", {
+      name: "audit.clearButton",
+    });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(askMock).toHaveBeenCalledTimes(1);
+    });
+    expect(clearMock).not.toHaveBeenCalled();
+  });
+
+  it("invokes audit.clear and refetches when the user confirms", async () => {
+    // First load: pre-clear log with one event. Second load (after
+    // invalidation): the surviving auditCleared event.
+    listMock
+      .mockResolvedValueOnce({
+        events: [
+          {
+            kind: "vaultUnlockFailed",
+            timestamp: "2026-05-16T11:00:00.000Z",
+            attemptCount: 1,
+          },
+        ],
+        degraded: false,
+      })
+      .mockResolvedValueOnce({
+        events: [
+          {
+            kind: "auditCleared",
+            timestamp: "2026-05-17T12:00:00.000Z",
+          },
+        ],
+        degraded: false,
+      });
+    askMock.mockResolvedValueOnce(true);
+    clearMock.mockResolvedValueOnce(undefined);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    // Wait for the initial load to settle.
+    await screen.findAllByRole("listitem");
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "audit.clearButton" })
+    );
+
+    await waitFor(() => {
+      expect(clearMock).toHaveBeenCalledWith("/tmp/vault.kdbx");
+    });
+
+    // The panel re-fetches and ends up showing exactly the auditCleared
+    // surviving event.
+    await waitFor(() => {
+      const rows = screen.getAllByRole("listitem");
+      expect(rows.length).toBe(1);
+      expect(rows[0].getAttribute("data-kind")).toBe("auditCleared");
+    });
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("toasts an error and leaves the panel intact when audit.clear rejects", async () => {
+    listMock.mockResolvedValue({
+      events: [
+        {
+          kind: "vaultUnlockFailed",
+          timestamp: "2026-05-16T11:00:00.000Z",
+          attemptCount: 1,
+        },
+      ],
+      degraded: false,
+    });
+    askMock.mockResolvedValueOnce(true);
+    clearMock.mockRejectedValueOnce(new Error("disk full"));
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    await screen.findAllByRole("listitem");
+    fireEvent.click(
+      await screen.findByRole("button", { name: "audit.clearButton" })
+    );
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalled();
+    });
+    // Pre-clear event still visible — the original log was preserved.
+    const rows = screen.getAllByRole("listitem");
+    expect(rows[0].getAttribute("data-kind")).toBe("vaultUnlockFailed");
+  });
+
+  it("renders an auditCleared row with the localized kind label", async () => {
+    listMock.mockResolvedValueOnce({
+      events: [
+        {
+          kind: "auditCleared",
+          timestamp: "2026-05-17T12:00:00.000Z",
+        },
+      ],
+      degraded: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    const row = await screen.findByRole("listitem");
+    expect(row.getAttribute("data-kind")).toBe("auditCleared");
+    expect(row.textContent).toContain("audit.kind.auditCleared");
   });
 
   it("renders the loadError state when the backend fails", async () => {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -664,6 +664,14 @@ export const audit = {
     });
     return AuditEventsResponseSchema.parse(result);
   },
+
+  /// Truncates the per-Vault audit log and leaves behind a single
+  /// `auditCleared` event so the wipe shows up in the panel. The backend
+  /// rewrites the file atomically, so on failure the original log is
+  /// preserved and this rejects with the backend error.
+  async clear(vaultPath: string): Promise<void> {
+    await invoke("clear_audit_log", { vaultPath });
+  },
 };
 
 export const windowProtection = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -336,6 +336,7 @@ export const AuditEventKindSchema = z.enum([
   "entryPasswordRevealed",
   "entryPasswordCopied",
   "entryProtectedFieldRevealed",
+  "auditCleared",
 ]);
 export type AuditEventKind = z.infer<typeof AuditEventKindSchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -18,6 +18,35 @@
   "clipboard": {
     "countdown": "Zwischenablage wird in {{seconds}}s gelöscht"
   },
+  "audit": {
+    "title": "Audit-Protokoll",
+    "description": "Sicherheitsrelevante Ereignisse, die auf diesem Gerät für den aktuell geöffneten Tresor aufgezeichnet wurden.",
+    "empty": "Noch keine Audit-Ereignisse für diesen Tresor.",
+    "emptyNoVault": "Öffnen Sie einen Tresor, um sein Audit-Protokoll zu sehen.",
+    "loadError": "Audit-Ereignisse konnten nicht geladen werden: {{error}}",
+    "degradedWarning": "Das Audit-Subsystem hat in dieser Sitzung einen oder mehrere interne Fehler gemeldet. Einige Ereignisse fehlen möglicherweise.",
+    "attemptCount_one": "Versuch {{count}}",
+    "attemptCount_other": "Versuch {{count}}",
+    "kind": {
+      "vaultUnlockFailed": "Fehlgeschlagener Entsperrversuch",
+      "vaultOpened": "Tresor geöffnet",
+      "vaultLocked": "Tresor gesperrt",
+      "entryPasswordRevealed": "Passwort angezeigt",
+      "entryPasswordCopied": "Passwort kopiert",
+      "entryProtectedFieldRevealed": "Geschütztes Feld angezeigt",
+      "auditCleared": "Audit-Protokoll geleert"
+    },
+    "reason": {
+      "manual": "Manuell",
+      "autoLock": "Auto-Sperre",
+      "appQuit": "App beendet",
+      "screenLock": "Bildschirmsperre"
+    },
+    "clearButton": "Audit-Protokoll leeren",
+    "clearConfirmTitle": "Audit-Protokoll leeren?",
+    "clearConfirm": "Dies löscht alle für den geöffneten Tresor auf diesem Gerät aufgezeichneten Audit-Ereignisse. Ein einzelner \"Audit-Protokoll geleert\"-Eintrag bleibt erhalten, damit die Löschung sichtbar ist.",
+    "clearError": "Audit-Protokoll konnte nicht geleert werden: {{error}}"
+  },
   "settings": {
     "title": "Einstellungen",
     "description": "Anwendungseinstellungen und Datenbankkonfiguration.",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -33,14 +33,19 @@
       "vaultLocked": "Vault locked",
       "entryPasswordRevealed": "Password revealed",
       "entryPasswordCopied": "Password copied",
-      "entryProtectedFieldRevealed": "Protected field revealed"
+      "entryProtectedFieldRevealed": "Protected field revealed",
+      "auditCleared": "Audit log cleared"
     },
     "reason": {
       "manual": "Manual",
       "autoLock": "Auto-lock",
       "appQuit": "App quit",
       "screenLock": "Screen lock"
-    }
+    },
+    "clearButton": "Clear audit log",
+    "clearConfirmTitle": "Clear audit log?",
+    "clearConfirm": "This deletes every audit event recorded on this device for the open vault. A single \"Audit log cleared\" entry will remain so the wipe is visible.",
+    "clearError": "Failed to clear audit log: {{error}}"
   },
   "settings": {
     "title": "Settings",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -18,6 +18,35 @@
   "clipboard": {
     "countdown": "El portapapeles se limpia en {{seconds}}s"
   },
+  "audit": {
+    "title": "Registro de auditoría",
+    "description": "Eventos relevantes para la seguridad registrados en este dispositivo para la bóveda actualmente abierta.",
+    "empty": "Aún no hay eventos de auditoría para esta bóveda.",
+    "emptyNoVault": "Abra una bóveda para ver su registro de auditoría.",
+    "loadError": "Error al cargar los eventos de auditoría: {{error}}",
+    "degradedWarning": "El subsistema de auditoría ha informado de uno o más fallos internos esta sesión. Puede que falten algunos eventos.",
+    "attemptCount_one": "Intento {{count}}",
+    "attemptCount_other": "Intento {{count}}",
+    "kind": {
+      "vaultUnlockFailed": "Intento de desbloqueo fallido",
+      "vaultOpened": "Bóveda abierta",
+      "vaultLocked": "Bóveda bloqueada",
+      "entryPasswordRevealed": "Contraseña revelada",
+      "entryPasswordCopied": "Contraseña copiada",
+      "entryProtectedFieldRevealed": "Campo protegido revelado",
+      "auditCleared": "Registro de auditoría borrado"
+    },
+    "reason": {
+      "manual": "Manual",
+      "autoLock": "Auto-bloqueo",
+      "appQuit": "App cerrada",
+      "screenLock": "Bloqueo de pantalla"
+    },
+    "clearButton": "Borrar registro de auditoría",
+    "clearConfirmTitle": "¿Borrar registro de auditoría?",
+    "clearConfirm": "Esto elimina todos los eventos de auditoría registrados en este dispositivo para la bóveda abierta. Quedará una sola entrada \"Registro de auditoría borrado\" para que el borrado sea visible.",
+    "clearError": "Error al borrar el registro de auditoría: {{error}}"
+  },
   "settings": {
     "title": "Configuración",
     "description": "Preferencias de la aplicación y configuración de la base de datos.",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -18,6 +18,35 @@
   "clipboard": {
     "countdown": "Le presse-papiers s'efface dans {{seconds}}s"
   },
+  "audit": {
+    "title": "Journal d'audit",
+    "description": "Événements liés à la sécurité enregistrés sur cet appareil pour le coffre actuellement ouvert.",
+    "empty": "Aucun événement d'audit pour ce coffre.",
+    "emptyNoVault": "Ouvrez un coffre pour voir son journal d'audit.",
+    "loadError": "Échec du chargement des événements d'audit : {{error}}",
+    "degradedWarning": "Le sous-système d'audit a signalé une ou plusieurs erreurs internes durant cette session. Certains événements peuvent manquer.",
+    "attemptCount_one": "Tentative {{count}}",
+    "attemptCount_other": "Tentative {{count}}",
+    "kind": {
+      "vaultUnlockFailed": "Tentative de déverrouillage échouée",
+      "vaultOpened": "Coffre ouvert",
+      "vaultLocked": "Coffre verrouillé",
+      "entryPasswordRevealed": "Mot de passe affiché",
+      "entryPasswordCopied": "Mot de passe copié",
+      "entryProtectedFieldRevealed": "Champ protégé affiché",
+      "auditCleared": "Journal d'audit effacé"
+    },
+    "reason": {
+      "manual": "Manuel",
+      "autoLock": "Verrouillage automatique",
+      "appQuit": "Quitter l'application",
+      "screenLock": "Verrouillage d'écran"
+    },
+    "clearButton": "Effacer le journal d'audit",
+    "clearConfirmTitle": "Effacer le journal d'audit ?",
+    "clearConfirm": "Cela supprime tous les événements d'audit enregistrés sur cet appareil pour le coffre ouvert. Une seule entrée « Journal d'audit effacé » sera conservée pour que l'effacement reste visible.",
+    "clearError": "Échec de l'effacement du journal d'audit : {{error}}"
+  },
   "settings": {
     "title": "Paramètres",
     "description": "Préférences de l'application et configuration de la base de données.",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -18,6 +18,35 @@
   "clipboard": {
     "countdown": "Privremena memorija se briše za {{seconds}}s"
   },
+  "audit": {
+    "title": "Dnevnik nadzora",
+    "description": "Bezbednosno značajni događaji zabeleženi na ovom uređaju za trenutno otvoreni sef.",
+    "empty": "Još uvek nema događaja nadzora za ovaj sef.",
+    "emptyNoVault": "Otvorite sef da biste videli njegov dnevnik nadzora.",
+    "loadError": "Učitavanje događaja nadzora nije uspelo: {{error}}",
+    "degradedWarning": "Podsistem nadzora prijavio je jednu ili više internih grešaka u ovoj sesiji. Neki događaji možda nedostaju.",
+    "attemptCount_one": "Pokušaj {{count}}",
+    "attemptCount_other": "Pokušaj {{count}}",
+    "kind": {
+      "vaultUnlockFailed": "Neuspeo pokušaj otključavanja",
+      "vaultOpened": "Sef otvoren",
+      "vaultLocked": "Sef zaključan",
+      "entryPasswordRevealed": "Lozinka prikazana",
+      "entryPasswordCopied": "Lozinka kopirana",
+      "entryProtectedFieldRevealed": "Zaštićeno polje prikazano",
+      "auditCleared": "Dnevnik nadzora obrisan"
+    },
+    "reason": {
+      "manual": "Ručno",
+      "autoLock": "Automatsko zaključavanje",
+      "appQuit": "Zatvaranje aplikacije",
+      "screenLock": "Zaključavanje ekrana"
+    },
+    "clearButton": "Obriši dnevnik nadzora",
+    "clearConfirmTitle": "Obrisati dnevnik nadzora?",
+    "clearConfirm": "Ovo briše sve događaje nadzora zabeležene na ovom uređaju za otvoreni sef. Ostaje samo jedan unos „Dnevnik nadzora obrisan\" kako bi brisanje bilo vidljivo.",
+    "clearError": "Brisanje dnevnika nadzora nije uspelo: {{error}}"
+  },
   "settings": {
     "title": "Podešavanja",
     "description": "Podešavanja aplikacije i konfiguracija baze podataka.",


### PR DESCRIPTION
Closes #220.

## Summary
- Adds `AuditService::clear(vault_path)` that wipes the per-Vault log and leaves behind exactly one `audit.cleared` event so a manual clear is never silent. Storage performs the rewrite atomically (temp file + rename under exclusive advisory lock) so a mid-write failure preserves the original file.
- Exposes `clear_audit_log` over IPC; surfaces hard errors as `AppError::AuditClear` (asymmetric from infallible `AuditService::record` — user-initiated wipes must visibly fail rather than silently flip `degraded`).
- Settings → Audit Log grows a destructive "Clear audit log" button; click → `ask()` confirm → call → invalidate query → re-render with the surviving `auditCleared` row. Failures toast via `sonner`.

## Test plan
- [x] `cargo test --lib` (232 pass) — new tests:
  - `format::tests::audit_cleared_round_trips_with_dotted_kind` (wire tag pinned to `audit.cleared`)
  - `storage::tests::replace_with_single_leaves_exactly_one_frame`
  - `storage::tests::replace_with_single_on_missing_file_creates_file_with_that_frame`
  - `service::tests::clear_replaces_history_with_single_audit_cleared_event` (AC #6 integration)
  - `service::tests::clear_on_empty_vault_writes_audit_cleared_event`
  - `service::tests::clear_against_unwritable_dir_returns_error`
  - `dto::audit::tests::audit_cleared_event_converts_to_dto_with_camel_case_kind`
- [x] `cargo clippy --lib --tests --no-deps -- -D warnings` clean, `cargo fmt --check` clean
- [x] `bun run test` (47 files / 393 tests pass) — new `AuditLogSection` tests cover button visibility, confirm-dismiss, success+refetch, error-toast leaves panel intact, `auditCleared` row rendering
- [x] `bun run lint` / `bun run format:check` clean
- [x] Manual: open vault → Settings → Audit Log → confirm dialog → file ends with one `audit.cleared` line; panel shows one row; localised label "Audit log cleared" renders
- [x] Manual: clear with disk-full / read-only base dir → error toast, original log untouched

## Acceptance criteria
- [x] `AuditEventKind` extended with `audit.cleared`; format round-trips it
- [x] `AuditService::clear(vault_id)` holds the exclusive file lock for the whole operation
- [x] `clear_audit_log(vault_path)` IPC command
- [x] `audit.clear(vaultPath)` exposed in `lib/tauri.ts`
- [x] Settings panel "Clear Audit Log" button + `ask()` confirmation
- [x] Integration test populate → clear → read returns one `audit.cleared`
- [x] Mid-clear failure preserves original (atomicity via temp file + rename)
- [x] i18n keys under `audit.*` in `src/locales/en/common.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)