### PR TITLE
feat(core,ui): audit log records preferences.security_changed for allowlisted keys (#221)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,8 +3,9 @@
 use crate::dto::error::AppError;
 use crate::services::audit::AuditService;
 use crate::services::kdbx::KdbxService;
-use crate::services::settings::SettingsService;
+use crate::services::settings::{diff_security_changes, SettingsService};
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::sync::Arc;
 use tauri::State;
 
@@ -396,6 +397,28 @@ pub async fn get_app_preferences(
     settings_service.get_app_preferences()
 }
 
+/// Fans changed allowlisted leaves out across every currently-open Vault,
+/// emitting one `preferences.security_changed` audit record per
+/// (vault, leaf) pair. Extracted from `update_app_preferences` so the
+/// fan-out logic can be unit-tested without a Tauri runtime.
+///
+/// The audit log is per-Vault (one file per canonicalized vault path),
+/// while preferences are global — a flip therefore has to land in each
+/// open Vault's log to surface in the Audit Log panel. When no Vault is
+/// open the call is a no-op: the preference flip still persists, but
+/// there is no per-Vault log to write to.
+pub(crate) fn fan_out_security_changes(
+    audit_service: &AuditService,
+    open_vault_paths: &[String],
+    changed_leaves: &[&'static str],
+) {
+    for path in open_vault_paths {
+        for leaf in changed_leaves {
+            audit_service.record_preferences_security_changed(Path::new(path), leaf);
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn update_app_preferences(
     new_preferences: AppPreferences,
@@ -403,9 +426,19 @@ pub async fn update_app_preferences(
     kdbx_service: State<'_, Arc<KdbxService>>,
     audit_service: State<'_, Arc<AuditService>>,
 ) -> Result<(), AppError> {
+    let old_preferences = settings_service.get_app_preferences()?;
     settings_service.update_app_preferences(&new_preferences)?;
-    kdbx_service.set_backup_settings(new_preferences.backups)?;
+    kdbx_service.set_backup_settings(new_preferences.backups.clone())?;
     audit_service.set_enabled(new_preferences.audit.enabled);
+
+    let changed_leaves = diff_security_changes(&old_preferences, &new_preferences);
+    if !changed_leaves.is_empty() {
+        let open_paths: Vec<String> = kdbx_service
+            .list_open_databases()
+            .map(|dbs| dbs.into_iter().map(|d| d.path).collect())
+            .unwrap_or_default();
+        fan_out_security_changes(&audit_service, &open_paths, &changed_leaves);
+    }
     Ok(())
 }
 
@@ -462,4 +495,85 @@ pub async fn clear_recent_databases(
     settings_service: State<'_, Arc<SettingsService>>,
 ) -> Result<(), AppError> {
     settings_service.clear_recent_databases()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod fan_out_security_changes_tests {
+    use super::fan_out_security_changes;
+    use crate::services::audit::format::AuditEvent;
+    use crate::services::audit::key::InMemoryAuditKey;
+    use crate::services::audit::{AuditFilter, AuditService};
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    /// AC: each (open vault × changed leaf) pair produces exactly one
+    /// `preferences.security_changed` record. Two opens × two leaves
+    /// must land four records (two per file), and each leaf must reach
+    /// each vault — proves the fan-out is the cartesian product, not a
+    /// per-call-once shortcut.
+    #[test]
+    fn each_vault_gets_one_event_per_leaf() {
+        let dir = tempdir().expect("tempdir");
+        let vault_a = dir.path().join("a.kdbx");
+        let vault_b = dir.path().join("b.kdbx");
+        std::fs::write(&vault_a, b"a").expect("write a");
+        std::fs::write(&vault_b, b"b").expect("write b");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+
+        let opens = vec![
+            vault_a.to_string_lossy().into_owned(),
+            vault_b.to_string_lossy().into_owned(),
+        ];
+        let leaves = ["security.preventScreenCapture", "audit.retentionDays"];
+        fan_out_security_changes(&service, &opens, &leaves);
+
+        for vault in [&vault_a, &vault_b] {
+            let events = service.read(vault, &AuditFilter::default()).expect("read");
+            assert_eq!(events.len(), 2, "two leaves => two events per vault");
+            let names: Vec<&str> = events
+                .iter()
+                .map(|e| match e {
+                    AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                        setting_name.as_str()
+                    }
+                    other => panic!("unexpected variant: {other:?}"),
+                })
+                .collect();
+            assert!(names.contains(&"security.preventScreenCapture"));
+            assert!(names.contains(&"audit.retentionDays"));
+        }
+    }
+
+    /// When no Vault is open, the preference flip still persists but
+    /// nothing reaches the audit log. Pin the no-op explicitly so a
+    /// future change can't quietly start writing to a global file (the
+    /// ADR rejects a global single-stream log on privacy grounds).
+    #[test]
+    fn empty_open_vault_list_is_a_no_op() {
+        let dir = tempdir().expect("tempdir");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+        fan_out_security_changes(&service, &[], &["security.preventScreenCapture"]);
+        assert!(!service.is_degraded());
+        // No vault file should have been created under the audit dir.
+        // tempdir() left it nonexistent, so any creation here would be loud.
+        assert!(!dir.path().join("audit").exists());
+    }
+
+    /// Empty leaf set with N open vaults is also a no-op — happens on
+    /// every preference save where nothing audited changed (e.g. font
+    /// size edit). Must not touch the per-Vault log files.
+    #[test]
+    fn empty_leaf_list_is_a_no_op() {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("v.kdbx");
+        std::fs::write(&vault, b"v").expect("write");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+        fan_out_security_changes(&service, &[vault.to_string_lossy().into_owned()], &[]);
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert!(events.is_empty());
+    }
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -419,34 +419,37 @@ pub(crate) fn fan_out_security_changes(
     }
 }
 
-/// Diffs `old` vs `new` preferences, records each allowlisted leaf
-/// against every open Vault, and only THEN applies the new audit gate.
+/// Diffs `old` vs `new` preferences, applies the new audit gate, and
+/// force-writes one `preferences.security_changed` event per allowlisted
+/// leaf that changed against every open Vault.
 ///
-/// The audit log's master gate (`AuditService::set_enabled`) makes
-/// `record` a no-op when off. Naively setting the new state first would
-/// drop a true→false disable event; naively setting it last would drop
-/// a false→true enable event. Both transitions are themselves audited
-/// allowlist leaves, so neither can be silently swallowed.
+/// Ordering is deliberate. The master gate is set FIRST so any
+/// concurrent producer sharing this `AuditService` (entry reveals,
+/// failed unlocks, vault locks, …) immediately reflects the user's
+/// persisted intent — a previous version of this helper transiently
+/// flipped the gate on around the fan-out to capture the transition
+/// itself, but that reopened logging process-wide and let unrelated
+/// concurrent events slip into the disabled-by-the-user log.
 ///
-/// To capture the transition itself: when there are changes to record
-/// AND logging is on at either the old or the new end, the gate is
-/// briefly forced on for the duration of the fan-out, then the final
-/// state from `new.audit.enabled` is applied. When logging is off at
-/// both ends, the user has consistently opted out — nothing is
-/// recorded, respecting that intent.
+/// The transition events themselves go through
+/// [`AuditService::record_preferences_security_changed`], which
+/// force-writes around the gate. That captures both the true→false
+/// disable and false→true enable cases without ever widening the gate.
+///
+/// When logging is off at BOTH ends of the transition, the user has
+/// consistently opted out — nothing is recorded, respecting that intent.
 pub(crate) fn apply_preference_security_audit(
     audit_service: &AuditService,
     open_vault_paths: &[String],
     old: &AppPreferences,
     new: &AppPreferences,
 ) {
+    audit_service.set_enabled(new.audit.enabled);
     let changed_leaves = diff_security_changes(old, new);
     let should_record = !changed_leaves.is_empty() && (old.audit.enabled || new.audit.enabled);
     if should_record {
-        audit_service.set_enabled(true);
         fan_out_security_changes(audit_service, open_vault_paths, &changed_leaves);
     }
-    audit_service.set_enabled(new.audit.enabled);
 }
 
 fn open_vault_paths(kdbx_service: &KdbxService) -> Vec<String> {
@@ -701,12 +704,65 @@ mod fan_out_security_changes_tests {
         assert!(service.is_enabled(), "gate must end up matching new state");
     }
 
+    /// Follow-up review finding on #221: the prior fix forced the
+    /// master gate on around the fan-out, which let unrelated
+    /// concurrent producers (sharing this `AuditService`) slip events
+    /// through the transition window. The corrected design routes
+    /// preference-transition events through a force-write path and
+    /// leaves the gate strictly tracking `new.audit.enabled`. Pin
+    /// that invariant: across a disable transition, the gate must be
+    /// off the moment `apply_preference_security_audit` returns —
+    /// AND `is_enabled()` reporting it being off mid-call must imply
+    /// no transient flip happened. We assert the end-state here and
+    /// rely on the service-level `record_preferences_security_changed_bypasses_the_master_gate`
+    /// test to pin that the fan-out itself doesn't touch the gate.
+    #[test]
+    fn disable_transition_never_transiently_widens_the_gate() {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("v.kdbx");
+        std::fs::write(&vault, b"v").expect("write vault");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+
+        let defaults = AppPreferences::default(); // audit enabled
+        let new = AppPreferences {
+            audit: AuditSettings {
+                enabled: false,
+                ..defaults.audit
+            },
+            ..defaults.clone()
+        };
+
+        let opens = vec![vault.to_string_lossy().into_owned()];
+        apply_preference_security_audit(&service, &opens, &defaults, &new);
+
+        // Final state: gate off (persisted user intent applied).
+        assert!(
+            !service.is_enabled(),
+            "gate must reflect new.audit.enabled after the call"
+        );
+        // And the disable event itself was captured via force-write.
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        let names: Vec<&str> = events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                    setting_name.as_str()
+                }
+                other => panic!("unexpected variant: {other:?}"),
+            })
+            .collect();
+        assert!(
+            names.contains(&"audit.enabled"),
+            "disable event must be captured, got: {names:?}"
+        );
+    }
+
     /// When logging is off at BOTH ends of the transition, the user has
     /// consistently opted out — even an allowlisted change like
     /// `preventScreenCapture` must not write to disk. This pins the
-    /// privacy contract: a disabled audit log stays disabled, the
-    /// briefly-forced-on window around real transitions does not leak
-    /// into pure-disabled saves.
+    /// privacy contract: a disabled audit log stays disabled, and no
+    /// transient gate-widening leaks into pure-disabled saves.
     #[test]
     fn disabled_at_both_ends_records_nothing_even_when_other_leaves_change() {
         let dir = tempdir().expect("tempdir");

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -419,6 +419,37 @@ pub(crate) fn fan_out_security_changes(
     }
 }
 
+/// Diffs `old` vs `new` preferences, records each allowlisted leaf
+/// against every open Vault, and only THEN applies the new audit gate.
+/// The ordering is load-bearing: if `set_enabled(new.audit.enabled)`
+/// ran first, a true→false flip would short-circuit inside
+/// `AuditService::record` and silently swallow the disable action (and
+/// any other allowlisted flip submitted in the same call).
+///
+/// Asymmetric corner: a false→true flip records under the still-off
+/// gate, so the enable event itself is not captured. Subsequent
+/// changes are captured because the gate is on by the time the next
+/// call returns — acceptable for an opt-in transition.
+pub(crate) fn apply_preference_security_audit(
+    audit_service: &AuditService,
+    open_vault_paths: &[String],
+    old: &AppPreferences,
+    new: &AppPreferences,
+) {
+    let changed_leaves = diff_security_changes(old, new);
+    if !changed_leaves.is_empty() {
+        fan_out_security_changes(audit_service, open_vault_paths, &changed_leaves);
+    }
+    audit_service.set_enabled(new.audit.enabled);
+}
+
+fn open_vault_paths(kdbx_service: &KdbxService) -> Vec<String> {
+    kdbx_service
+        .list_open_databases()
+        .map(|dbs| dbs.into_iter().map(|d| d.path).collect())
+        .unwrap_or_default()
+}
+
 #[tauri::command]
 pub async fn update_app_preferences(
     new_preferences: AppPreferences,
@@ -429,16 +460,14 @@ pub async fn update_app_preferences(
     let old_preferences = settings_service.get_app_preferences()?;
     settings_service.update_app_preferences(&new_preferences)?;
     kdbx_service.set_backup_settings(new_preferences.backups.clone())?;
-    audit_service.set_enabled(new_preferences.audit.enabled);
 
-    let changed_leaves = diff_security_changes(&old_preferences, &new_preferences);
-    if !changed_leaves.is_empty() {
-        let open_paths: Vec<String> = kdbx_service
-            .list_open_databases()
-            .map(|dbs| dbs.into_iter().map(|d| d.path).collect())
-            .unwrap_or_default();
-        fan_out_security_changes(&audit_service, &open_paths, &changed_leaves);
-    }
+    let open_paths = open_vault_paths(&kdbx_service);
+    apply_preference_security_audit(
+        &audit_service,
+        &open_paths,
+        &old_preferences,
+        &new_preferences,
+    );
     Ok(())
 }
 
@@ -448,9 +477,16 @@ pub async fn reset_app_preferences(
     kdbx_service: State<'_, Arc<KdbxService>>,
     audit_service: State<'_, Arc<AuditService>>,
 ) -> Result<AppPreferences, AppError> {
+    // Snapshot the pre-reset preferences so the diff/fan-out can emit
+    // a `preferences.security_changed` event for every allowlisted
+    // leaf that the reset is about to overwrite — otherwise resetting
+    // from non-default values would silently change those settings.
+    let old_preferences = settings_service.get_app_preferences()?;
     let prefs = settings_service.reset_app_preferences()?;
     kdbx_service.set_backup_settings(prefs.backups.clone())?;
-    audit_service.set_enabled(prefs.audit.enabled);
+
+    let open_paths = open_vault_paths(&kdbx_service);
+    apply_preference_security_audit(&audit_service, &open_paths, &old_preferences, &prefs);
     Ok(prefs)
 }
 
@@ -500,7 +536,8 @@ pub async fn clear_recent_databases(
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
 mod fan_out_security_changes_tests {
-    use super::fan_out_security_changes;
+    use super::{apply_preference_security_audit, fan_out_security_changes, AppPreferences};
+    use crate::commands::settings::AuditSettings;
     use crate::services::audit::format::AuditEvent;
     use crate::services::audit::key::InMemoryAuditKey;
     use crate::services::audit::{AuditFilter, AuditService};
@@ -560,6 +597,139 @@ mod fan_out_security_changes_tests {
         // No vault file should have been created under the audit dir.
         // tempdir() left it nonexistent, so any creation here would be loud.
         assert!(!dir.path().join("audit").exists());
+    }
+
+    /// Regression for the P1 review finding on #221: disabling audit
+    /// logging in the same submit as another allowlisted flip must NOT
+    /// suppress its own `audit.enabled` record. If we flipped the gate
+    /// off before fanning out, every event in this submit (including
+    /// the disable action itself) would short-circuit inside
+    /// `AuditService::record` and the disable would happen silently.
+    #[test]
+    fn disabling_audit_in_one_submit_still_records_audit_enabled_event() {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("v.kdbx");
+        std::fs::write(&vault, b"v").expect("write vault");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+        // Old prefs: audit enabled (the realistic starting state).
+        let old = AppPreferences::default();
+        // New prefs: audit disabled + screen-capture toggle flipped.
+        let new = AppPreferences {
+            audit: AuditSettings {
+                enabled: false,
+                ..old.audit.clone()
+            },
+            security: crate::commands::settings::SecuritySettings {
+                prevent_screen_capture: !old.security.prevent_screen_capture,
+                ..old.security.clone()
+            },
+            ..old.clone()
+        };
+
+        let opens = vec![vault.to_string_lossy().into_owned()];
+        apply_preference_security_audit(&service, &opens, &old, &new);
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        let names: Vec<&str> = events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                    setting_name.as_str()
+                }
+                other => panic!("unexpected variant: {other:?}"),
+            })
+            .collect();
+        assert!(
+            names.contains(&"audit.enabled"),
+            "audit.enabled disable must be recorded, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"security.preventScreenCapture"),
+            "co-submitted flip must also be recorded, got: {names:?}"
+        );
+        // Final gate state matches the new preferences.
+        assert!(!service.is_enabled());
+    }
+
+    /// Enabling audit from a previously-disabled state lands in the
+    /// asymmetric corner that the P1 fix intentionally accepts: the
+    /// enable event itself is lost (recorded under the old, disabled
+    /// gate), but subsequent flips record. We pin that the gate ends
+    /// up on so the next change reaches the log.
+    #[test]
+    fn enabling_audit_from_disabled_leaves_gate_on_for_future_records() {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("v.kdbx");
+        std::fs::write(&vault, b"v").expect("write vault");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+        service.set_enabled(false);
+
+        let old = AppPreferences {
+            audit: AuditSettings {
+                enabled: false,
+                ..AppPreferences::default().audit
+            },
+            ..AppPreferences::default()
+        };
+        let new = AppPreferences::default(); // audit.enabled = true
+
+        let opens = vec![vault.to_string_lossy().into_owned()];
+        apply_preference_security_audit(&service, &opens, &old, &new);
+
+        assert!(service.is_enabled(), "gate must end up matching new state");
+    }
+
+    /// Regression for the P2 review finding on #221: resetting from
+    /// non-default values for any allowlisted leaf must emit one
+    /// `preferences.security_changed` record per changed leaf, just
+    /// like an in-place update would.
+    #[test]
+    fn reset_from_non_default_values_emits_security_change_records() {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("v.kdbx");
+        std::fs::write(&vault, b"v").expect("write vault");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+
+        let defaults = AppPreferences::default();
+        // Pre-reset preferences: flip several allowlisted leaves away
+        // from defaults so the reset has something to record.
+        let old = AppPreferences {
+            security: crate::commands::settings::SecuritySettings {
+                prevent_screen_capture: !defaults.security.prevent_screen_capture,
+                auto_download_favicons: !defaults.security.auto_download_favicons,
+                ..defaults.security.clone()
+            },
+            audit: AuditSettings {
+                enabled: !defaults.audit.enabled,
+                retention_days: defaults.audit.retention_days.saturating_add(7),
+            },
+            ..defaults.clone()
+        };
+
+        let opens = vec![vault.to_string_lossy().into_owned()];
+        apply_preference_security_audit(&service, &opens, &old, &defaults);
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        let names: std::collections::HashSet<&str> = events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                    setting_name.as_str()
+                }
+                other => panic!("unexpected variant: {other:?}"),
+            })
+            .collect();
+        for want in [
+            "security.preventScreenCapture",
+            "security.autoDownloadFavicons",
+            "audit.enabled",
+            "audit.retentionDays",
+        ] {
+            assert!(names.contains(want), "missing {want} in {names:?}");
+        }
     }
 
     /// Empty leaf set with N open vaults is also a no-op — happens on

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -421,15 +421,19 @@ pub(crate) fn fan_out_security_changes(
 
 /// Diffs `old` vs `new` preferences, records each allowlisted leaf
 /// against every open Vault, and only THEN applies the new audit gate.
-/// The ordering is load-bearing: if `set_enabled(new.audit.enabled)`
-/// ran first, a true→false flip would short-circuit inside
-/// `AuditService::record` and silently swallow the disable action (and
-/// any other allowlisted flip submitted in the same call).
 ///
-/// Asymmetric corner: a false→true flip records under the still-off
-/// gate, so the enable event itself is not captured. Subsequent
-/// changes are captured because the gate is on by the time the next
-/// call returns — acceptable for an opt-in transition.
+/// The audit log's master gate (`AuditService::set_enabled`) makes
+/// `record` a no-op when off. Naively setting the new state first would
+/// drop a true→false disable event; naively setting it last would drop
+/// a false→true enable event. Both transitions are themselves audited
+/// allowlist leaves, so neither can be silently swallowed.
+///
+/// To capture the transition itself: when there are changes to record
+/// AND logging is on at either the old or the new end, the gate is
+/// briefly forced on for the duration of the fan-out, then the final
+/// state from `new.audit.enabled` is applied. When logging is off at
+/// both ends, the user has consistently opted out — nothing is
+/// recorded, respecting that intent.
 pub(crate) fn apply_preference_security_audit(
     audit_service: &AuditService,
     open_vault_paths: &[String],
@@ -437,7 +441,9 @@ pub(crate) fn apply_preference_security_audit(
     new: &AppPreferences,
 ) {
     let changed_leaves = diff_security_changes(old, new);
-    if !changed_leaves.is_empty() {
+    let should_record = !changed_leaves.is_empty() && (old.audit.enabled || new.audit.enabled);
+    if should_record {
+        audit_service.set_enabled(true);
         fan_out_security_changes(audit_service, open_vault_paths, &changed_leaves);
     }
     audit_service.set_enabled(new.audit.enabled);
@@ -652,13 +658,13 @@ mod fan_out_security_changes_tests {
         assert!(!service.is_enabled());
     }
 
-    /// Enabling audit from a previously-disabled state lands in the
-    /// asymmetric corner that the P1 fix intentionally accepts: the
-    /// enable event itself is lost (recorded under the old, disabled
-    /// gate), but subsequent flips record. We pin that the gate ends
-    /// up on so the next change reaches the log.
+    /// Follow-up review finding on #221: a false→true `audit.enabled`
+    /// flip must also be recorded. The helper briefly forces the gate
+    /// on around the fan-out so the enable event is captured under
+    /// "logging on," even though logging was off at the start of the
+    /// call.
     #[test]
-    fn enabling_audit_from_disabled_leaves_gate_on_for_future_records() {
+    fn enabling_audit_from_disabled_records_the_enable_event() {
         let dir = tempdir().expect("tempdir");
         let vault = dir.path().join("v.kdbx");
         std::fs::write(&vault, b"v").expect("write vault");
@@ -678,7 +684,71 @@ mod fan_out_security_changes_tests {
         let opens = vec![vault.to_string_lossy().into_owned()];
         apply_preference_security_audit(&service, &opens, &old, &new);
 
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        let names: Vec<&str> = events
+            .iter()
+            .map(|e| match e {
+                AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                    setting_name.as_str()
+                }
+                other => panic!("unexpected variant: {other:?}"),
+            })
+            .collect();
+        assert!(
+            names.contains(&"audit.enabled"),
+            "audit.enabled enable must be recorded, got: {names:?}"
+        );
         assert!(service.is_enabled(), "gate must end up matching new state");
+    }
+
+    /// When logging is off at BOTH ends of the transition, the user has
+    /// consistently opted out — even an allowlisted change like
+    /// `preventScreenCapture` must not write to disk. This pins the
+    /// privacy contract: a disabled audit log stays disabled, the
+    /// briefly-forced-on window around real transitions does not leak
+    /// into pure-disabled saves.
+    #[test]
+    fn disabled_at_both_ends_records_nothing_even_when_other_leaves_change() {
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("v.kdbx");
+        std::fs::write(&vault, b"v").expect("write vault");
+        let service =
+            AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+        service.set_enabled(false);
+
+        let defaults = AppPreferences::default();
+        let old = AppPreferences {
+            audit: AuditSettings {
+                enabled: false,
+                ..defaults.audit
+            },
+            ..defaults.clone()
+        };
+        let new = AppPreferences {
+            audit: AuditSettings {
+                enabled: false,
+                ..defaults.audit
+            },
+            security: crate::commands::settings::SecuritySettings {
+                prevent_screen_capture: !defaults.security.prevent_screen_capture,
+                ..defaults.security.clone()
+            },
+            ..defaults.clone()
+        };
+
+        let opens = vec![vault.to_string_lossy().into_owned()];
+        apply_preference_security_audit(&service, &opens, &old, &new);
+
+        // read() returns Ok([]) when no log file exists for this vault.
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert!(
+            events.is_empty(),
+            "no events must be recorded when audit is off at both ends, got: {events:?}"
+        );
+        assert!(
+            !service.is_enabled(),
+            "gate must remain disabled after the call"
+        );
     }
 
     /// Regression for the P2 review finding on #221: resetting from

--- a/src-tauri/src/dto/audit.rs
+++ b/src-tauri/src/dto/audit.rs
@@ -18,6 +18,7 @@ pub enum AuditEventKindDto {
     EntryPasswordRevealed,
     EntryPasswordCopied,
     EntryProtectedFieldRevealed,
+    PreferencesSecurityChanged,
 }
 
 /// Why a Vault transitioned from unlocked to locked, mirrored from
@@ -57,6 +58,12 @@ pub struct AuditEventDto {
     /// on-disk log can never carry entry titles outside the Vault.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub entry_id: Option<String>,
+    /// Dot-pathed App Preference leaf (e.g. `security.preventScreenCapture`)
+    /// for `preferences.security_changed`. Old/new values are deliberately
+    /// not carried — the on-disk audit log records that a flip happened,
+    /// not what it flipped to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub setting_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -93,6 +100,7 @@ impl From<AuditEvent> for AuditEventDto {
                 attempt_count: Some(attempt_count),
                 reason: None,
                 entry_id: None,
+                setting_name: None,
             },
             AuditEvent::VaultOpened { timestamp } => Self {
                 kind: AuditEventKindDto::VaultOpened,
@@ -100,6 +108,7 @@ impl From<AuditEvent> for AuditEventDto {
                 attempt_count: None,
                 reason: None,
                 entry_id: None,
+                setting_name: None,
             },
             AuditEvent::VaultLocked { timestamp, reason } => Self {
                 kind: AuditEventKindDto::VaultLocked,
@@ -107,6 +116,18 @@ impl From<AuditEvent> for AuditEventDto {
                 attempt_count: None,
                 reason: Some(reason.into()),
                 entry_id: None,
+                setting_name: None,
+            },
+            AuditEvent::PreferencesSecurityChanged {
+                timestamp,
+                setting_name,
+            } => Self {
+                kind: AuditEventKindDto::PreferencesSecurityChanged,
+                timestamp,
+                attempt_count: None,
+                reason: None,
+                entry_id: None,
+                setting_name: Some(setting_name),
             },
             AuditEvent::EntryPasswordRevealed {
                 timestamp,
@@ -117,6 +138,7 @@ impl From<AuditEvent> for AuditEventDto {
                 attempt_count: None,
                 reason: None,
                 entry_id: Some(entry_id),
+                setting_name: None,
             },
             AuditEvent::EntryPasswordCopied {
                 timestamp,
@@ -127,6 +149,7 @@ impl From<AuditEvent> for AuditEventDto {
                 attempt_count: None,
                 reason: None,
                 entry_id: Some(entry_id),
+                setting_name: None,
             },
             AuditEvent::EntryProtectedFieldRevealed {
                 timestamp,
@@ -137,6 +160,7 @@ impl From<AuditEvent> for AuditEventDto {
                 attempt_count: None,
                 reason: None,
                 entry_id: Some(entry_id),
+                setting_name: None,
             },
         }
     }
@@ -156,6 +180,7 @@ mod tests {
             attempt_count: Some(2),
             reason: None,
             entry_id: None,
+            setting_name: None,
         };
         let json = serde_json::to_string(&dto).expect("ser");
         assert!(json.contains("\"vaultUnlockFailed\""));
@@ -245,6 +270,43 @@ mod tests {
         assert!(
             !json.contains("attemptCount"),
             "attemptCount must be omitted for entry kinds: {json}"
+        );
+    }
+
+    #[test]
+    fn preferences_security_changed_event_converts_to_dto_with_camel_case_kind_and_setting_name() {
+        let ts = Utc.with_ymd_and_hms(2026, 5, 17, 10, 0, 0).unwrap();
+        let dto: AuditEventDto = AuditEvent::PreferencesSecurityChanged {
+            timestamp: ts,
+            setting_name: "security.preventScreenCapture".to_string(),
+        }
+        .into();
+
+        assert!(matches!(
+            dto.kind,
+            AuditEventKindDto::PreferencesSecurityChanged
+        ));
+        assert_eq!(dto.timestamp, ts);
+        assert_eq!(
+            dto.setting_name.as_deref(),
+            Some("security.preventScreenCapture")
+        );
+        assert!(dto.entry_id.is_none());
+        assert!(dto.attempt_count.is_none());
+        assert!(dto.reason.is_none());
+
+        let json = serde_json::to_string(&dto).expect("ser");
+        assert!(
+            json.contains("\"preferencesSecurityChanged\""),
+            "kind must serialize as camelCase, got: {json}"
+        );
+        assert!(
+            json.contains("\"settingName\":\"security.preventScreenCapture\""),
+            "settingName must be camelCase on the wire, got: {json}"
+        );
+        assert!(
+            !json.contains("oldValue") && !json.contains("newValue"),
+            "no old/new values must reach the wire, got: {json}"
         );
     }
 

--- a/src-tauri/src/services/audit/format.rs
+++ b/src-tauri/src/services/audit/format.rs
@@ -46,6 +46,11 @@ pub enum AuditEvent {
         timestamp: DateTime<Utc>,
         entry_id: String,
     },
+    #[serde(rename = "preferences.security_changed")]
+    PreferencesSecurityChanged {
+        timestamp: DateTime<Utc>,
+        setting_name: String,
+    },
 }
 
 /// Why a Vault transitioned from unlocked to locked. Serialised as
@@ -216,6 +221,47 @@ mod tests {
         let json = String::from_utf8(event.to_bytes()).expect("utf8");
         assert!(json.contains("\"kind\":\"entry.protected_field_revealed\""));
         assert!(json.contains("\"entry_id\":\"uuid-3\""));
+    }
+
+    #[test]
+    fn preferences_security_changed_round_trips_with_setting_name() {
+        let event = AuditEvent::PreferencesSecurityChanged {
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 17, 9, 30, 0).unwrap(),
+            setting_name: "security.preventScreenCapture".to_string(),
+        };
+        let parsed = AuditEvent::from_bytes(&event.to_bytes()).expect("parse");
+        assert_eq!(parsed, event);
+
+        let json = String::from_utf8(event.to_bytes()).expect("utf8");
+        assert!(
+            json.contains("\"kind\":\"preferences.security_changed\""),
+            "kind must serialize dot-namespaced, got: {json}"
+        );
+        assert!(
+            json.contains("\"setting_name\":\"security.preventScreenCapture\""),
+            "setting_name must serialize verbatim, got: {json}"
+        );
+    }
+
+    /// The PRD is explicit: we record THAT a flip happened, not what it
+    /// flipped TO. Pin the wire contract — adding an old/new field later
+    /// has privacy consequences and must be a conscious decision, not a
+    /// stray refactor.
+    #[test]
+    fn preferences_security_changed_wire_omits_old_and_new_values() {
+        let event = AuditEvent::PreferencesSecurityChanged {
+            timestamp: Utc.with_ymd_and_hms(2026, 5, 17, 9, 30, 0).unwrap(),
+            setting_name: "security.preventScreenCapture".to_string(),
+        };
+        let json = String::from_utf8(event.to_bytes()).expect("utf8");
+        assert!(
+            !json.contains("old_value") && !json.contains("oldValue"),
+            "old value must never appear on the wire, got: {json}"
+        );
+        assert!(
+            !json.contains("new_value") && !json.contains("newValue"),
+            "new value must never appear on the wire, got: {json}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -269,12 +269,26 @@ impl AuditService {
     /// open Vault — the audit log is per-Vault, so a global preference
     /// change has to land in each open Vault's log to be visible from
     /// the Audit Log panel. Infallible by contract.
+    ///
+    /// Forced-write: bypasses the master `is_enabled()` gate because
+    /// this method's event IS the user's transition between gated and
+    /// ungated states. Going through [`AuditService::record`] would
+    /// lose the disable event the moment the new "off" state is
+    /// persisted; flipping the gate on process-wide for the duration
+    /// of the fan-out would let unrelated concurrent events (entry
+    /// reveals, failed unlocks, …) from other Tauri commands slip
+    /// through the same `AuditService`. The caller
+    /// (`commands::settings::apply_preference_security_audit`)
+    /// already gates whether to call us at all by looking at logging
+    /// state on both ends of the transition.
     pub fn record_preferences_security_changed(&self, vault_path: &Path, setting_name: &str) {
         let event = AuditEvent::PreferencesSecurityChanged {
             timestamp: Utc::now(),
             setting_name: setting_name.to_string(),
         };
-        self.record(vault_path, &event);
+        if self.try_record(vault_path, &event).is_err() {
+            self.degraded.store(true, Ordering::SeqCst);
+        }
     }
 
     /// Wipes the per-Vault audit log and leaves behind exactly one
@@ -565,6 +579,42 @@ mod tests {
             other => panic!("expected PreferencesSecurityChanged, got {other:?}"),
         }
         assert!(!service.is_degraded());
+    }
+
+    /// Follow-up review finding on #221: the preference-transition
+    /// event is itself the user's flip between gated and ungated
+    /// states. Routing it through the standard `record` gate would
+    /// lose the disable event (gate just flipped off); forcing the
+    /// gate on process-wide would leak unrelated concurrent events
+    /// from other Tauri commands. Force-write is the narrow fix.
+    /// The caller (`commands::settings::apply_preference_security_audit`)
+    /// gates "should we call this at all" using both ends of the
+    /// transition, so a user who has audit off at both ends still
+    /// records nothing.
+    #[test]
+    fn record_preferences_security_changed_bypasses_the_master_gate() {
+        let (service, _dir, vault) = fresh_service();
+        service.set_enabled(false);
+
+        service.record_preferences_security_changed(&vault, "audit.enabled");
+
+        // Bypass means the event landed in the log even with the gate off.
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                assert_eq!(setting_name, "audit.enabled");
+            }
+            other => panic!("expected PreferencesSecurityChanged, got {other:?}"),
+        }
+        // And — critically — the method must NOT have flipped the gate
+        // back on as a side effect. Any unrelated concurrent producer
+        // calling `record` right after this returns must still see the
+        // user's persisted "off" state.
+        assert!(
+            !service.is_enabled(),
+            "force-write must not flip the master gate"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -251,6 +251,20 @@ impl AuditService {
         self.record(vault_path, &event);
     }
 
+    /// Appends one `preferences.security_changed` event naming the App
+    /// Preference leaf that flipped. Called by the settings command once
+    /// per changed allowlisted leaf, fanned out across every currently-
+    /// open Vault — the audit log is per-Vault, so a global preference
+    /// change has to land in each open Vault's log to be visible from
+    /// the Audit Log panel. Infallible by contract.
+    pub fn record_preferences_security_changed(&self, vault_path: &Path, setting_name: &str) {
+        let event = AuditEvent::PreferencesSecurityChanged {
+            timestamp: Utc::now(),
+            setting_name: setting_name.to_string(),
+        };
+        self.record(vault_path, &event);
+    }
+
     /// Resets the per-Vault failed-unlock counter — called on successful
     /// open/unlock so the next failure starts the count back at 1.
     pub fn reset_unlock_attempts(&self, vault_path: &Path) {
@@ -494,6 +508,23 @@ mod tests {
                 assert_eq!(entry_id, "uuid-1");
             }
             other => panic!("expected EntryPasswordRevealed, got {other:?}"),
+        }
+        assert!(!service.is_degraded());
+    }
+
+    #[test]
+    fn record_preferences_security_changed_appends_exactly_one_event() {
+        let (service, _dir, vault) = fresh_service();
+
+        service.record_preferences_security_changed(&vault, "security.preventScreenCapture");
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            AuditEvent::PreferencesSecurityChanged { setting_name, .. } => {
+                assert_eq!(setting_name, "security.preventScreenCapture");
+            }
+            other => panic!("expected PreferencesSecurityChanged, got {other:?}"),
         }
         assert!(!service.is_degraded());
     }

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -225,6 +225,52 @@ impl SettingsService {
     }
 }
 
+/// Allowlisted App Preference leaves whose flips emit a
+/// `preferences.security_changed` audit event. Adding a key here is a
+/// one-line change; UI/preference changes (theme, language, layout) are
+/// deliberately excluded.
+///
+/// The lookup is a `(setting_name, did_change)` pair so each entry pins
+/// both the wire identifier (dot-pathed camelCase, matching the JSON
+/// shape of `AppPreferences` over IPC) and the equality check against
+/// the typed pref struct. Old/new values are never returned — the audit
+/// log records THAT a flip happened, not what it flipped to.
+type SecurityChangeProbe = fn(&AppPreferences, &AppPreferences) -> bool;
+const AUDITED_SECURITY_LEAVES: &[(&str, SecurityChangeProbe)] = &[
+    ("security.clipboardClearTimeout", |o, n| {
+        o.security.clipboard_clear_timeout != n.security.clipboard_clear_timeout
+    }),
+    ("security.preventScreenCapture", |o, n| {
+        o.security.prevent_screen_capture != n.security.prevent_screen_capture
+    }),
+    ("security.autoDownloadFavicons", |o, n| {
+        o.security.auto_download_favicons != n.security.auto_download_favicons
+    }),
+    ("security.allowThirdPartyFaviconFallbacks", |o, n| {
+        o.security.allow_third_party_favicon_fallbacks
+            != n.security.allow_third_party_favicon_fallbacks
+    }),
+    ("security.autoLockTimeout", |o, n| {
+        o.security.auto_lock_timeout != n.security.auto_lock_timeout
+    }),
+    ("audit.enabled", |o, n| o.audit.enabled != n.audit.enabled),
+    ("audit.retentionDays", |o, n| {
+        o.audit.retention_days != n.audit.retention_days
+    }),
+];
+
+/// Returns the wire names of allowlisted App Preference leaves that
+/// differ between `old` and `new`, in declaration order. Empty when
+/// nothing audited changed — the caller (commands layer) fans the
+/// result across every currently-open Vault, recording one
+/// `preferences.security_changed` event per (vault, leaf) pair.
+pub fn diff_security_changes(old: &AppPreferences, new: &AppPreferences) -> Vec<&'static str> {
+    AUDITED_SECURITY_LEAVES
+        .iter()
+        .filter_map(|(name, changed)| if changed(old, new) { Some(*name) } else { None })
+        .collect()
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::panic)]
 mod validate_preferences_tests {
@@ -330,5 +376,211 @@ mod validate_preferences_tests {
             SettingsService::validate_preferences(&prefs)
                 .unwrap_or_else(|_| panic!("retention_days={days} should validate"));
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod diff_security_changes_tests {
+    use super::diff_security_changes;
+    use crate::commands::settings::{
+        AppPreferences, AppearanceSettings, AuditSettings, GeneralSettings, SecuritySettings,
+    };
+    use std::collections::HashSet;
+
+    /// Tracer: flipping a single allowlisted leaf reports exactly that
+    /// leaf's wire name. Nothing else changed, so nothing else fires.
+    #[test]
+    fn flipping_clipboard_clear_timeout_emits_one_leaf() {
+        let old = AppPreferences::default();
+        let new = AppPreferences {
+            security: SecuritySettings {
+                clipboard_clear_timeout: old.security.clipboard_clear_timeout + 10,
+                ..old.security.clone()
+            },
+            ..old.clone()
+        };
+        let leaves = diff_security_changes(&old, &new);
+        assert_eq!(leaves, vec!["security.clipboardClearTimeout"]);
+    }
+
+    /// PRD AC: UI/preference changes (theme, language, layout) are
+    /// deliberately excluded. The audit log must stay tightly focused on
+    /// security-relevant flips so the user can scan it without the signal
+    /// drowning in cosmetic noise.
+    #[test]
+    fn changing_theme_emits_no_leaves() {
+        let old = AppPreferences::default();
+        let new = AppPreferences {
+            appearance: AppearanceSettings {
+                theme: "dark".into(),
+                ..old.appearance.clone()
+            },
+            ..old.clone()
+        };
+        let leaves = diff_security_changes(&old, &new);
+        assert!(leaves.is_empty(), "theme is not audited, got: {leaves:?}");
+    }
+
+    #[test]
+    fn changing_language_emits_no_leaves() {
+        let old = AppPreferences::default();
+        let new = AppPreferences {
+            general: GeneralSettings {
+                language: "de".into(),
+                ..old.general.clone()
+            },
+            ..old.clone()
+        };
+        let leaves = diff_security_changes(&old, &new);
+        assert!(
+            leaves.is_empty(),
+            "language is not audited, got: {leaves:?}"
+        );
+    }
+
+    /// AC: "Multiple changes in one call produce multiple events." The
+    /// caller emits one audit record per leaf in the returned vec, so
+    /// missing one here means a missing audit record in production.
+    #[test]
+    fn two_allowlisted_flips_in_one_call_emit_both_leaves() {
+        let old = AppPreferences::default();
+        let new = AppPreferences {
+            security: SecuritySettings {
+                prevent_screen_capture: !old.security.prevent_screen_capture,
+                auto_download_favicons: !old.security.auto_download_favicons,
+                ..old.security.clone()
+            },
+            ..old.clone()
+        };
+        let leaves: HashSet<&str> = diff_security_changes(&old, &new).into_iter().collect();
+        let expected: HashSet<&str> = [
+            "security.preventScreenCapture",
+            "security.autoDownloadFavicons",
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(leaves, expected);
+    }
+
+    /// Each allowlisted leaf has its own test row: flipping that leaf in
+    /// isolation must produce exactly its wire name. The table doubles as
+    /// living documentation of which paths emit and which do not. Adding
+    /// a new key to the allowlist requires adding a row here too — if a
+    /// future contributor forgets, this test stays green only by accident.
+    #[test]
+    fn every_allowlisted_leaf_emits_its_own_wire_name() {
+        struct Case {
+            name: &'static str,
+            mutate: fn(&mut AppPreferences),
+        }
+        let cases = [
+            Case {
+                name: "security.clipboardClearTimeout",
+                mutate: |p| p.security.clipboard_clear_timeout += 1,
+            },
+            Case {
+                name: "security.preventScreenCapture",
+                mutate: |p| p.security.prevent_screen_capture = !p.security.prevent_screen_capture,
+            },
+            Case {
+                name: "security.autoDownloadFavicons",
+                mutate: |p| p.security.auto_download_favicons = !p.security.auto_download_favicons,
+            },
+            Case {
+                name: "security.allowThirdPartyFaviconFallbacks",
+                mutate: |p| {
+                    p.security.allow_third_party_favicon_fallbacks =
+                        !p.security.allow_third_party_favicon_fallbacks;
+                },
+            },
+            Case {
+                name: "security.autoLockTimeout",
+                mutate: |p| p.security.auto_lock_timeout += 60,
+            },
+            Case {
+                name: "audit.enabled",
+                mutate: |p| p.audit.enabled = !p.audit.enabled,
+            },
+            Case {
+                name: "audit.retentionDays",
+                mutate: |p| p.audit.retention_days += 1,
+            },
+        ];
+        for case in &cases {
+            let old = AppPreferences::default();
+            let mut new = old.clone();
+            (case.mutate)(&mut new);
+            let leaves = diff_security_changes(&old, &new);
+            assert_eq!(
+                leaves,
+                vec![case.name],
+                "flipping {} alone must emit only that leaf",
+                case.name
+            );
+        }
+    }
+
+    /// Non-allowlisted security siblings (`showPasswordByDefault`,
+    /// `minimizeToTray`, `startMinimized`, `clearClipboardOnLock`,
+    /// `showClipboardCountdown`) must NOT emit — they are UX
+    /// preferences that happen to live under `security.*`, not
+    /// security-relevant flips. Pinning the carve-out here means a
+    /// future "let's just audit everything under security.*" refactor
+    /// fails loudly.
+    #[test]
+    fn non_allowlisted_security_siblings_emit_no_leaves() {
+        let old = AppPreferences::default();
+        let new = AppPreferences {
+            security: SecuritySettings {
+                show_password_by_default: !old.security.show_password_by_default,
+                minimize_to_tray: !old.security.minimize_to_tray,
+                start_minimized: !old.security.start_minimized,
+                clear_clipboard_on_lock: !old.security.clear_clipboard_on_lock,
+                show_clipboard_countdown: !old.security.show_clipboard_countdown,
+                ..old.security.clone()
+            },
+            ..old.clone()
+        };
+        let leaves = diff_security_changes(&old, &new);
+        assert!(
+            leaves.is_empty(),
+            "non-allowlisted security siblings must not emit, got: {leaves:?}"
+        );
+    }
+
+    /// AC: "Adding a key to the allowlist is a one-line change." The
+    /// table-driven definition above already makes the source-side
+    /// one-liner; this test pins the runtime shape (declaration order,
+    /// no duplicate wire names) so a future edit can't silently shadow a
+    /// key or reorder it in a way that surprises log consumers.
+    #[test]
+    fn allowlist_wire_names_are_unique() {
+        use super::AUDITED_SECURITY_LEAVES;
+        let mut seen = HashSet::new();
+        for (name, _) in AUDITED_SECURITY_LEAVES {
+            assert!(
+                seen.insert(*name),
+                "duplicate wire name in allowlist: {name}"
+            );
+        }
+    }
+
+    /// The audit settings unit struct must round-trip through the diff:
+    /// an unchanged `AuditSettings` (constructed via `..Default::default()`)
+    /// across the call site must NOT cause a spurious diff. This pins the
+    /// equality check against the typed `AuditSettings` struct so a future
+    /// refactor of `AuditSettings` (adding a field, swapping the order)
+    /// can't accidentally flip the eq invariant.
+    #[test]
+    fn unchanged_audit_struct_does_not_diff() {
+        let old = AppPreferences::default();
+        let new = AppPreferences {
+            audit: AuditSettings {
+                ..old.audit.clone()
+            },
+            ..old.clone()
+        };
+        assert!(diff_security_changes(&old, &new).is_empty());
     }
 }

--- a/src/components/settings/sections/AuditLogSection.tsx
+++ b/src/components/settings/sections/AuditLogSection.tsx
@@ -58,15 +58,20 @@ function AuditRow({
   const entryId = event.entryId ?? null;
   const title = entryId ? resolveTitle(entryId) : null;
   const entryLabel = entryId ? (title ?? entryId.slice(0, 8)) : null;
+  const settingName = event.settingName ?? null;
   return (
     <li
       data-kind={event.kind}
       data-entry-id={entryId ?? undefined}
+      data-setting-name={settingName ?? undefined}
       className="flex flex-col gap-1 rounded-md border bg-card/50 p-3 text-sm md:flex-row md:items-center md:justify-between"
     >
       <span className="font-medium">{t(`audit.kind.${event.kind}`)}</span>
       <div className="flex items-center gap-3 text-xs text-muted-foreground">
         {entryLabel ? <span>{entryLabel}</span> : null}
+        {settingName ? (
+          <span>{t(`audit.settingName.${settingName}`)}</span>
+        ) : null}
         {typeof event.attemptCount === "number" ? (
           <span>{t("audit.attemptCount", { count: event.attemptCount })}</span>
         ) : null}

--- a/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
@@ -396,6 +396,35 @@ describe("AuditLogSection", () => {
     });
   });
 
+  it("renders a preferences.security_changed row with the localized setting-name label", async () => {
+    listMock.mockResolvedValueOnce({
+      events: [
+        {
+          kind: "preferencesSecurityChanged",
+          timestamp: "2026-05-17T10:00:00.000Z",
+          settingName: "security.preventScreenCapture",
+        },
+      ],
+      degraded: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <AuditLogSection dbId="/tmp/vault.kdbx" />
+      </Wrapper>
+    );
+
+    const row = await screen.findByRole("listitem");
+    expect(row.getAttribute("data-kind")).toBe("preferencesSecurityChanged");
+    expect(row.textContent).toContain("audit.kind.preferencesSecurityChanged");
+    // i18n mock echoes keys; the row must render the per-setting label key
+    // so each allowlisted leaf gets a human-readable name in production.
+    expect(row.textContent).toContain(
+      "audit.settingName.security.preventScreenCapture"
+    );
+  });
+
   it("renders the loadError state when the backend fails", async () => {
     listMock.mockRejectedValueOnce(new Error("boom"));
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -336,6 +336,7 @@ export const AuditEventKindSchema = z.enum([
   "entryPasswordRevealed",
   "entryPasswordCopied",
   "entryProtectedFieldRevealed",
+  "preferencesSecurityChanged",
 ]);
 export type AuditEventKind = z.infer<typeof AuditEventKindSchema>;
 
@@ -349,12 +350,35 @@ export const AuditReasonSchema = z.enum([
 ]);
 export type AuditReason = z.infer<typeof AuditReasonSchema>;
 
+/// Allowlisted App Preference leaves whose flips surface as
+/// `preferencesSecurityChanged` events. Pinning this as a union (not a
+/// free string) ties the wire identifier to the i18n key registry, so a
+/// new allowlist entry on the backend fails the frontend type-check
+/// until its label is added under `audit.settingName.*`.
+export const SecuritySettingChangeNameSchema = z.enum([
+  "security.clipboardClearTimeout",
+  "security.preventScreenCapture",
+  "security.autoDownloadFavicons",
+  "security.allowThirdPartyFaviconFallbacks",
+  "security.autoLockTimeout",
+  "audit.enabled",
+  "audit.retentionDays",
+]);
+export type SecuritySettingChangeName = z.infer<
+  typeof SecuritySettingChangeNameSchema
+>;
+
 export const AuditEventSchema = z.object({
   kind: AuditEventKindSchema,
   timestamp: z.string().min(1),
   attemptCount: z.number().int().positive().nullable().optional(),
   reason: AuditReasonSchema.nullable().optional(),
   entryId: z.string().min(1).nullable().optional(),
+  /// Dot-pathed App Preference leaf for `preferencesSecurityChanged`
+  /// events (e.g. `security.preventScreenCapture`). Old/new values are
+  /// deliberately absent from the wire — the on-disk log records THAT a
+  /// flip happened, not what it flipped to.
+  settingName: SecuritySettingChangeNameSchema.nullable().optional(),
 });
 export type AuditEvent = z.infer<typeof AuditEventSchema>;
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -33,13 +33,27 @@
       "vaultLocked": "Vault locked",
       "entryPasswordRevealed": "Password revealed",
       "entryPasswordCopied": "Password copied",
-      "entryProtectedFieldRevealed": "Protected field revealed"
+      "entryProtectedFieldRevealed": "Protected field revealed",
+      "preferencesSecurityChanged": "Security preference changed"
     },
     "reason": {
       "manual": "Manual",
       "autoLock": "Auto-lock",
       "appQuit": "App quit",
       "screenLock": "Screen lock"
+    },
+    "settingName": {
+      "security": {
+        "clipboardClearTimeout": "Clipboard clear timeout",
+        "preventScreenCapture": "Prevent screen capture",
+        "autoDownloadFavicons": "Auto-download favicons",
+        "allowThirdPartyFaviconFallbacks": "Allow third-party favicon fallbacks",
+        "autoLockTimeout": "Auto-lock timeout"
+      },
+      "audit": {
+        "enabled": "Audit logging enabled",
+        "retentionDays": "Audit retention (days)"
+      }
     }
   },
   "settings": {


### PR DESCRIPTION
Closes #221.

## Summary

- New `preferences.security_changed` audit kind carrying only `setting_name` (no old/new values).
- One-line-extensible allowlist (`AUDITED_SECURITY_LEAVES` in `services/settings.rs`); UI/preference changes (theme, language, layout) are excluded.
- `update_app_preferences` diffs old vs new preferences and fans one record per `(currently-open vault × changed leaf)` pair. No open vault ⇒ no-op (no global log file, per the ADR).
- Frontend ties the wire identifier to i18n keys via `SecuritySettingChangeNameSchema` — a new backend allowlist entry fails the TypeScript check until its label is added under `audit.settingName.*`.

## Allowlisted leaves

- `security.clipboardClearTimeout`
- `security.preventScreenCapture`
- `security.autoDownloadFavicons`
- `security.allowThirdPartyFaviconFallbacks`
- `security.autoLockTimeout` (the only current leaf matching the issue's `autoLock.*`; there's no nested `autoLock` object today)
- `audit.enabled`
- `audit.retentionDays`

## Test plan

- [x] `cargo test --lib` — 240 pass (incl. new format / service / settings-diff / fan-out tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bun run test` — 388 pass (incl. new `AuditLogSection` row test)
- [x] `bun run build` — tsc + vite build clean
- [x] `bun run check` — lint + prettier clean
- [ ] Manual: flip a security preference with a vault open and confirm a `Security preference changed` row appears in Settings → Audit log
- [ ] Manual: change theme / language; confirm no audit row is added

🤖 Generated with [Claude Code](https://claude.com/claude-code)