### PR TITLE
feat(core): age-based audit log retention with 10 MB size cap (#222)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -79,3 +79,9 @@ The namespaced enum of recordable events:
 - `audit.cleared` — user emptied the Audit Log; the record itself survives the clear
 
 Entry selection, group navigation, search, theme/language changes, and other non-security-relevant interactions are explicitly **not** Audit Event Kinds.
+
+### Audit Retention
+The policy that bounds how much history an Audit Log keeps. Two limits applied in order: an **age cutoff** (default 90 days, user-configurable 1–365 via `retentionDays`) drops events older than `now − retentionDays`; a **10 MB hard size cap** then drops the oldest survivors until under the cap. A single event larger than the cap is retained — the cap is a defense-in-depth ceiling, not a guarantee.
+
+### Audit Compaction
+The rewrite pass that enforces Audit Retention. Reads every encrypted frame under an exclusive file lock, partitions via `retention::partition_by_retention`, re-encrypts the keepers with fresh nonces, and atomically replaces the log file (temp + rename). Triggered lazily on append when the file crosses the size cap or the oldest cached timestamp falls outside the retention window; the explicit `AuditService::compact` is also directly callable.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -406,6 +406,7 @@ pub async fn update_app_preferences(
     settings_service.update_app_preferences(&new_preferences)?;
     kdbx_service.set_backup_settings(new_preferences.backups)?;
     audit_service.set_enabled(new_preferences.audit.enabled);
+    audit_service.set_retention_days(new_preferences.audit.retention_days);
     Ok(())
 }
 
@@ -418,6 +419,7 @@ pub async fn reset_app_preferences(
     let prefs = settings_service.reset_app_preferences()?;
     kdbx_service.set_backup_settings(prefs.backups.clone())?;
     audit_service.set_enabled(prefs.audit.enabled);
+    audit_service.set_retention_days(prefs.audit.retention_days);
     Ok(prefs)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -143,11 +143,10 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     // so we can apply it to AuditService below.
     let initial_audit = settings_service
         .get_app_preferences()
-        .map(|prefs| {
+        .map_or((true, 90), |prefs| {
             let _ = kdbx_arc.set_backup_settings(prefs.backups);
             (prefs.audit.enabled, prefs.audit.retention_days)
-        })
-        .unwrap_or((true, 90));
+        });
     app.manage(Arc::new(settings_service));
 
     let auto_lock_service = AutoLockService::new();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -141,12 +141,13 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     // Push the persisted backup config into the KDBX service so the save
     // hook honours it from first save onward. Capture the audit gate too
     // so we can apply it to AuditService below.
-    let initial_audit_enabled = settings_service
+    let initial_audit = settings_service
         .get_app_preferences()
-        .map_or(true, |prefs| {
+        .map(|prefs| {
             let _ = kdbx_arc.set_backup_settings(prefs.backups);
-            prefs.audit.enabled
-        });
+            (prefs.audit.enabled, prefs.audit.retention_days)
+        })
+        .unwrap_or((true, 90));
     app.manage(Arc::new(settings_service));
 
     let auto_lock_service = AutoLockService::new();
@@ -159,7 +160,8 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     let audit_root = data_dir.join("audit");
     let key_source = Arc::new(FileBackedAuditKey::new(audit_root.join("key.bin")));
     let audit_service = AuditService::new(audit_root, key_source);
-    audit_service.set_enabled(initial_audit_enabled);
+    audit_service.set_enabled(initial_audit.0);
+    audit_service.set_retention_days(initial_audit.1);
     app.manage(Arc::new(audit_service));
 
     Ok(())

--- a/src-tauri/src/services/audit/retention.rs
+++ b/src-tauri/src/services/audit/retention.rs
@@ -59,16 +59,22 @@ pub fn partition_by_retention(
         }
     }
 
-    // Apply the size cap: while the kept set occupies more than `max_bytes`
-    // AND there's more than one event to drop from, push the oldest kept
-    // event into drop. The "more than one" guard is what implements the
-    // single-event-bigger-than-cap rule — we never produce an empty kept
-    // set just because one frame is oversized.
+    // Apply the size cap with a single front-trim pass instead of a
+    // `Vec::remove(0)` loop: figure out how many oldest entries must
+    // go to land at-or-under the cap (capped at `len - 1` so the
+    // single-oversized-event floor is preserved), then `drain` that
+    // prefix in one O(n) shift. The previous loop was O(n²) when the
+    // cap forced many evictions — measurable when lazy compaction
+    // runs against a 10 MiB log full of tiny frames.
     let mut total: usize = keep.iter().map(|f| f.encoded_len).sum();
-    while total > max_bytes && keep.len() > 1 {
-        let oldest = keep.remove(0);
-        total = total.saturating_sub(oldest.encoded_len);
-        drop.push(oldest);
+    let mut to_drop: usize = 0;
+    let max_drop = keep.len().saturating_sub(1);
+    while total > max_bytes && to_drop < max_drop {
+        total = total.saturating_sub(keep[to_drop].encoded_len);
+        to_drop += 1;
+    }
+    if to_drop > 0 {
+        drop.extend(keep.drain(0..to_drop));
     }
 
     (keep, drop)

--- a/src-tauri/src/services/audit/retention.rs
+++ b/src-tauri/src/services/audit/retention.rs
@@ -2,14 +2,217 @@
 
 //! Retention policy for the audit log.
 //!
-//! Stub for the tracer-bullet slice. The real age-based + size-cap policy
-//! lands in a follow-up issue; for now [`apply_retention`] is a no-op so
-//! `AuditService::record` can call it without conditionals.
+//! Two limits applied in order:
+//! 1. **Age** — events with timestamp older than `now - max_age` are dropped.
+//! 2. **Size cap** — if the surviving events would still occupy more than
+//!    `max_bytes` on disk, the oldest survivors are dropped until under the
+//!    cap. A *single* event larger than the cap is retained: the cap is a
+//!    defense-in-depth ceiling, not a guarantee — silently dropping the
+//!    only thing in the log would lose the user-facing record entirely.
+//!
+//! [`partition_by_retention`] is a pure function so the policy can be
+//! exercised exhaustively without touching the filesystem or the system
+//! clock; the audit service wires it into the lazy compaction trigger that
+//! fires from [`super::service::AuditService::record`].
 
-use std::path::Path;
+use chrono::{DateTime, Duration, Utc};
 
-/// Applies retention to the audit log file at `_path`. No-op until the
-/// follow-up implementation lands.
-pub fn apply_retention(_path: &Path) {
-    // intentionally empty
+use crate::services::audit::format::AuditEvent;
+
+/// A decrypted audit event paired with the byte length it occupies on
+/// disk (base64-encoded frame + newline). Pairing the size next to the
+/// event lets [`partition_by_retention`] apply the size cap without
+/// re-encoding to measure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SizedEvent {
+    pub event: AuditEvent,
+    pub encoded_len: usize,
+}
+
+/// Partition `events` into `(keep, drop)` by the two retention policies.
+///
+/// `now` is passed in so the function is pure: tests pin the clock and
+/// the service supplies `Utc::now()`. Within each output vector, events
+/// stay in input order — callers append in chronological order, so the
+/// kept slice round-trips back to disk preserving append order.
+///
+/// Age cutoff is inclusive: an event with timestamp exactly equal to
+/// `now - max_age` is kept. The boundary is on the *cutoff* side so a
+/// pinned 90-day retention doesn't lose the 90-day-old event a user
+/// would expect to still be there.
+pub fn partition_by_retention(
+    events: Vec<SizedEvent>,
+    now: DateTime<Utc>,
+    max_age: Duration,
+    max_bytes: usize,
+) -> (Vec<SizedEvent>, Vec<SizedEvent>) {
+    let cutoff = now - max_age;
+
+    let mut keep: Vec<SizedEvent> = Vec::with_capacity(events.len());
+    let mut drop: Vec<SizedEvent> = Vec::new();
+
+    for item in events {
+        if event_timestamp(&item.event) >= cutoff {
+            keep.push(item);
+        } else {
+            drop.push(item);
+        }
+    }
+
+    // Apply the size cap: while the kept set occupies more than `max_bytes`
+    // AND there's more than one event to drop from, push the oldest kept
+    // event into drop. The "more than one" guard is what implements the
+    // single-event-bigger-than-cap rule — we never produce an empty kept
+    // set just because one frame is oversized.
+    let mut total: usize = keep.iter().map(|f| f.encoded_len).sum();
+    while total > max_bytes && keep.len() > 1 {
+        let oldest = keep.remove(0);
+        total = total.saturating_sub(oldest.encoded_len);
+        drop.push(oldest);
+    }
+
+    (keep, drop)
+}
+
+fn event_timestamp(event: &AuditEvent) -> DateTime<Utc> {
+    match event {
+        AuditEvent::VaultUnlockFailed { timestamp, .. }
+        | AuditEvent::VaultOpened { timestamp }
+        | AuditEvent::VaultLocked { timestamp, .. }
+        | AuditEvent::EntryPasswordRevealed { timestamp, .. }
+        | AuditEvent::EntryPasswordCopied { timestamp, .. }
+        | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
+        | AuditEvent::AuditCleared { timestamp } => *timestamp,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(days_ago: i64, now: DateTime<Utc>) -> DateTime<Utc> {
+        now - Duration::days(days_ago)
+    }
+
+    fn opened(ts: DateTime<Utc>, encoded_len: usize) -> SizedEvent {
+        SizedEvent {
+            event: AuditEvent::VaultOpened { timestamp: ts },
+            encoded_len,
+        }
+    }
+
+    fn now_fixed() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 17, 12, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn empty_input_partitions_to_empty_keep_and_empty_drop() {
+        let (keep, drop) =
+            partition_by_retention(Vec::new(), now_fixed(), Duration::days(90), 10_000);
+        assert!(keep.is_empty());
+        assert!(drop.is_empty());
+    }
+
+    /// All events younger than `max_age` survive untouched and `drop`
+    /// stays empty — the most common steady-state shape (no retention
+    /// pressure yet) must not churn frames.
+    #[test]
+    fn all_young_events_are_kept() {
+        let now = now_fixed();
+        let events = vec![
+            opened(at(1, now), 100),
+            opened(at(2, now), 100),
+            opened(at(3, now), 100),
+        ];
+        let (keep, drop) = partition_by_retention(events.clone(), now, Duration::days(90), 10_000);
+        assert_eq!(keep, events);
+        assert!(drop.is_empty());
+    }
+
+    /// Every event older than `max_age` ends up in `drop`. The size cap
+    /// is irrelevant here — age is the primary policy and must clear the
+    /// log on its own when nothing is fresh.
+    #[test]
+    fn all_old_events_are_dropped() {
+        let now = now_fixed();
+        let events = vec![
+            opened(at(200, now), 100),
+            opened(at(150, now), 100),
+            opened(at(100, now), 100),
+        ];
+        let (keep, drop) = partition_by_retention(events.clone(), now, Duration::days(90), 10_000);
+        assert!(keep.is_empty());
+        assert_eq!(drop, events);
+    }
+
+    /// The age cutoff is inclusive: an event whose timestamp is exactly
+    /// `now - max_age` is kept. Pinning this means a 90-day retention
+    /// doesn't lose the 90-day-old record a user would expect to find.
+    #[test]
+    fn event_exactly_at_age_boundary_is_kept() {
+        let now = now_fixed();
+        let max_age = Duration::days(90);
+        let on_boundary = opened(now - max_age, 100);
+        let one_second_older = opened(now - max_age - Duration::seconds(1), 100);
+
+        let (keep, drop) = partition_by_retention(
+            vec![one_second_older.clone(), on_boundary.clone()],
+            now,
+            max_age,
+            10_000,
+        );
+        assert_eq!(keep, vec![on_boundary]);
+        assert_eq!(drop, vec![one_second_older]);
+    }
+
+    /// When the size cap would still be exceeded after the age pass, the
+    /// oldest *surviving* events are dropped until the kept set is under
+    /// the cap. The drop set therefore contains BOTH the age-evicted and
+    /// the size-evicted events; size-evicted ones are appended after the
+    /// age-evicted ones to make the audit trail of "what compaction did"
+    /// readable in order.
+    #[test]
+    fn over_size_cap_drops_oldest_survivors_after_age_pass() {
+        let now = now_fixed();
+        // Each event is 100 bytes; cap is 250 bytes; 4 young events
+        // would total 400 — must drop the two oldest survivors to land
+        // at 200, which is under the cap.
+        let young_oldest = opened(at(10, now), 100);
+        let young_old = opened(at(8, now), 100);
+        let young_new = opened(at(6, now), 100);
+        let young_newest = opened(at(4, now), 100);
+        let too_old = opened(at(200, now), 100);
+
+        let (keep, drop) = partition_by_retention(
+            vec![
+                too_old.clone(),
+                young_oldest.clone(),
+                young_old.clone(),
+                young_new.clone(),
+                young_newest.clone(),
+            ],
+            now,
+            Duration::days(90),
+            250,
+        );
+
+        assert_eq!(keep, vec![young_new, young_newest]);
+        assert_eq!(drop, vec![too_old, young_oldest, young_old]);
+    }
+
+    /// A single event whose encoded length exceeds the cap is RETAINED.
+    /// The cap is a defense-in-depth ceiling, not a guarantee — silently
+    /// dropping the only thing in the log would lose the user-facing
+    /// record entirely. Better to overflow the cap than to vanish.
+    #[test]
+    fn single_event_larger_than_cap_is_retained() {
+        let now = now_fixed();
+        let oversized = opened(at(1, now), 50_000);
+        let (keep, drop) =
+            partition_by_retention(vec![oversized.clone()], now, Duration::days(90), 10_000);
+        assert_eq!(keep, vec![oversized]);
+        assert!(drop.is_empty());
+    }
 }

--- a/src-tauri/src/services/audit/retention.rs
+++ b/src-tauri/src/services/audit/retention.rs
@@ -82,6 +82,7 @@ fn event_timestamp(event: &AuditEvent) -> DateTime<Utc> {
         | AuditEvent::EntryPasswordRevealed { timestamp, .. }
         | AuditEvent::EntryPasswordCopied { timestamp, .. }
         | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
+        | AuditEvent::PreferencesSecurityChanged { timestamp, .. }
         | AuditEvent::AuditCleared { timestamp } => *timestamp,
     }
 }

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -1240,8 +1240,7 @@ mod tests {
         // decrypt frames the first one wrote — this is the in-test
         // equivalent of a `FileBackedAuditKey` surviving a process
         // restart.
-        let key: Arc<dyn crate::services::audit::key::AuditKey> =
-            Arc::new(InMemoryAuditKey::new());
+        let key: Arc<dyn crate::services::audit::key::AuditKey> = Arc::new(InMemoryAuditKey::new());
 
         // Session 1: write a stale event into disk under a generous
         // retention, then drop the service to simulate process exit.

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -206,6 +206,17 @@ impl AuditService {
         let log = AuditLogFile::new(log_path.clone());
         log.append(&frame).map_err(|_| ())?;
 
+        // Seed the per-Vault oldest-timestamp cache from disk on first
+        // use this session. Without this, after a process restart the
+        // cache only ever knows about events recorded *this* session
+        // (all `Utc::now()`) so the age trigger would silently never
+        // fire against frames left over on disk — age retention would
+        // stop working until the size cap eventually happened to trip.
+        // The seed runs *after* the append so the freshly-written frame
+        // is included in the disk scan and the cache reflects the new
+        // post-append state in one pass.
+        self.ensure_oldest_loaded(vault_path, &key);
+
         // Update the cached oldest-timestamp for this vault: the
         // just-appended event is the smallest known timestamp if the
         // cache was empty, or stays unchanged if an older event was
@@ -511,6 +522,24 @@ impl AuditService {
         self.refresh_oldest(vault_path, &key);
 
         Ok(stats)
+    }
+
+    /// Populates the per-Vault oldest-timestamp cache from disk if it
+    /// is empty for this Vault. Idempotent and best-effort: a hit on a
+    /// previously-loaded cache returns immediately; a miss falls
+    /// through to [`AuditService::refresh_oldest`]. Called from
+    /// `try_record` so the first append per process per Vault picks up
+    /// any old frames that survived a previous session.
+    fn ensure_oldest_loaded(&self, vault_path: &Path, key: &[u8; KEY_LEN]) {
+        let cache_key = attempts_key(vault_path);
+        if let Ok(map) = self.oldest.lock() {
+            if map.contains_key(&cache_key) {
+                return;
+            }
+        } else {
+            return;
+        }
+        self.refresh_oldest(vault_path, key);
     }
 
     /// Recomputes and caches the oldest timestamp on disk for
@@ -1182,6 +1211,72 @@ mod tests {
 
         let events = service.read(&vault, &AuditFilter::default()).expect("read");
         assert_eq!(events.len(), 1, "compaction must drop the stale entry");
+        match &events[0] {
+            AuditEvent::VaultUnlockFailed { attempt_count, .. } => {
+                assert_eq!(*attempt_count, 2);
+            }
+            other => panic!("expected VaultUnlockFailed, got {other:?}"),
+        }
+    }
+
+    /// Regression: after a process restart, the per-Vault oldest-timestamp
+    /// cache starts empty. A fresh append's `Utc::now()` would otherwise
+    /// be the only known timestamp and the age trigger would *never*
+    /// fire against the stale frames already on disk — age retention
+    /// would silently stop working until the size cap eventually
+    /// happened to trip. Seed the cache from disk on first use so the
+    /// first append for a Vault this session correctly notices that
+    /// the existing log has aged out.
+    #[test]
+    fn restart_with_stale_on_disk_log_triggers_compaction_on_first_record() {
+        use crate::services::audit::key::InMemoryAuditKey;
+        use chrono::Duration;
+        use tempfile::tempdir;
+
+        let dir = tempdir().expect("tempdir");
+        let vault = dir.path().join("vault.kdbx");
+        std::fs::write(&vault, b"x").expect("write vault");
+        // Both services share one key source so the second one can
+        // decrypt frames the first one wrote — this is the in-test
+        // equivalent of a `FileBackedAuditKey` surviving a process
+        // restart.
+        let key: Arc<dyn crate::services::audit::key::AuditKey> =
+            Arc::new(InMemoryAuditKey::new());
+
+        // Session 1: write a stale event into disk under a generous
+        // retention, then drop the service to simulate process exit.
+        {
+            let service = AuditService::new(dir.path().join("audit"), Arc::clone(&key));
+            service.set_retention_days(365);
+            service.set_lazy_trigger_enabled_for_test(false);
+            let stale = AuditEvent::VaultUnlockFailed {
+                timestamp: Utc::now() - Duration::days(60),
+                attempt_count: 1,
+            };
+            service.record(&vault, &stale);
+        }
+
+        // Session 2: brand-new service against the same audit dir.
+        // Configure a 1-day retention; the lazy trigger is enabled by
+        // default. The first record this session should seed the
+        // oldest-cache from disk, see the 60-day-old frame, and run
+        // compaction so the stale entry is gone.
+        let service = AuditService::new(dir.path().join("audit"), Arc::clone(&key));
+        service.set_retention_days(1);
+        service.record(
+            &vault,
+            &AuditEvent::VaultUnlockFailed {
+                timestamp: Utc::now(),
+                attempt_count: 2,
+            },
+        );
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(
+            events.len(),
+            1,
+            "stale on-disk event must be aged out on first record after restart"
+        );
         match &events[0] {
             AuditEvent::VaultUnlockFailed { attempt_count, .. } => {
                 assert_eq!(*attempt_count, 2);

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -246,7 +246,7 @@ impl AuditService {
             return;
         }
         let path = self.log_path_for(vault_path);
-        let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let size = std::fs::metadata(&path).map_or(0, |m| m.len());
         let now = Utc::now();
         let cutoff = now - Duration::days(i64::from(self.retention_days()));
         let oldest = self
@@ -1215,7 +1215,7 @@ mod tests {
         // After the size-cap trigger, the kept set must satisfy the cap
         // OR be the single surviving event (per the floor rule).
         let log_path = service.log_path_for(&vault);
-        let size = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+        let size = std::fs::metadata(&log_path).map_or(0, |m| m.len());
         let events = service.read(&vault, &AuditFilter::default()).expect("read");
         assert!(
             size <= 100 || events.len() == 1,

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -230,6 +230,7 @@ impl AuditService {
             | AuditEvent::EntryPasswordRevealed { timestamp, .. }
             | AuditEvent::EntryPasswordCopied { timestamp, .. }
             | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
+            | AuditEvent::PreferencesSecurityChanged { timestamp, .. }
             | AuditEvent::AuditCleared { timestamp } => *timestamp,
         };
         if let Ok(mut map) = self.oldest.lock() {
@@ -620,6 +621,7 @@ fn event_timestamp(event: &AuditEvent) -> DateTime<Utc> {
         | AuditEvent::EntryPasswordRevealed { timestamp, .. }
         | AuditEvent::EntryPasswordCopied { timestamp, .. }
         | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
+        | AuditEvent::PreferencesSecurityChanged { timestamp, .. }
         | AuditEvent::AuditCleared { timestamp } => *timestamp,
     }
 }

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -540,7 +540,14 @@ impl AuditService {
                 AuditCompactError::Storage(e.to_string())
             })?;
 
-        if undecryptable > 0 {
+        // Flip degraded for any signal that the input log was not
+        // fully readable: AEAD-undecryptable frames the closure
+        // counted, and base64-malformed lines the storage layer
+        // surfaced via `CompactStats::malformed_lines`. Without this,
+        // a lazy compaction running before the user opens the audit
+        // panel would silently delete corrupt lines and the banner
+        // would never appear.
+        if undecryptable > 0 || stats.malformed_lines > 0 {
             self.degraded.store(true, Ordering::SeqCst);
         }
 
@@ -1300,6 +1307,35 @@ mod tests {
             }
             other => panic!("expected VaultUnlockFailed, got {other:?}"),
         }
+    }
+
+    /// Regression: a lazy compaction running before the user opens the
+    /// audit panel must not silently delete a malformed base64 line
+    /// without flipping `degraded`. Otherwise the corrupt log would be
+    /// rewritten clean and the user would never know.
+    #[test]
+    fn compact_flips_degraded_when_input_log_has_malformed_lines() {
+        use std::io::Write;
+        let (service, _dir, vault) = fresh_service();
+        service.set_lazy_trigger_enabled_for_test(false);
+        service.record(&vault, &unlock_failed_event(1));
+
+        // Splice a non-base64 line directly into the log file so the
+        // compact-time reader sees it.
+        let log_path = service.log_path_for(&vault);
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&log_path)
+            .expect("open log for splice");
+        f.write_all(b"!!!not-base64!!!\n").expect("splice");
+        drop(f);
+        assert!(!service.is_degraded(), "precondition: not yet degraded");
+
+        service.compact(&vault).expect("compact");
+        assert!(
+            service.is_degraded(),
+            "compact must flip degraded when input had malformed lines"
+        );
     }
 
     /// Regression: after a process restart, the per-Vault oldest-timestamp

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -11,18 +11,29 @@
 //!   audit log cannot become a `DoS` vector against the user's own Vault flows.
 //! * [`AuditService::read`] — list events for a Vault path.
 
-use crate::services::audit::crypto::{decrypt, encrypt, KEY_LEN};
+use crate::services::audit::crypto::{decrypt, encode_frame, encrypt, KEY_LEN};
 use crate::services::audit::format::{AuditEvent, Reason};
 use crate::services::audit::key::AuditKey;
-use crate::services::audit::retention::apply_retention;
-use crate::services::audit::storage::AuditLogFile;
+use crate::services::audit::retention::{partition_by_retention, SizedEvent};
+use crate::services::audit::storage::{AuditLogFile, CompactStats};
 use crate::services::audit::vault_id::hash_vault_path;
-use chrono::Utc;
+use chrono::{DateTime, Duration, Utc};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
+
+/// Hard ceiling on the on-disk audit log size, in bytes. Defense-in-depth
+/// against the age policy running away — even at the maximum allowed
+/// `retentionDays`, a single Vault's log cannot grow past this.
+pub(crate) const MAX_LOG_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Default `retentionDays` used when nothing has pushed a value in yet —
+/// matches the public default in [`crate::commands::settings::AuditSettings`].
+/// Duplicated here (rather than imported) so the audit service stays free
+/// of a dependency on the commands layer.
+const DEFAULT_RETENTION_DAYS: u32 = 90;
 
 /// Errors surfaced from [`AuditService::read`]. Distinct from the
 /// internally-swallowed errors of [`AuditService::record`]: read is called
@@ -48,6 +59,19 @@ pub enum AuditClearError {
     Storage(String),
 }
 
+/// Errors surfaced from [`AuditService::compact`]. Compaction is a
+/// best-effort retention operation that the audit subsystem runs lazily
+/// from `record`; it is also directly callable for tests. Failures are
+/// distinct from the infallible `record` path because a test or settings-
+/// triggered compaction wants the failure to be observable.
+#[derive(Debug, Error)]
+pub enum AuditCompactError {
+    #[error("audit key unavailable: {0}")]
+    Key(String),
+    #[error("audit compact failed: {0}")]
+    Storage(String),
+}
+
 /// Permissive filter applied by [`AuditService::read`]. Shape is in place so
 /// future issues can plug in `kinds` / time-range filtering without changing
 /// callers; today it returns everything.
@@ -64,10 +88,32 @@ pub struct AuditService {
     /// Pushed in from `update_app_preferences` and at startup; defaults
     /// to true so a fresh `AuditService` records out of the box.
     enabled: AtomicBool,
+    /// Configured age cap pushed in from `AuditSettings.retentionDays`.
+    /// Validated to `1..=365` at the settings boundary, so any value
+    /// stored here is already in range; we still saturate at `u32` here
+    /// for cheap atomic reads from the `record` hot path.
+    retention_days: AtomicU32,
+    /// On-disk size ceiling beyond which the lazy trigger fires
+    /// compaction. Defaults to [`MAX_LOG_BYTES`]; overridable via
+    /// [`AuditService::set_size_cap_for_test`] so tests can exercise
+    /// the trigger without writing 10 MiB of fake data.
+    size_cap: AtomicU64,
+    /// Whether the lazy compaction trigger in `record` fires at all.
+    /// `true` in production; tests that want to inspect the explicit
+    /// `compact` pass in isolation flip this to `false` so setup
+    /// `record` calls don't pre-compact behind the assertion.
+    lazy_trigger_enabled: AtomicBool,
     /// Per-Vault consecutive-failed-unlock counters, keyed by canonicalized
     /// path. Lives in memory only — resets on process restart per the AC's
     /// "per session" wording.
     attempts: Mutex<HashMap<PathBuf, u32>>,
+    /// Per-Vault cached oldest event timestamp, populated lazily on the
+    /// first `record` for a Vault after process start (and after each
+    /// successful compaction). The lazy-trigger check reads from this
+    /// cache so `record` doesn't have to re-decode the whole log on
+    /// every append — only the first append for a Vault, and again
+    /// after a compaction shrinks the log.
+    oldest: Mutex<HashMap<PathBuf, DateTime<Utc>>>,
 }
 
 impl AuditService {
@@ -77,8 +123,43 @@ impl AuditService {
             key_source,
             degraded: AtomicBool::new(false),
             enabled: AtomicBool::new(true),
+            retention_days: AtomicU32::new(DEFAULT_RETENTION_DAYS),
+            size_cap: AtomicU64::new(MAX_LOG_BYTES),
+            lazy_trigger_enabled: AtomicBool::new(true),
             attempts: Mutex::new(HashMap::new()),
+            oldest: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Test-only hook: override the on-disk size cap so the lazy trigger
+    /// can be exercised with a tiny synthetic ceiling instead of the
+    /// production 10 MiB. Production paths leave this at
+    /// [`MAX_LOG_BYTES`].
+    pub fn set_size_cap_for_test(&self, n: u64) {
+        self.size_cap.store(n, Ordering::SeqCst);
+    }
+
+    /// Test-only hook: suspend the lazy compaction trigger in `record`
+    /// so setup-phase appends don't silently pre-compact the log before
+    /// an assertion runs. Production paths leave the trigger enabled.
+    pub fn set_lazy_trigger_enabled_for_test(&self, enabled: bool) {
+        self.lazy_trigger_enabled.store(enabled, Ordering::SeqCst);
+    }
+
+    fn size_cap(&self) -> u64 {
+        self.size_cap.load(Ordering::SeqCst)
+    }
+
+    /// Pushes the configured `retentionDays` in from settings. Called from
+    /// `update_app_preferences` / `reset_app_preferences` / startup, the
+    /// same plumbing that drives [`AuditService::set_enabled`]. Stored as
+    /// an atomic so `record` can read it on the hot path without a lock.
+    pub fn set_retention_days(&self, days: u32) {
+        self.retention_days.store(days, Ordering::SeqCst);
+    }
+
+    fn retention_days(&self) -> u32 {
+        self.retention_days.load(Ordering::SeqCst)
     }
 
     /// Flips the master logging gate. Off => [`AuditService::record`]
@@ -124,8 +205,60 @@ impl AuditService {
         let log_path = self.log_path_for(vault_path);
         let log = AuditLogFile::new(log_path.clone());
         log.append(&frame).map_err(|_| ())?;
-        apply_retention(&log_path);
+
+        // Update the cached oldest-timestamp for this vault: the
+        // just-appended event is the smallest known timestamp if the
+        // cache was empty, or stays unchanged if an older event was
+        // already recorded earlier in this session. Failures swallowed —
+        // a poisoned mutex must not cause an audit record to silently
+        // re-error after the storage append already succeeded.
+        let event_ts = match event {
+            AuditEvent::VaultUnlockFailed { timestamp, .. }
+            | AuditEvent::VaultOpened { timestamp }
+            | AuditEvent::VaultLocked { timestamp, .. }
+            | AuditEvent::EntryPasswordRevealed { timestamp, .. }
+            | AuditEvent::EntryPasswordCopied { timestamp, .. }
+            | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
+            | AuditEvent::AuditCleared { timestamp } => *timestamp,
+        };
+        if let Ok(mut map) = self.oldest.lock() {
+            let key = attempts_key(vault_path);
+            map.entry(key)
+                .and_modify(|t| {
+                    if event_ts < *t {
+                        *t = event_ts;
+                    }
+                })
+                .or_insert(event_ts);
+        }
+
+        // Lazy compaction trigger: synchronous because `record` itself is
+        // already best-effort and called *after* the triggering user
+        // action has returned, so latency here cannot regress the
+        // user-facing flow. Errors swallowed: compaction is a
+        // housekeeping nicety, not a correctness requirement.
+        self.maybe_trigger_compaction(vault_path);
         Ok(())
+    }
+
+    fn maybe_trigger_compaction(&self, vault_path: &Path) {
+        if !self.lazy_trigger_enabled.load(Ordering::SeqCst) {
+            return;
+        }
+        let path = self.log_path_for(vault_path);
+        let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        let now = Utc::now();
+        let cutoff = now - Duration::days(i64::from(self.retention_days()));
+        let oldest = self
+            .oldest
+            .lock()
+            .ok()
+            .and_then(|m| m.get(&attempts_key(vault_path)).copied());
+        let size_trigger = size > self.size_cap();
+        let age_trigger = oldest.is_some_and(|ts| ts < cutoff);
+        if size_trigger || age_trigger {
+            let _ = self.compact(vault_path);
+        }
     }
 
     /// Returns every recorded event for the Vault at `vault_path` that
@@ -296,6 +429,119 @@ impl AuditService {
             map.remove(&attempts_key(vault_path));
         }
     }
+
+    /// Forces a retention compaction pass on the per-Vault log: reads
+    /// every encrypted frame under the exclusive storage lock, decrypts
+    /// to [`AuditEvent`]s, partitions by the configured `retentionDays`
+    /// and the [`MAX_LOG_BYTES`] hard cap via
+    /// [`partition_by_retention`], re-encrypts the keepers with fresh
+    /// XChaCha20-Poly1305 nonces, and atomically replaces the file.
+    ///
+    /// Public so the lazy trigger in `record` and tests can invoke it
+    /// directly. Returns the kept / dropped counts so callers can verify
+    /// idempotency (a second run on an already-in-window log drops 0).
+    ///
+    /// Skipped (returns `CompactStats::default()`) when the master gate
+    /// is off — disabled audit logging shouldn't trigger background
+    /// rewrites against an existing log. Frames that fail to decrypt
+    /// (auth failure, wrong key) flip `degraded` and are *dropped* from
+    /// the rewrite: keeping unreadable frames around forever would let
+    /// a corrupt log bloat the file with bytes the user can never see.
+    pub fn compact(&self, vault_path: &Path) -> Result<CompactStats, AuditCompactError> {
+        if !self.is_enabled() {
+            return Ok(CompactStats::default());
+        }
+        let key = self
+            .key_source
+            .get_or_create()
+            .map_err(|e| AuditCompactError::Key(e.to_string()))?;
+
+        let now = Utc::now();
+        let max_age = Duration::days(i64::from(self.retention_days()));
+        let max_bytes = usize::try_from(self.size_cap()).unwrap_or(usize::MAX);
+
+        let log = AuditLogFile::new(self.log_path_for(vault_path));
+        let mut undecryptable: usize = 0;
+        let degraded_flag = &self.degraded;
+
+        let stats = log
+            .compact(|frames| {
+                let mut sized: Vec<SizedEvent> = Vec::with_capacity(frames.len());
+                for frame in frames {
+                    match decrypt_and_parse(&key, &frame) {
+                        Some(event) => {
+                            // Approximate encoded size: base64 of the
+                            // frame, plus newline. This is the same
+                            // shape the writer will produce, so the
+                            // size-cap accounting is exact.
+                            let encoded_len = encode_frame(&frame).len() + 1;
+                            sized.push(SizedEvent { event, encoded_len });
+                        }
+                        None => {
+                            undecryptable = undecryptable.saturating_add(1);
+                        }
+                    }
+                }
+
+                let (keep, _drop) = partition_by_retention(sized, now, max_age, max_bytes);
+
+                // Re-encrypt keepers with fresh nonces. If any individual
+                // re-encryption fails (vanishingly unlikely with a valid
+                // key) we drop that frame rather than abort — the
+                // retention pass should always converge, and dropping a
+                // single frame is preferable to refusing to compact a
+                // bloated log at all.
+                keep.into_iter()
+                    .filter_map(|s| encrypt(&key, &s.event.to_bytes()).ok())
+                    .collect()
+            })
+            .map_err(|e| {
+                degraded_flag.store(true, Ordering::SeqCst);
+                AuditCompactError::Storage(e.to_string())
+            })?;
+
+        if undecryptable > 0 {
+            self.degraded.store(true, Ordering::SeqCst);
+        }
+
+        // Refresh the cached oldest timestamp so the next lazy-trigger
+        // check uses post-compaction state. Re-read the file rather than
+        // tracking it through the closure: the file is now smaller and
+        // the re-read is cheap.
+        self.refresh_oldest(vault_path, &key);
+
+        Ok(stats)
+    }
+
+    /// Recomputes and caches the oldest timestamp on disk for
+    /// `vault_path`. Best-effort: failures (key unavailable, file
+    /// unreadable, no decryptable frames) clear the cache entry rather
+    /// than poisoning it with stale data.
+    fn refresh_oldest(&self, vault_path: &Path, key: &[u8; KEY_LEN]) {
+        let log = AuditLogFile::new(self.log_path_for(vault_path));
+        let Ok(outcome) = log.read_all() else {
+            if let Ok(mut map) = self.oldest.lock() {
+                map.remove(&attempts_key(vault_path));
+            }
+            return;
+        };
+        let oldest_ts = outcome
+            .frames
+            .iter()
+            .filter_map(|f| decrypt_and_parse(key, f))
+            .map(|e| event_timestamp(&e))
+            .min();
+        if let Ok(mut map) = self.oldest.lock() {
+            match oldest_ts {
+                Some(ts) => {
+                    map.insert(attempts_key(vault_path), ts);
+                }
+                None => {
+                    map.remove(&attempts_key(vault_path));
+                }
+            }
+        }
+    }
 }
 
 fn attempts_key(vault_path: &Path) -> PathBuf {
@@ -307,6 +553,18 @@ fn attempts_key(vault_path: &Path) -> PathBuf {
 fn decrypt_and_parse(key: &[u8; KEY_LEN], frame: &[u8]) -> Option<AuditEvent> {
     let plaintext = decrypt(key, frame).ok()?;
     AuditEvent::from_bytes(&plaintext).ok()
+}
+
+fn event_timestamp(event: &AuditEvent) -> DateTime<Utc> {
+    match event {
+        AuditEvent::VaultUnlockFailed { timestamp, .. }
+        | AuditEvent::VaultOpened { timestamp }
+        | AuditEvent::VaultLocked { timestamp, .. }
+        | AuditEvent::EntryPasswordRevealed { timestamp, .. }
+        | AuditEvent::EntryPasswordCopied { timestamp, .. }
+        | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
+        | AuditEvent::AuditCleared { timestamp } => *timestamp,
+    }
 }
 
 #[cfg(test)]
@@ -801,6 +1059,177 @@ mod tests {
 
         let result = service.clear(&vault);
         assert!(result.is_err(), "clear under unwritable dir must error");
+    }
+
+    /// Acceptance-criteria integration test for issue #222: appending
+    /// many events spanning *more than* the configured `retentionDays`
+    /// and then forcing a compaction must leave only the in-window
+    /// events on disk, in original append order, decryptable end-to-end.
+    /// This is the end-to-end proof that the pure partition function,
+    /// the storage rewrite, and the service-level glue actually compose.
+    #[test]
+    fn compact_drops_events_older_than_retention_and_keeps_the_rest_in_order() {
+        use chrono::Duration;
+        let (service, _dir, vault) = fresh_service();
+        service.set_retention_days(30);
+        // Suspend the lazy trigger so setup `record` calls don't
+        // silently pre-compact behind the explicit compact assertion.
+        service.set_lazy_trigger_enabled_for_test(false);
+
+        let now = Utc::now();
+        // 100 events: half outside the 30-day window, half inside.
+        // Append timestamps in chronological order so the in-window
+        // remainder must come back from `read` in the same order.
+        for i in 0..50 {
+            let evt = AuditEvent::VaultUnlockFailed {
+                timestamp: now - Duration::days(60) + Duration::seconds(i),
+                attempt_count: u32::try_from(i + 1).unwrap(),
+            };
+            service.record(&vault, &evt);
+        }
+        for i in 0..50 {
+            let evt = AuditEvent::VaultUnlockFailed {
+                timestamp: now - Duration::days(5) + Duration::seconds(i),
+                attempt_count: u32::try_from(i + 1).unwrap(),
+            };
+            service.record(&vault, &evt);
+        }
+
+        let stats = service.compact(&vault).expect("compact");
+        assert_eq!(stats.kept, 50);
+        assert_eq!(stats.dropped, 50);
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 50);
+        // Every surviving event must be inside the 30-day window and in
+        // append order — the partition pass preserves chronological
+        // order so the audit panel reads as a continuous stream.
+        let cutoff = now - Duration::days(30);
+        for (i, evt) in events.iter().enumerate() {
+            match evt {
+                AuditEvent::VaultUnlockFailed {
+                    timestamp,
+                    attempt_count,
+                } => {
+                    assert!(*timestamp >= cutoff, "kept event {i} is past the cutoff");
+                    assert_eq!(*attempt_count, u32::try_from(i + 1).unwrap());
+                }
+                other => panic!("unexpected variant in kept log: {other:?}"),
+            }
+        }
+    }
+
+    /// Idempotency: a second compact run touches nothing because the
+    /// first pass already left only in-window events behind.
+    #[test]
+    fn compact_is_idempotent_against_an_already_compact_log() {
+        use chrono::Duration;
+        let (service, _dir, vault) = fresh_service();
+        service.set_retention_days(30);
+        service.set_lazy_trigger_enabled_for_test(false);
+
+        let now = Utc::now();
+        for i in 0..5 {
+            let evt = AuditEvent::VaultUnlockFailed {
+                timestamp: now - Duration::days(60) + Duration::seconds(i),
+                attempt_count: u32::try_from(i + 1).unwrap(),
+            };
+            service.record(&vault, &evt);
+        }
+        for i in 0..5 {
+            let evt = AuditEvent::VaultUnlockFailed {
+                timestamp: now - Duration::hours(1) + Duration::seconds(i),
+                attempt_count: u32::try_from(i + 1).unwrap(),
+            };
+            service.record(&vault, &evt);
+        }
+
+        let first = service.compact(&vault).expect("first compact");
+        assert_eq!(first.dropped, 5);
+
+        let second = service.compact(&vault).expect("second compact");
+        assert_eq!(second.dropped, 0, "second compact must drop nothing");
+        assert_eq!(second.kept, 5);
+    }
+
+    /// Lazy trigger #1: when the oldest event already on disk is older
+    /// than `retentionDays`, the very next `record` call automatically
+    /// runs a compaction pass — the user never has to manually trim and
+    /// the audit panel never accumulates ancient events. Verified by
+    /// configuring a 1-day retention, backdating one event, then
+    /// recording a fresh one and reading back the post-trigger state.
+    #[test]
+    fn record_triggers_compaction_when_cached_oldest_is_past_retention() {
+        use chrono::Duration;
+        let (service, _dir, vault) = fresh_service();
+        service.set_retention_days(1);
+
+        let now = Utc::now();
+        let stale = AuditEvent::VaultUnlockFailed {
+            timestamp: now - Duration::days(3),
+            attempt_count: 1,
+        };
+        let fresh = AuditEvent::VaultUnlockFailed {
+            timestamp: now,
+            attempt_count: 2,
+        };
+
+        service.record(&vault, &stale);
+        // After the stale append the cached-oldest is 3 days ago. The
+        // next record's lazy-trigger check should fire and rewrite the
+        // log without the stale entry.
+        service.record(&vault, &fresh);
+
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert_eq!(events.len(), 1, "compaction must drop the stale entry");
+        match &events[0] {
+            AuditEvent::VaultUnlockFailed { attempt_count, .. } => {
+                assert_eq!(*attempt_count, 2);
+            }
+            other => panic!("expected VaultUnlockFailed, got {other:?}"),
+        }
+    }
+
+    /// Lazy trigger #2: when the on-disk file crosses the size cap, the
+    /// next `record` automatically compacts. Tested with a synthetic
+    /// small cap so we don't have to actually write 10 MiB.
+    #[test]
+    fn record_triggers_compaction_when_file_exceeds_size_cap() {
+        let (service, _dir, vault) = fresh_service();
+        // Cap small enough that two appends will push it past — each
+        // base64 frame is roughly 90+ bytes. The third record's trigger
+        // check must rewrite the file.
+        service.set_size_cap_for_test(100);
+
+        let now = Utc::now();
+        for i in 1..=3u32 {
+            service.record(
+                &vault,
+                &AuditEvent::VaultUnlockFailed {
+                    timestamp: now,
+                    attempt_count: i,
+                },
+            );
+        }
+
+        // After the size-cap trigger, the kept set must satisfy the cap
+        // OR be the single surviving event (per the floor rule).
+        let log_path = service.log_path_for(&vault);
+        let size = std::fs::metadata(&log_path).map(|m| m.len()).unwrap_or(0);
+        let events = service.read(&vault, &AuditFilter::default()).expect("read");
+        assert!(
+            size <= 100 || events.len() == 1,
+            "post-trigger size {size} must respect cap or be the single-event floor (events={})",
+            events.len()
+        );
+        // And the LATEST event must be among the survivors — the size
+        // cap drops oldest-first, never the just-appended event.
+        match events.last().expect("at least one event") {
+            AuditEvent::VaultUnlockFailed { attempt_count, .. } => {
+                assert_eq!(*attempt_count, 3);
+            }
+            other => panic!("expected VaultUnlockFailed, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -157,6 +157,92 @@ impl AuditLogFile {
         result.map_err(StorageError::from)
     }
 
+    /// Atomically rewrites the log to contain the frames produced by
+    /// `rewriter`. The rewriter receives every existing decoded frame in
+    /// append order and returns the subset (or transformation) to keep;
+    /// the closure shape lets the caller apply a global policy like the
+    /// audit retention size cap that no per-frame predicate can express.
+    ///
+    /// Atomicity: the new content is written to a sibling temp file under
+    /// the exclusive sidecar lock and atomically renamed over the
+    /// original. A crash mid-write leaves the original log intact —
+    /// callers never observe a partial file. Locking is the same sidecar
+    /// scheme as [`AuditLogFile::append`] / [`AuditLogFile::replace_with_single`]
+    /// so a concurrent appender or reader that arrives mid-compaction
+    /// blocks on the stable lock target rather than the about-to-be-
+    /// unlinked log inode.
+    ///
+    /// If the rewriter returns an empty vec, the destination file is
+    /// truncated to zero bytes — a fresh-cleared state. Missing input
+    /// file is treated as an empty input.
+    pub fn compact<F>(&self, rewriter: F) -> Result<CompactStats, StorageError>
+    where
+        F: FnOnce(Vec<Vec<u8>>) -> Vec<Vec<u8>>,
+    {
+        let _guard = self
+            .write_lock
+            .lock()
+            .map_err(|_| StorageError::Io("audit compact mutex poisoned".into()))?;
+
+        let lock = self.open_sidecar_lock()?;
+        FileExt::lock_exclusive(&lock)?;
+
+        let result = (|| -> std::io::Result<CompactStats> {
+            // Read existing frames under the exclusive lock so no
+            // concurrent appender can interleave a frame that the
+            // rewriter won't get to see.
+            let existing = match File::open(&self.path) {
+                Ok(f) => {
+                    let reader = BufReader::new(&f);
+                    let mut frames: Vec<Vec<u8>> = Vec::new();
+                    for line in reader.lines() {
+                        let line = line?;
+                        if line.trim().is_empty() {
+                            continue;
+                        }
+                        if let Ok(frame) = decode_frame(&line) {
+                            frames.push(frame);
+                        }
+                        // Malformed lines are dropped silently here:
+                        // they were already unrecoverable, and the
+                        // service-level read path is what surfaces the
+                        // degraded indicator to the user.
+                    }
+                    frames
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+                Err(e) => return Err(e),
+            };
+            let input_count = existing.len();
+
+            let kept = rewriter(existing);
+            let kept_count = kept.len();
+
+            let tmp_path = tmp_path_for(&self.path);
+            let mut tmp = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp_path)?;
+            for frame in &kept {
+                let line = encode_frame(frame);
+                tmp.write_all(line.as_bytes())?;
+                tmp.write_all(b"\n")?;
+            }
+            tmp.sync_data()?;
+            drop(tmp);
+            std::fs::rename(&tmp_path, &self.path)?;
+
+            Ok(CompactStats {
+                kept: kept_count,
+                dropped: input_count.saturating_sub(kept_count),
+            })
+        })();
+
+        let _ = FileExt::unlock(&lock);
+        result.map_err(StorageError::from)
+    }
+
     /// Reads all frames in append order. Missing file returns an empty
     /// outcome. Lines that fail base64 decode are *counted* in
     /// [`LogReadOutcome::malformed_lines`] rather than dropped silently:
@@ -221,6 +307,16 @@ fn tmp_path_for(path: &Path) -> PathBuf {
 pub struct LogReadOutcome {
     pub frames: Vec<Vec<u8>>,
     pub malformed_lines: usize,
+}
+
+/// Summary of a compaction pass. Exposes the count of kept and dropped
+/// frames so the service layer can verify that the rewriter actually
+/// shrunk the log (and tests can assert idempotency by checking that a
+/// second run drops zero).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct CompactStats {
+    pub kept: usize,
+    pub dropped: usize,
 }
 
 #[cfg(test)]
@@ -475,6 +571,109 @@ mod tests {
             frames.contains(&b"late-append".to_vec()),
             "late append was lost to orphaned inode: {frames:?}"
         );
+    }
+
+    /// `compact` is the storage operation that backs retention rewrites:
+    /// it reads every frame under the exclusive sidecar lock, hands them
+    /// to a rewriter closure, and atomically replaces the log file with
+    /// whatever the rewriter returns. The identity case (rewriter returns
+    /// the input verbatim) must round-trip the on-disk content frame-for-
+    /// frame — proof that the read→write path doesn't lose, reorder, or
+    /// re-encode frames behind the rewriter's back.
+    #[test]
+    fn compact_with_identity_rewriter_preserves_frames_in_order() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("v.jsonl"));
+
+        log.append(b"first").expect("append first");
+        log.append(b"second").expect("append second");
+        log.append(b"third").expect("append third");
+
+        let stats = log.compact(|frames| frames).expect("compact identity");
+        assert_eq!(stats.kept, 3);
+        assert_eq!(stats.dropped, 0);
+
+        let outcome = log.read_all().expect("read");
+        assert_eq!(
+            outcome.frames,
+            vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
+        );
+        assert_eq!(outcome.malformed_lines, 0);
+    }
+
+    /// An empty rewriter result truncates the log to zero bytes. This
+    /// is the "everything aged out" extreme — the file must still exist
+    /// (so a future append goes through normally) but `read_all` should
+    /// report an empty frame list.
+    #[test]
+    fn compact_with_empty_rewriter_truncates_log() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("v.jsonl"));
+
+        log.append(b"first").expect("append first");
+        log.append(b"second").expect("append second");
+
+        let stats = log.compact(|_| Vec::new()).expect("compact empty");
+        assert_eq!(stats.kept, 0);
+        assert_eq!(stats.dropped, 2);
+
+        let outcome = log.read_all().expect("read");
+        assert!(outcome.frames.is_empty());
+        assert_eq!(outcome.malformed_lines, 0);
+
+        // Following append must succeed against the truncated file.
+        log.append(b"after").expect("append after");
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames, vec![b"after".to_vec()]);
+    }
+
+    /// The rewriter is the policy seat — it can keep an arbitrary subset
+    /// in arbitrary order. This test pins the contract: storage applies
+    /// whatever the rewriter returns verbatim, with no implicit ordering
+    /// fixups, so retention can hand back exactly the survivors.
+    #[test]
+    fn compact_with_filter_rewriter_keeps_selected_frames() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("v.jsonl"));
+
+        log.append(b"alpha").expect("append alpha");
+        log.append(b"beta").expect("append beta");
+        log.append(b"gamma").expect("append gamma");
+        log.append(b"delta").expect("append delta");
+
+        let stats = log
+            .compact(|frames| {
+                frames
+                    .into_iter()
+                    .filter(|f| f == b"beta" || f == b"delta")
+                    .collect()
+            })
+            .expect("compact filter");
+        assert_eq!(stats.kept, 2);
+        assert_eq!(stats.dropped, 2);
+
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames, vec![b"beta".to_vec(), b"delta".to_vec()]);
+    }
+
+    /// Compacting an empty / missing log is a no-op — the rewriter
+    /// sees an empty input, returns an empty output, and the file
+    /// (if it existed) ends up empty. No panic, no error.
+    #[test]
+    fn compact_on_missing_file_is_a_no_op() {
+        let dir = tempdir().expect("tempdir");
+        let log = AuditLogFile::new(dir.path().join("nope.jsonl"));
+
+        let stats = log
+            .compact(|frames| {
+                assert!(frames.is_empty());
+                frames
+            })
+            .expect("compact missing");
+        assert_eq!(stats, CompactStats::default());
+
+        let outcome = log.read_all().expect("read");
+        assert!(outcome.frames.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/services/audit/storage.rs
+++ b/src-tauri/src/services/audit/storage.rs
@@ -190,7 +190,10 @@ impl AuditLogFile {
         let result = (|| -> std::io::Result<CompactStats> {
             // Read existing frames under the exclusive lock so no
             // concurrent appender can interleave a frame that the
-            // rewriter won't get to see.
+            // rewriter won't get to see. Count malformed lines as we
+            // go: silently dropping them would let a corrupt log be
+            // rewritten without flipping the degraded banner.
+            let mut malformed_lines: usize = 0;
             let existing = match File::open(&self.path) {
                 Ok(f) => {
                     let reader = BufReader::new(&f);
@@ -200,13 +203,12 @@ impl AuditLogFile {
                         if line.trim().is_empty() {
                             continue;
                         }
-                        if let Ok(frame) = decode_frame(&line) {
-                            frames.push(frame);
+                        match decode_frame(&line) {
+                            Ok(frame) => frames.push(frame),
+                            Err(_) => {
+                                malformed_lines = malformed_lines.saturating_add(1);
+                            }
                         }
-                        // Malformed lines are dropped silently here:
-                        // they were already unrecoverable, and the
-                        // service-level read path is what surfaces the
-                        // degraded indicator to the user.
                     }
                     frames
                 }
@@ -236,6 +238,7 @@ impl AuditLogFile {
             Ok(CompactStats {
                 kept: kept_count,
                 dropped: input_count.saturating_sub(kept_count),
+                malformed_lines,
             })
         })();
 
@@ -309,14 +312,21 @@ pub struct LogReadOutcome {
     pub malformed_lines: usize,
 }
 
-/// Summary of a compaction pass. Exposes the count of kept and dropped
-/// frames so the service layer can verify that the rewriter actually
-/// shrunk the log (and tests can assert idempotency by checking that a
-/// second run drops zero).
+/// Summary of a compaction pass. Exposes kept, dropped, and the count
+/// of base64-malformed lines the read pass skipped over.
+///
+/// `malformed_lines` is surfaced (not silently swallowed) because lazy
+/// compaction runs in the background from `record` — without this
+/// signal a corrupt line would be permanently deleted from disk on the
+/// next compaction without the user-facing `degraded` banner ever
+/// flipping. The service layer reads this field after every compact
+/// call and flips `degraded` when non-zero, matching the behavior of
+/// [`LogReadOutcome::malformed_lines`] on the read path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct CompactStats {
     pub kept: usize,
     pub dropped: usize,
+    pub malformed_lines: usize,
 }
 
 #[cfg(test)]
@@ -654,6 +664,43 @@ mod tests {
 
         let outcome = log.read_all().expect("read");
         assert_eq!(outcome.frames, vec![b"beta".to_vec(), b"delta".to_vec()]);
+    }
+
+    /// `compact` must count base64-malformed lines and surface them
+    /// through [`CompactStats::malformed_lines`] — otherwise a lazy
+    /// compaction running before the user opens the audit panel would
+    /// silently delete unreadable lines and the degraded banner would
+    /// never appear. Splice in a non-base64 line and assert the count.
+    #[test]
+    fn compact_counts_malformed_lines_so_caller_can_flag_degraded() {
+        use std::io::Write;
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("v.jsonl");
+        let log = AuditLogFile::new(path.clone());
+
+        log.append(b"first").expect("append first");
+
+        // Splice a raw non-base64 line — `!!!` isn't in the standard
+        // base64 alphabet.
+        let mut f = OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .expect("reopen for raw append");
+        f.write_all(b"!!!not-base64!!!\n").expect("write junk");
+        drop(f);
+
+        log.append(b"third").expect("append third");
+
+        let stats = log.compact(|frames| frames).expect("compact identity");
+        assert_eq!(stats.kept, 2);
+        assert_eq!(stats.dropped, 0);
+        assert_eq!(
+            stats.malformed_lines, 1,
+            "compact must surface the malformed line count"
+        );
+
+        let outcome = log.read_all().expect("read");
+        assert_eq!(outcome.frames, vec![b"first".to_vec(), b"third".to_vec()]);
     }
 
     /// Compacting an empty / missing log is a no-op — the rewriter


### PR DESCRIPTION
## Summary

Implements [#222](https://github.com/SchnitzelAndSpaetzle/mithril-vault/issues/222): replaces the audit-log retention stub with a real two-stage policy and wires lazy compaction into the append path.

- **`retention::partition_by_retention(events, now, max_age, max_bytes) -> (keep, drop)`** — pure function over `SizedEvent { event, encoded_len }`. Age cutoff is inclusive; over-cap drops oldest survivors; a single oversized event is retained so the cap never silently empties the log. `now` is injected for deterministic tests.
- **`AuditLogFile::compact<F>(rewriter)`** — exclusive sidecar lock + atomic temp+rename. A crash mid-write leaves the original log intact; concurrent appenders/readers block on the stable sidecar (same scheme as `append` and `replace_with_single`).
- **`AuditService::compact`** — composes the two: decrypts, partitions, re-encrypts with fresh XChaCha20-Poly1305 nonces. Idempotent.
- **Lazy trigger in `record`** — caches per-Vault oldest timestamp; after a successful append, if `size > cap` or `oldest < now − retentionDays`, runs compaction. Inline-synchronous since `record` is best-effort and called after the user-facing action has already returned. Test-only `set_size_cap_for_test` / `set_lazy_trigger_enabled_for_test` hooks isolate explicit-compact assertions from the trigger.
- **Settings wiring** — `set_retention_days` pushed in from `AuditSettings` at startup, `update_app_preferences`, and `reset_app_preferences`, mirroring the existing `set_enabled` plumbing. Hard 10 MB ceiling is a constant (`MAX_LOG_BYTES`), enforced independently of `retentionDays`.

## Test plan

- [x] `cargo test --lib services::audit` — 73 tests pass, including 6 table-driven partition tests (empty / all-young / all-old / boundary / over-cap / single-oversized), 4 storage::compact tests, the 100-event integration AC test, idempotency, and both lazy-trigger paths.
- [x] `cargo test --lib` — full Rust suite (247 tests) green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `bun run check` — lint + format clean (pre-existing warnings unchanged).
- [x] `bun run test` — 393 frontend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)