### PR TITLE
feat(ui): translate audit log panel and event labels to de/es/fr/sr (#224)

### DIFF
--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -34,6 +34,7 @@
       "entryPasswordRevealed": "Passwort angezeigt",
       "entryPasswordCopied": "Passwort kopiert",
       "entryProtectedFieldRevealed": "Geschütztes Feld angezeigt",
+      "preferencesSecurityChanged": "Sicherheitseinstellung geändert",
       "auditCleared": "Audit-Protokoll geleert"
     },
     "reason": {
@@ -41,6 +42,19 @@
       "autoLock": "Auto-Sperre",
       "appQuit": "App beendet",
       "screenLock": "Bildschirmsperre"
+    },
+    "settingName": {
+      "security": {
+        "clipboardClearTimeout": "Zwischenablage löschen nach",
+        "preventScreenCapture": "Bildschirmaufnahme verhindern",
+        "autoDownloadFavicons": "Favicons automatisch herunterladen",
+        "allowThirdPartyFaviconFallbacks": "Favicon-Fallback-Dienste von Drittanbietern erlauben",
+        "autoLockTimeout": "Automatische Sperre"
+      },
+      "audit": {
+        "enabled": "Audit-Protokollierung aktiviert",
+        "retentionDays": "Audit-Aufbewahrung (Tage)"
+      }
     },
     "clearButton": "Audit-Protokoll leeren",
     "clearConfirmTitle": "Audit-Protokoll leeren?",
@@ -146,16 +160,16 @@
       "dataLocation": "Datenspeicherort"
     },
     "audit": {
-      "title": "Audit log",
-      "description": "Record security-relevant events for your vaults on this device.",
+      "title": "Audit-Protokoll",
+      "description": "Sicherheitsrelevante Ereignisse für Ihre Tresore auf diesem Gerät aufzeichnen.",
       "enabled": {
-        "label": "Enable audit logging",
-        "description": "When off, no new events are written. Your existing log file is preserved."
+        "label": "Audit-Protokollierung aktivieren",
+        "description": "Bei Deaktivierung werden keine neuen Ereignisse geschrieben. Ihre bestehende Protokolldatei bleibt erhalten."
       },
       "retentionDays": {
-        "label": "Retention (days)",
-        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
-        "validation": "Retention must be between 1 and 365 days."
+        "label": "Aufbewahrung (Tage)",
+        "description": "Wie lange Audit-Ereignisse aufbewahrt werden. Gültiger Bereich: 1 bis 365 Tage. Das Bereinigen älterer Ereignisse wird derzeit noch nicht erzwungen.",
+        "validation": "Die Aufbewahrung muss zwischen 1 und 365 Tagen liegen."
       }
     },
     "backups": {

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -34,6 +34,7 @@
       "entryPasswordRevealed": "Contraseña revelada",
       "entryPasswordCopied": "Contraseña copiada",
       "entryProtectedFieldRevealed": "Campo protegido revelado",
+      "preferencesSecurityChanged": "Preferencia de seguridad modificada",
       "auditCleared": "Registro de auditoría borrado"
     },
     "reason": {
@@ -41,6 +42,19 @@
       "autoLock": "Auto-bloqueo",
       "appQuit": "App cerrada",
       "screenLock": "Bloqueo de pantalla"
+    },
+    "settingName": {
+      "security": {
+        "clipboardClearTimeout": "Tiempo de limpieza del portapapeles",
+        "preventScreenCapture": "Impedir capturas de pantalla",
+        "autoDownloadFavicons": "Descargar favicons automáticamente",
+        "allowThirdPartyFaviconFallbacks": "Permitir servicios de respaldo de favicon de terceros",
+        "autoLockTimeout": "Tiempo de bloqueo automático"
+      },
+      "audit": {
+        "enabled": "Registro de auditoría activado",
+        "retentionDays": "Retención de auditoría (días)"
+      }
     },
     "clearButton": "Borrar registro de auditoría",
     "clearConfirmTitle": "¿Borrar registro de auditoría?",
@@ -146,16 +160,16 @@
       "dataLocation": "Ubicación de datos"
     },
     "audit": {
-      "title": "Audit log",
-      "description": "Record security-relevant events for your vaults on this device.",
+      "title": "Registro de auditoría",
+      "description": "Registra los eventos relevantes para la seguridad de sus bóvedas en este dispositivo.",
       "enabled": {
-        "label": "Enable audit logging",
-        "description": "When off, no new events are written. Your existing log file is preserved."
+        "label": "Activar el registro de auditoría",
+        "description": "Cuando está desactivado, no se escriben eventos nuevos. Su archivo de registro existente se conserva."
       },
       "retentionDays": {
-        "label": "Retention (days)",
-        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
-        "validation": "Retention must be between 1 and 365 days."
+        "label": "Retención (días)",
+        "description": "Cuánto tiempo se conservan los eventos de auditoría. Rango válido: 1 a 365 días. La limpieza de eventos antiguos aún no se aplica.",
+        "validation": "La retención debe estar entre 1 y 365 días."
       }
     },
     "backups": {

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -34,6 +34,7 @@
       "entryPasswordRevealed": "Mot de passe affiché",
       "entryPasswordCopied": "Mot de passe copié",
       "entryProtectedFieldRevealed": "Champ protégé affiché",
+      "preferencesSecurityChanged": "Préférence de sécurité modifiée",
       "auditCleared": "Journal d'audit effacé"
     },
     "reason": {
@@ -41,6 +42,19 @@
       "autoLock": "Verrouillage automatique",
       "appQuit": "Quitter l'application",
       "screenLock": "Verrouillage d'écran"
+    },
+    "settingName": {
+      "security": {
+        "clipboardClearTimeout": "Délai d'effacement du presse-papiers",
+        "preventScreenCapture": "Empêcher la capture d'écran",
+        "autoDownloadFavicons": "Téléchargement automatique des favicons",
+        "allowThirdPartyFaviconFallbacks": "Autoriser les services tiers de secours pour les favicons",
+        "autoLockTimeout": "Délai de verrouillage automatique"
+      },
+      "audit": {
+        "enabled": "Journalisation d'audit activée",
+        "retentionDays": "Conservation des audits (jours)"
+      }
     },
     "clearButton": "Effacer le journal d'audit",
     "clearConfirmTitle": "Effacer le journal d'audit ?",
@@ -146,16 +160,16 @@
       "dataLocation": "Emplacement des données"
     },
     "audit": {
-      "title": "Audit log",
-      "description": "Record security-relevant events for your vaults on this device.",
+      "title": "Journal d'audit",
+      "description": "Enregistre les événements liés à la sécurité de vos coffres sur cet appareil.",
       "enabled": {
-        "label": "Enable audit logging",
-        "description": "When off, no new events are written. Your existing log file is preserved."
+        "label": "Activer la journalisation d'audit",
+        "description": "Lorsqu'elle est désactivée, aucun nouvel événement n'est écrit. Votre fichier journal existant est conservé."
       },
       "retentionDays": {
-        "label": "Retention (days)",
-        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
-        "validation": "Retention must be between 1 and 365 days."
+        "label": "Conservation (jours)",
+        "description": "Durée de conservation des événements d'audit. Plage valide : 1 à 365 jours. La purge des événements plus anciens n'est pas encore appliquée.",
+        "validation": "La conservation doit être comprise entre 1 et 365 jours."
       }
     },
     "backups": {

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -34,6 +34,7 @@
       "entryPasswordRevealed": "Lozinka prikazana",
       "entryPasswordCopied": "Lozinka kopirana",
       "entryProtectedFieldRevealed": "Zaštićeno polje prikazano",
+      "preferencesSecurityChanged": "Bezbednosno podešavanje promenjeno",
       "auditCleared": "Dnevnik nadzora obrisan"
     },
     "reason": {
@@ -41,6 +42,19 @@
       "autoLock": "Automatsko zaključavanje",
       "appQuit": "Zatvaranje aplikacije",
       "screenLock": "Zaključavanje ekrana"
+    },
+    "settingName": {
+      "security": {
+        "clipboardClearTimeout": "Vreme brisanja privremene memorije",
+        "preventScreenCapture": "Spreči snimak ekrana",
+        "autoDownloadFavicons": "Automatsko preuzimanje favikona",
+        "allowThirdPartyFaviconFallbacks": "Dozvoli usluge treće strane za rezervne favikone",
+        "autoLockTimeout": "Vreme automatskog zaključavanja"
+      },
+      "audit": {
+        "enabled": "Beleženje nadzora omogućeno",
+        "retentionDays": "Čuvanje nadzora (dani)"
+      }
     },
     "clearButton": "Obriši dnevnik nadzora",
     "clearConfirmTitle": "Obrisati dnevnik nadzora?",
@@ -146,16 +160,16 @@
       "dataLocation": "Lokacija podataka"
     },
     "audit": {
-      "title": "Audit log",
-      "description": "Record security-relevant events for your vaults on this device.",
+      "title": "Dnevnik nadzora",
+      "description": "Beleži bezbednosno značajne događaje za vaše sefove na ovom uređaju.",
       "enabled": {
-        "label": "Enable audit logging",
-        "description": "When off, no new events are written. Your existing log file is preserved."
+        "label": "Omogući beleženje nadzora",
+        "description": "Kada je isključeno, novi događaji se ne upisuju. Vaša postojeća datoteka dnevnika je sačuvana."
       },
       "retentionDays": {
-        "label": "Retention (days)",
-        "description": "How long to keep audit events. Valid range: 1 to 365 days. Cleanup of older events is not enforced yet.",
-        "validation": "Retention must be between 1 and 365 days."
+        "label": "Čuvanje (dani)",
+        "description": "Koliko dugo se čuvaju događaji nadzora. Validan opseg: 1 do 365 dana. Brisanje starijih događaja još uvek nije primenjeno.",
+        "validation": "Čuvanje mora biti između 1 i 365 dana."
       }
     },
     "backups": {


### PR DESCRIPTION
## Summary
- Closes #224. Brings `audit.*` and `settings.audit.*` keys in de/es/fr/sr to full parity with `en/common.json`.
- Adds the missing `audit.kind.preferencesSecurityChanged` and the entire `audit.settingName.{security,audit}.*` subtree to each non-English bundle, with phrasing aligned to the existing security-section translations in that locale.
- Translates the previously-English `settings.audit.*` block (title/description, `enabled.{label,description}`, `retentionDays.{label,description,validation}`) in all four locales.

## Test plan
- [x] `bun run check` — lint + prettier clean.
- [x] `bun run test` — 408/408 pass.
- [x] Parity script: every leaf under `audit.*` and `settings.audit.*` in `en/common.json` exists in `de`, `es`, `fr`, `sr`.
- [ ] Manual smoke: switch app language to de/es/fr/sr and confirm no English fallbacks appear in the Audit Log panel, Audit Log settings section, or the audit `settingName` chips when a `preferences.security_changed` event is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)