### PR TITLE
ci: fix Coverage workflow startup failure on Sonar token guard

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,11 @@ env:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    env:
+      # Resolved here (where the `secrets` context is allowed) so the step-level
+      # `if:` below can check it via the `env` context. Holds only "true"/"false";
+      # the actual token stays scoped to the Sonar step.
+      HAS_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -61,7 +66,9 @@ jobs:
       - name: SonarQube Cloud scan
         # Skip on fork PRs and Dependabot runs where SONAR_TOKEN isn't available;
         # otherwise the step would fail and turn the whole Coverage job red.
-        if: ${{ secrets.SONAR_TOKEN != '' }}
+        # The `secrets` context isn't allowed in step-level `if:`, so the guard
+        # is resolved to a boolean via the job-level `HAS_SONAR_TOKEN` env var.
+        if: env.HAS_SONAR_TOKEN == 'true'
         uses: SonarSource/sonarqube-scan-action@v6
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

The post-merge Coverage runs of PR #236 on `main` failed at workflow startup with zero scheduled jobs. Root cause: my guard `if: ${{ secrets.SONAR_TOKEN != '' }}` used the `secrets` context inside a **step-level** `if:`, which GitHub's parser rejects — per [context availability docs](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), `secrets` is allowed in `env:` and `with:` at any level, but in `if:` only at the **job** level.

## Fix

Resolve the secret presence to a boolean **once** at job level (where `secrets` IS allowed), and check that resolved value in the step-level `if:` via the `env` context:

```yaml
jobs:
  coverage:
    env:
      HAS_SONAR_TOKEN: ${{ secrets.SONAR_TOKEN != '' }}
    steps:
      - name: SonarQube Cloud scan
        if: env.HAS_SONAR_TOKEN == 'true'
        uses: SonarSource/sonarqube-scan-action@v6
        env:
          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
```

`HAS_SONAR_TOKEN` only ever holds the literal string `"true"` or `"false"` — the real token stays scoped to the Sonar step.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"` passes
- [ ] The Coverage workflow on this PR should run successfully (the merge to main was broken specifically because zero jobs were scheduled — on this PR we should see the full job run, with the Sonar step executing because the secret is set on the repo).
- [ ] Confirm SonarCloud picks up this PR's analysis (PR decoration appears).

🤖 Generated with [Claude Code](https://claude.com/claude-code)