### PR TITLE
feat(core): password-health tracer slice (#241)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3094,7 +3094,7 @@ dependencies = [
  "rust-argon2 3.0.0",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ zeroize = { version = "1", features = ["derive"] }
 rand = "0.10"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "bmp", "ico", "webp", "pnm", "tiff"] }
-sha2 = "0.10"
+sha2 = "0.11"
 url = "2"
 uuid = { version = "1", features = ["v4"] }
 

--- a/src-tauri/src/commands/database.rs
+++ b/src-tauri/src/commands/database.rs
@@ -142,12 +142,20 @@ pub async fn open_database<R: Runtime>(
 
 /// Closes a specific open database.
 /// The `db_id` is the path to the database file.
+///
+/// Evicts the password-health cache slot *after* the close succeeds so
+/// a subsequent open of the same path computes a fresh report instead
+/// of returning the previous session's snapshot — generation restarts
+/// at 0 on a fresh open, which would otherwise look like a cache hit.
 #[tauri::command]
 pub async fn close_database(
     db_id: String,
     state: State<'_, Arc<KdbxService>>,
+    health: State<'_, Arc<PasswordHealthService>>,
 ) -> Result<(), AppError> {
-    state.close(&db_id)
+    state.close(&db_id)?;
+    health.on_lock(&db_id);
+    Ok(())
 }
 
 /// Create a new KDBX4 database
@@ -403,8 +411,16 @@ pub async fn restore_backup<R: Runtime>(
     backup_path: String,
     app: AppHandle<R>,
     state: State<'_, Arc<KdbxService>>,
+    health: State<'_, Arc<PasswordHealthService>>,
 ) -> Result<(), AppError> {
     let source_path = state.restore_backup(&backup_path)?;
+    // Restore replaces the on-disk file under the Vault that owns
+    // `source_path`. The in-memory slot is locked-in-place rather than
+    // removed, so the lock-time eviction wired into `lock_database`
+    // does not run here. Evict explicitly so the next unlock recomputes
+    // against the freshly-restored bytes instead of serving the
+    // pre-restore report from cache.
+    health.on_lock(&source_path);
     let _ = app.emit(
         "database-closed",
         DatabaseClosedPayload {

--- a/src-tauri/src/commands/database.rs
+++ b/src-tauri/src/commands/database.rs
@@ -9,6 +9,7 @@ use crate::services::audit::AuditService;
 use crate::services::auto_lock::AutoLockService;
 use crate::services::kdbx::backups::{BackupError, BackupInfo, BackupListEntry};
 use crate::services::kdbx::KdbxService;
+use crate::services::password_health::service::PasswordHealthService;
 use serde::Serialize;
 use std::path::Path;
 use std::sync::Arc;
@@ -246,9 +247,17 @@ pub async fn lock_database(
     db_id: String,
     state: State<'_, Arc<KdbxService>>,
     audit: State<'_, Arc<AuditService>>,
+    health: State<'_, Arc<PasswordHealthService>>,
 ) -> Result<DatabaseInfo, AppError> {
-    let (info, _did_transition) =
+    let (info, did_transition) =
         record_lock_audit(&audit, &db_id, Reason::Manual, state.lock(&db_id))?;
+    if did_transition {
+        // Drop the cached report so a future unlock-then-read pulls a
+        // fresh analysis instead of returning a snapshot from the
+        // pre-lock session. Eviction is idempotent — calling it on a
+        // redundant lock is harmless.
+        health.on_lock(&db_id);
+    }
     Ok(info)
 }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod database;
 pub mod entries;
 pub mod generator;
 pub mod groups;
+pub mod password_health;
 pub mod secure_storage;
 pub mod settings;
 pub mod window;
@@ -22,6 +23,7 @@ pub use database::{
 pub use entries::*;
 pub use generator::*;
 pub use groups::*;
+pub use password_health::*;
 pub use secure_storage::*;
 pub use settings::*;
 pub use window::*;

--- a/src-tauri/src/commands/password_health.rs
+++ b/src-tauri/src/commands/password_health.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+
+//! Tauri commands for the Password Health report.
+//!
+//! In this slice the command surface is the single
+//! [`get_password_health_report`] entry point. It returns a complete
+//! report synchronously per call; progressive analysis via Tauri
+//! events ships in the follow-up cycle. Cancellation will surface
+//! through a separate command then.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use tauri::State;
+
+use crate::dto::error::AppError;
+use crate::dto::password_health::PasswordHealthReportDto;
+use crate::services::kdbx::KdbxService;
+use crate::services::password_health::service::PasswordHealthService;
+
+/// Returns the Password Health report for the Vault at `db_id`.
+///
+/// Cache-keyed on `(db_id, generation)` — repeat calls against an
+/// unchanged Vault return the cached report; a call after a write
+/// (one that flipped `VaultMut::mark_modified`) returns a freshly-
+/// computed report. The clock is `Utc::now()` here so callers in
+/// tests pin time at the service-level entry point rather than at
+/// the IPC boundary.
+#[tauri::command]
+pub async fn get_password_health_report(
+    db_id: String,
+    kdbx: State<'_, Arc<KdbxService>>,
+    health: State<'_, Arc<PasswordHealthService>>,
+) -> Result<PasswordHealthReportDto, AppError> {
+    let report = health.generate_report(&kdbx, &db_id, Utc::now())?;
+    Ok(report.into())
+}

--- a/src-tauri/src/domain/kdbx.rs
+++ b/src-tauri/src/domain/kdbx.rs
@@ -13,6 +13,13 @@ pub struct OpenDatabase {
     pub version: String,
     pub name: String,
     pub root_group_id: String,
+    /// Monotonically increasing per-unlock counter, bumped by
+    /// `VaultMut::mark_modified()`. The Password Health service keys
+    /// its `(db_id, generation)` cache on this counter so a fresh
+    /// analysis runs after every Vault mutation — see ADR 0002. Reset
+    /// to zero on `unlock()` so a re-unlocked Vault doesn't carry
+    /// stale generation numbers from its previous session.
+    pub generation: u64,
 }
 
 impl OpenDatabase {

--- a/src-tauri/src/dto/mod.rs
+++ b/src-tauri/src/dto/mod.rs
@@ -5,9 +5,11 @@ pub mod database;
 pub mod entry;
 pub mod error;
 pub mod group;
+pub mod password_health;
 
 pub use audit::*;
 pub use database::*;
 pub use entry::*;
 pub use error::*;
 pub use group::*;
+pub use password_health::*;

--- a/src-tauri/src/dto/password_health.rs
+++ b/src-tauri/src/dto/password_health.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+
+//! IPC-facing types for the Password Health report.
+//!
+//! Wire shape is camelCase to match the rest of `dto::*`. Finding kinds
+//! serialize as namespaced strings (`"password.expired"`, etc.) — same
+//! convention as Audit Event Kinds. `reuseGroups` is on the wire from
+//! day one even though the reuse check ships in slice 2; freezing the
+//! shape now means the frontend's `usePasswordHealthReport` hook does
+//! not have to migrate when reuse detection lands.
+
+use serde::{Deserialize, Serialize};
+
+use crate::services::password_health::analyzer::{
+    Finding, FindingKind, HealthTotals, PasswordHealthReport,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PasswordHealthReportDto {
+    pub score: Option<u32>,
+    pub findings: Vec<FindingDto>,
+    pub totals: HealthTotalsDto,
+    /// Empty in this slice — the reuse check ships in slice 2.
+    pub reuse_groups: Vec<ReuseGroupDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FindingDto {
+    pub entry_id: String,
+    pub kind: FindingKindDto,
+}
+
+/// Namespaced enum of Finding kinds. Serialized as the dotted string
+/// the frontend pattern-matches on (`"password.expired"`, etc.). Adding
+/// a new variant in a follow-up slice is wire-additive.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FindingKindDto {
+    #[serde(rename = "password.expired")]
+    PasswordExpired,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthTotalsDto {
+    pub critical: u32,
+    pub high: u32,
+    pub healthy: u32,
+    pub total: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ReuseGroupDto {
+    pub password_hash: String,
+    pub entry_ids: Vec<String>,
+}
+
+impl From<PasswordHealthReport> for PasswordHealthReportDto {
+    fn from(report: PasswordHealthReport) -> Self {
+        Self {
+            score: report.score,
+            findings: report.findings.into_iter().map(FindingDto::from).collect(),
+            totals: report.totals.into(),
+            reuse_groups: Vec::new(),
+        }
+    }
+}
+
+impl From<Finding> for FindingDto {
+    fn from(finding: Finding) -> Self {
+        Self {
+            entry_id: finding.entry_id,
+            kind: finding.kind.into(),
+        }
+    }
+}
+
+impl From<FindingKind> for FindingKindDto {
+    fn from(kind: FindingKind) -> Self {
+        match kind {
+            FindingKind::PasswordExpired => FindingKindDto::PasswordExpired,
+        }
+    }
+}
+
+impl From<HealthTotals> for HealthTotalsDto {
+    fn from(totals: HealthTotals) -> Self {
+        Self {
+            critical: totals.critical,
+            high: totals.high,
+            healthy: totals.healthy,
+            total: totals.total,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// The frontend pattern-matches on the namespaced string. Pinning
+    /// the JSON shape prevents a refactor inside `FindingKindDto` from
+    /// silently moving the variant to `"PasswordExpired"` or
+    /// `"password_expired"` and breaking the icon-and-section
+    /// rendering in `EntryListItem` / `PasswordHealthReportView`.
+    #[test]
+    fn finding_kind_serializes_as_namespaced_string() {
+        let json = serde_json::to_string(&FindingKindDto::PasswordExpired).expect("serialize");
+        assert_eq!(json, r#""password.expired""#);
+    }
+
+    /// End-to-end conversion: a domain report with one expired Finding
+    /// and a 1-high-of-4 totals breakdown maps to the wire-shape DTO
+    /// with the corresponding fields and an empty `reuseGroups`
+    /// vector. Pinning the conversion (not just the analyzer) catches
+    /// drift between the analyzer and the IPC contract.
+    #[test]
+    fn report_dto_carries_score_findings_totals_and_empty_reuse_groups() {
+        let domain = PasswordHealthReport {
+            score: Some(75),
+            findings: vec![Finding {
+                entry_id: "abc-123".into(),
+                kind: FindingKind::PasswordExpired,
+            }],
+            totals: HealthTotals {
+                critical: 0,
+                high: 1,
+                healthy: 3,
+                total: 4,
+            },
+        };
+
+        let dto: PasswordHealthReportDto = domain.into();
+
+        assert_eq!(dto.score, Some(75));
+        assert_eq!(
+            dto.findings,
+            vec![FindingDto {
+                entry_id: "abc-123".into(),
+                kind: FindingKindDto::PasswordExpired,
+            }]
+        );
+        assert_eq!(
+            dto.totals,
+            HealthTotalsDto {
+                critical: 0,
+                high: 1,
+                healthy: 3,
+                total: 4,
+            }
+        );
+        assert!(dto.reuse_groups.is_empty());
+    }
+
+    /// The whole `PasswordHealthReportDto` serializes as a camelCase
+    /// object. Pinning the JSON shape protects the frontend from a
+    /// silent rename to `snake_case` — a recurring footgun on the
+    /// boundary between Rust types and TypeScript consumers.
+    #[test]
+    fn report_dto_serializes_with_camelcase_keys() {
+        let dto = PasswordHealthReportDto {
+            score: Some(100),
+            findings: Vec::new(),
+            totals: HealthTotalsDto::default(),
+            reuse_groups: Vec::new(),
+        };
+        let value: serde_json::Value = serde_json::to_value(&dto).expect("serialize");
+        let obj = value.as_object().expect("object");
+        assert!(obj.contains_key("score"));
+        assert!(obj.contains_key("findings"));
+        assert!(obj.contains_key("totals"));
+        assert!(obj.contains_key("reuseGroups"));
+        assert!(!obj.contains_key("reuse_groups"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,8 +15,9 @@ use commands::{
     fetch_entry_favicon, generate_keyfile, generate_passphrase, generate_password,
     get_app_preferences, get_audit_events, get_audit_status, get_custom_icons, get_database_config,
     get_database_info, get_entry, get_entry_password, get_entry_protected_custom_field, get_group,
-    get_group_entry_counts, get_keyfile_for_database, get_recent_databases, get_recycle_bin_id,
-    get_window_content_protection_supported, has_session_key, inspect_database, list_backups,
+    get_group_entry_counts, get_keyfile_for_database, get_password_health_report,
+    get_recent_databases, get_recycle_bin_id, get_window_content_protection_supported,
+    has_session_key, inspect_database, list_backups,
     list_entries, list_groups, list_open_databases, lock_database, move_entry, move_group,
     open_database, open_database_with_keyfile, open_database_with_keyfile_only,
     remove_recent_database, rename_group, rename_tag, report_activity, reset_app_preferences,
@@ -29,6 +30,7 @@ use services::audit::AuditService;
 use services::auto_lock::AutoLockService;
 use services::clipboard::ClipboardService;
 use services::kdbx::KdbxService;
+use services::password_health::service::PasswordHealthService;
 use services::secure_storage::SecureStorageService;
 use services::settings::SettingsService;
 use services::window_protection::WindowProtectionService;
@@ -111,6 +113,7 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             report_activity,
             set_window_content_protected,
             get_window_content_protection_supported,
+            get_password_health_report,
         ])
 }
 
@@ -163,6 +166,8 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     audit_service.set_enabled(initial_audit.0);
     audit_service.set_retention_days(initial_audit.1);
     app.manage(Arc::new(audit_service));
+
+    app.manage(Arc::new(PasswordHealthService::new()));
 
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,12 +17,12 @@ use commands::{
     get_database_info, get_entry, get_entry_password, get_entry_protected_custom_field, get_group,
     get_group_entry_counts, get_keyfile_for_database, get_password_health_report,
     get_recent_databases, get_recycle_bin_id, get_window_content_protection_supported,
-    has_session_key, inspect_database, list_backups,
-    list_entries, list_groups, list_open_databases, lock_database, move_entry, move_group,
-    open_database, open_database_with_keyfile, open_database_with_keyfile_only,
-    remove_recent_database, rename_group, rename_tag, report_activity, reset_app_preferences,
-    restore_backup, save_database, set_entry_custom_icon, set_window_content_protected,
-    store_session_key, unlock_database, update_app_preferences, update_entry, update_group,
+    has_session_key, inspect_database, list_backups, list_entries, list_groups,
+    list_open_databases, lock_database, move_entry, move_group, open_database,
+    open_database_with_keyfile, open_database_with_keyfile_only, remove_recent_database,
+    rename_group, rename_tag, report_activity, reset_app_preferences, restore_backup,
+    save_database, set_entry_custom_icon, set_window_content_protected, store_session_key,
+    unlock_database, update_app_preferences, update_entry, update_group,
 };
 use services::audit::format::Reason;
 use services::audit::key::FileBackedAuditKey;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -193,6 +193,11 @@ pub fn run() {
                         if let Some(audit) = app.try_state::<Arc<AuditService>>() {
                             audit.record_vault_locked_batch(&locked_paths, Reason::ScreenLock);
                         }
+                        if let Some(health) = app.try_state::<Arc<PasswordHealthService>>() {
+                            for path in &locked_paths {
+                                health.on_lock(path);
+                            }
+                        }
                         let _ = app.emit("database-locked", &locked_paths);
                     }
                 }

--- a/src-tauri/src/services/auto_lock.rs
+++ b/src-tauri/src/services/auto_lock.rs
@@ -3,6 +3,7 @@
 use crate::services::audit::format::Reason;
 use crate::services::audit::AuditService;
 use crate::services::kdbx::KdbxService;
+use crate::services::password_health::service::PasswordHealthService;
 use crate::services::settings::SettingsService;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
@@ -76,6 +77,11 @@ pub fn start_auto_lock_task<R: Runtime>(app_handle: &tauri::AppHandle<R>) {
                     if !locked_paths.is_empty() {
                         if let Some(audit) = handle.try_state::<Arc<AuditService>>() {
                             audit.record_vault_locked_batch(&locked_paths, Reason::AutoLock);
+                        }
+                        if let Some(health) = handle.try_state::<Arc<PasswordHealthService>>() {
+                            for path in &locked_paths {
+                                health.on_lock(path);
+                            }
                         }
                         let _ = handle.emit("database-locked", &locked_paths);
                         // Reset activity to prevent repeated firing

--- a/src-tauri/src/services/kdbx/create.rs
+++ b/src-tauri/src/services/kdbx/create.rs
@@ -107,6 +107,7 @@ impl KdbxService {
                 version: version.clone(),
                 name: name.to_string(),
                 root_group_id: root_group_id.clone(),
+                generation: 0,
             },
         );
 

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -1,11 +1,11 @@
 use crate::dto::entry::{CreateEntryData, CustomFieldValue, Entry, UpdateEntryData};
 use crate::dto::error::AppError;
-use keepass::db::{Entry as KeepassEntry, EntryRef, Times, Value};
-use keepass::Database;
+use keepass::db::{Entry as KeepassEntry, Times, Value};
 
 use super::conversions::{
     apply_custom_fields, convert_entry, is_standard_entry_field, replace_custom_fields,
 };
+use super::recycle::is_in_recycle_bin;
 use super::KdbxService;
 
 impl KdbxService {
@@ -284,23 +284,6 @@ impl KdbxService {
             Ok(entry_model)
         })
     }
-}
-
-fn is_in_recycle_bin(db: &Database, entry: &EntryRef<'_>, recycle_uuid: uuid::Uuid) -> bool {
-    // Walk ancestors by GroupId rather than holding a GroupRef across the
-    // loop — re-looking up via db.group(gid) gives each iteration its own
-    // borrow scope, matching is_ancestor_of's pattern in mapping.rs.
-    let mut current_id = Some(entry.parent().id());
-    while let Some(gid) = current_id {
-        if gid.uuid() == recycle_uuid {
-            return true;
-        }
-        let Some(group) = db.group(gid) else {
-            return false;
-        };
-        current_id = group.parent().map(|p| p.id());
-    }
-    false
 }
 
 fn populate_entry(entry: &mut keepass::db::EntryMut<'_>, data: &CreateEntryData) {

--- a/src-tauri/src/services/kdbx/mod.rs
+++ b/src-tauri/src/services/kdbx/mod.rs
@@ -9,6 +9,7 @@ pub mod header;
 pub mod key;
 pub mod keyfile;
 pub mod open;
+pub mod recycle;
 pub mod restore;
 pub mod save;
 pub mod vault;

--- a/src-tauri/src/services/kdbx/open.rs
+++ b/src-tauri/src/services/kdbx/open.rs
@@ -48,6 +48,7 @@ fn install_open_database(
             version: version.clone(),
             name: name.clone(),
             root_group_id: root_group_id.clone(),
+            generation: 0,
         },
     );
 

--- a/src-tauri/src/services/kdbx/recycle.rs
+++ b/src-tauri/src/services/kdbx/recycle.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+//! Recycle-bin ancestry walks shared across services.
+//!
+//! The helper only touches `keepass` types — no `KdbxService` or
+//! domain state — so callers in `password_health` can use it without
+//! pulling in KDBX-internal dependencies.
+
+use keepass::db::EntryRef;
+use keepass::Database;
+
+/// Walks `entry`'s ancestor chain looking for `recycle_uuid`. Returns
+/// `true` when the Entry sits inside the Recycle Bin (or any descendant
+/// of it). Walks by `GroupId` rather than holding a `GroupRef` across
+/// iterations so each step has its own borrow scope.
+pub(crate) fn is_in_recycle_bin(
+    db: &Database,
+    entry: &EntryRef<'_>,
+    recycle_uuid: uuid::Uuid,
+) -> bool {
+    let mut current_id = Some(entry.parent().id());
+    while let Some(gid) = current_id {
+        if gid.uuid() == recycle_uuid {
+            return true;
+        }
+        let Some(group) = db.group(gid) else {
+            return false;
+        };
+        current_id = group.parent().map(|p| p.id());
+    }
+    false
+}

--- a/src-tauri/src/services/kdbx/vault.rs
+++ b/src-tauri/src/services/kdbx/vault.rs
@@ -1,3 +1,4 @@
+use crate::domain::kdbx::OpenDatabase;
 use crate::dto::error::AppError;
 use keepass::db::{
     Entry as KeepassEntry, EntryId, EntryMut, EntryRef, GroupId, GroupMut, GroupRef, Times,
@@ -10,6 +11,7 @@ use super::KdbxService;
 /// duration of the closure passed to `KdbxService::with_vault`.
 pub(crate) struct Vault<'a> {
     db: &'a Database,
+    generation: u64,
 }
 
 /// Scoped write access to an unlocked Vault. Holds the databases lock for the
@@ -19,6 +21,7 @@ pub(crate) struct Vault<'a> {
 pub(crate) struct VaultMut<'a> {
     db: &'a mut Database,
     is_modified: &'a mut bool,
+    generation: &'a mut u64,
 }
 
 impl KdbxService {
@@ -33,7 +36,10 @@ impl KdbxService {
             .get(&normalized_path)
             .ok_or_else(|| AppError::DatabaseNotFound(db_id.to_string()))?;
         let db = open_db.db_or_locked()?;
-        f(Vault { db })
+        f(Vault {
+            db,
+            generation: open_db.generation,
+        })
     }
 
     pub(crate) fn with_vault_mut<R>(
@@ -46,15 +52,24 @@ impl KdbxService {
         let open_db = databases
             .get_mut(&normalized_path)
             .ok_or_else(|| AppError::DatabaseNotFound(db_id.to_string()))?;
-        // Split the borrow so VaultMut can hold disjoint references to the
-        // database and the modified flag without alias conflicts.
+        // Split the borrow into three disjoint slots so VaultMut can hold
+        // references to the database, the modified flag, and the generation
+        // counter at the same time without alias conflicts.
         let open_db_path = open_db.path.clone();
-        let db = open_db
-            .db
+        let OpenDatabase {
+            db: db_slot,
+            is_modified,
+            generation,
+            ..
+        } = open_db;
+        let db = db_slot
             .as_mut()
             .ok_or(AppError::DatabaseLocked(open_db_path))?;
-        let is_modified = &mut open_db.is_modified;
-        let mut vault = VaultMut { db, is_modified };
+        let mut vault = VaultMut {
+            db,
+            is_modified,
+            generation,
+        };
         f(&mut vault)
     }
 }
@@ -111,6 +126,11 @@ pub(crate) fn group_has_children(group: &GroupRef<'_>) -> bool {
 impl<'a> Vault<'a> {
     pub fn db(&self) -> &'a Database {
         self.db
+    }
+
+    #[allow(dead_code)] // wired up by the upcoming password-health coordinator
+    pub fn generation(&self) -> u64 {
+        self.generation
     }
 
     pub fn root(&self) -> GroupRef<'a> {
@@ -242,7 +262,106 @@ impl VaultMut<'_> {
         count
     }
 
+    #[allow(dead_code)] // wired up by the upcoming password-health coordinator
+    pub fn generation(&self) -> u64 {
+        *self.generation
+    }
+
     pub fn mark_modified(&mut self) {
         *self.is_modified = true;
+        *self.generation = self.generation.saturating_add(1);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use crate::domain::kdbx::OpenDatabase;
+    use crate::services::kdbx::KdbxService;
+    use keepass::Database;
+
+    /// Drops a hand-built `OpenDatabase` straight into the service's
+    /// internal map so the test can drive `with_vault[_mut]` without
+    /// going through disk-backed `create_database`. The path doesn't
+    /// need to exist on disk — `KdbxService::normalize_path` falls back
+    /// to the literal string when canonicalize fails.
+    fn install_test_vault(service: &KdbxService, path: &str) {
+        let db = Database::new();
+        let root_id = db.root().id().uuid().to_string();
+        let open = OpenDatabase {
+            db: Some(db),
+            path: path.to_string(),
+            is_modified: false,
+            password: None,
+            keyfile_path: None,
+            version: "test".into(),
+            name: "test".into(),
+            root_group_id: root_id,
+            generation: 0,
+        };
+        let normalized = KdbxService::normalize_path(path);
+        service
+            .lock_databases()
+            .expect("lock databases")
+            .insert(normalized, open);
+    }
+
+    /// Every call to `mark_modified` must produce a strictly increasing
+    /// generation counter. The Password Health service keys its cache
+    /// on `(db_id, generation)`; if the counter ever fails to advance
+    /// after a write, the next `get_password_health_report` call would
+    /// return a stale report.
+    #[test]
+    fn mark_modified_bumps_generation() {
+        let service = KdbxService::new();
+        let path = "/tmp/__health_gen_test__.kdbx";
+        install_test_vault(&service, path);
+
+        let g0 = service
+            .with_vault(path, |v| Ok(v.generation()))
+            .expect("read g0");
+        service
+            .with_vault_mut(path, |v| {
+                v.mark_modified();
+                Ok(())
+            })
+            .expect("bump 1");
+        let g1 = service
+            .with_vault(path, |v| Ok(v.generation()))
+            .expect("read g1");
+        service
+            .with_vault_mut(path, |v| {
+                v.mark_modified();
+                Ok(())
+            })
+            .expect("bump 2");
+        let g2 = service
+            .with_vault(path, |v| Ok(v.generation()))
+            .expect("read g2");
+
+        assert_eq!(g0, 0);
+        assert_eq!(g1, 1);
+        assert_eq!(g2, 2);
+    }
+
+    /// Entering `with_vault_mut` is only the *opportunity* to mutate —
+    /// the counter does not move until the closure actually calls
+    /// `mark_modified`. Read-mostly mut paths (e.g. `report_activity`
+    /// touching last-access timestamps without dirtying) must not
+    /// invalidate the Password Health cache.
+    #[test]
+    fn entering_with_vault_mut_without_mark_modified_does_not_bump_generation() {
+        let service = KdbxService::new();
+        let path = "/tmp/__health_gen_test_noop__.kdbx";
+        install_test_vault(&service, path);
+
+        service
+            .with_vault_mut(path, |_v| Ok(()))
+            .expect("enter without marking");
+
+        let gen = service
+            .with_vault(path, |v| Ok(v.generation()))
+            .expect("read gen");
+        assert_eq!(gen, 0);
     }
 }

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -6,6 +6,7 @@ pub mod clipboard;
 pub mod crypto;
 pub mod generator;
 pub mod kdbx;
+pub mod password_health;
 pub mod secure_storage;
 pub mod settings;
 pub mod window_protection;

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -13,6 +13,8 @@
 //! pure function — tests pin the clock; the service supplies
 //! `Utc::now()`.
 
+use std::collections::HashSet;
+
 use chrono::{DateTime, Utc};
 
 /// Per-Entry input the analyzer consumes. The service layer assembles
@@ -38,6 +40,25 @@ pub enum FindingKind {
     PasswordExpired,
 }
 
+/// Two-bucket severity used to populate [`HealthTotals`] and decide
+/// which Section of the Security report an Entry surfaces in. Mirrors
+/// the wording in ADR 0002 — `Very Weak` is the only Critical Finding
+/// Kind; everything else (`Weak`, `Reused`, `Expired`) is High. Healthy
+/// Entries have no Findings and therefore no severity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Critical,
+    High,
+}
+
+impl FindingKind {
+    pub fn severity(&self) -> Severity {
+        match self {
+            FindingKind::PasswordExpired => Severity::High,
+        }
+    }
+}
+
 /// A single recordable Password Health Finding. Each Finding is scoped
 /// to exactly one Entry; an Entry that hits multiple checks produces
 /// multiple Findings rather than one merged Finding because the
@@ -46,6 +67,21 @@ pub enum FindingKind {
 pub struct Finding {
     pub entry_id: String,
     pub kind: FindingKind,
+}
+
+/// Severity-bucketed counts the report renders in the Security
+/// dashboard's totals strip. `critical` and `high` count *distinct
+/// Entries* with at least one Finding of that bucket — an Entry that
+/// is both Reused and Very Weak is counted once in `critical`, not
+/// twice. `healthy` counts Entries with zero Findings. `total` is the
+/// in-scope denominator the score is computed against. All four are
+/// zero for an empty Vault.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct HealthTotals {
+    pub critical: u32,
+    pub high: u32,
+    pub healthy: u32,
+    pub total: u32,
 }
 
 /// The output of [`analyze`] — a single periodic snapshot of every
@@ -59,6 +95,7 @@ pub struct Finding {
 pub struct PasswordHealthReport {
     pub score: Option<u32>,
     pub findings: Vec<Finding>,
+    pub totals: HealthTotals,
 }
 
 pub fn analyze(
@@ -71,6 +108,7 @@ pub fn analyze(
         return PasswordHealthReport {
             score: None,
             findings: Vec::new(),
+            totals: HealthTotals::default(),
         };
     }
 
@@ -83,23 +121,49 @@ pub fn analyze(
         })
         .collect();
 
-    // In this slice, every emitted Finding is scoped to a distinct
-    // Entry — there is only one Finding Kind — so `findings.len()`
-    // equals the un-healthy Entry count. Once additional Finding Kinds
-    // land, this collapse must move to a distinct-entry-id count.
-    let unhealthy = findings.len();
+    // Bucket each Entry by its highest-severity Finding so
+    // `critical + high + healthy == total` holds (the Security view
+    // adds the three numbers; an Entry double-counted between buckets
+    // would break the breakdown).
+    let mut critical_ids: HashSet<&str> = HashSet::new();
+    let mut high_ids: HashSet<&str> = HashSet::new();
+    for f in &findings {
+        match f.kind.severity() {
+            Severity::Critical => {
+                critical_ids.insert(f.entry_id.as_str());
+            }
+            Severity::High => {
+                high_ids.insert(f.entry_id.as_str());
+            }
+        }
+    }
+    // Critical wins over High when an Entry has Findings in both
+    // buckets — the more severe label is the one we surface.
+    for id in &critical_ids {
+        high_ids.remove(id);
+    }
+    let unhealthy = critical_ids.len() + high_ids.len();
     let healthy = total - unhealthy;
-    // `total <= u32::MAX` in any realistic Vault; cast is safe.
+
+    // `total <= u32::MAX` in any realistic Vault; casts are safe.
     #[allow(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         clippy::cast_precision_loss
     )]
     let score = ((healthy as f64 / total as f64) * 100.0).round() as u32;
+    #[allow(clippy::cast_possible_truncation)]
+    let totals = HealthTotals {
+        critical: critical_ids.len() as u32,
+        high: high_ids.len() as u32,
+        healthy: healthy as u32,
+        total: total as u32,
+    };
 
     PasswordHealthReport {
         score: Some(score),
         findings,
+        totals,
     }
 }
 
@@ -153,6 +217,42 @@ mod tests {
         let report = analyze(entries, now_fixed());
         assert_eq!(report.score, Some(100));
         assert!(report.findings.is_empty());
+    }
+
+    /// An empty Vault has no Entries in any bucket; every total is
+    /// zero. Pairs with `empty_input_produces_score_none` — both
+    /// behaviors share the same early-return path inside `analyze`.
+    #[test]
+    fn empty_input_totals_are_all_zero() {
+        let report = analyze(std::iter::empty::<EntryInput>(), now_fixed());
+        assert_eq!(report.totals, HealthTotals::default());
+    }
+
+    /// Severity-bucketed counts on a mixed Vault: two healthy + two
+    /// expired Entries. Expired is a High Finding (per
+    /// `FindingKind::severity`), so both expired Entries land in
+    /// `high` and the two healthy land in `healthy`. `critical` stays
+    /// zero — no Critical Findings exist in this slice. The sum
+    /// `critical + high + healthy` must equal `total`.
+    #[test]
+    fn totals_bucket_distinct_entries_by_highest_severity() {
+        let now = now_fixed();
+        let entries = vec![
+            healthy("a"),
+            healthy("b"),
+            expired("c", now),
+            expired("d", now),
+        ];
+        let report = analyze(entries, now);
+        assert_eq!(
+            report.totals,
+            HealthTotals {
+                critical: 0,
+                high: 2,
+                healthy: 2,
+                total: 4,
+            }
+        );
     }
 
     /// One expired Entry in a four-Entry Vault: 3 healthy / 4 total =

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -168,7 +168,11 @@ pub fn analyze(
 }
 
 fn is_expired(entry: &EntryInput, now: DateTime<Utc>) -> bool {
-    entry.expires && entry.expiry_time.is_some_and(|t| t < now)
+    // `KeePass` expiry semantics are "not in the future": an entry
+    // whose expiry instant equals `now` is already expired. Using `<`
+    // would leave a one-tick window where an exactly-expired entry
+    // counts as healthy.
+    entry.expires && entry.expiry_time.is_some_and(|t| t <= now)
 }
 
 #[cfg(test)]
@@ -253,6 +257,23 @@ mod tests {
                 total: 4,
             }
         );
+    }
+
+    /// Entries whose expiry instant equals `now` must already count as
+    /// expired — `KeePass` semantics are "not in the future", not "in
+    /// the past". Pinning the boundary prevents a regression to the
+    /// strict `<` comparison.
+    #[test]
+    fn entry_with_expiry_equal_to_now_is_expired() {
+        let now = now_fixed();
+        let entry = EntryInput {
+            id: "boundary".to_string(),
+            expires: true,
+            expiry_time: Some(now),
+        };
+        let report = analyze(vec![entry], now);
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, FindingKind::PasswordExpired);
     }
 
     /// One expired Entry in a four-Entry Vault: 3 healthy / 4 total =

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: MIT
+
+//! Pure-function Password Health analyzer.
+//!
+//! Takes an iterator of [`EntryInput`] — one per in-scope Entry — and
+//! returns a [`PasswordHealthReport`]. Owns the score formula and the
+//! finding-emission rules; owns no I/O, no Tauri, no `keepass-rs`. The
+//! service layer is responsible for walking the unlocked Vault, filtering
+//! Recycle Bin descendants and `password: None` Entries, and handing the
+//! remaining cleartext over.
+//!
+//! The clock is injected (`now: DateTime<Utc>`) so the policy stays a
+//! pure function — tests pin the clock; the service supplies
+//! `Utc::now()`.
+
+use chrono::{DateTime, Utc};
+
+/// Per-Entry input the analyzer consumes. The service layer assembles
+/// one of these for every in-scope Entry before invoking [`analyze`].
+///
+/// `expires` mirrors the KDBX `Times.expires` flag; `expiry_time` is the
+/// associated timestamp. Both come straight from the Entry record — the
+/// analyzer does not resolve "expired" until [`analyze`] compares them
+/// against the injected `now`.
+#[derive(Debug, Clone)]
+pub struct EntryInput {
+    pub id: String,
+    pub expires: bool,
+    pub expiry_time: Option<DateTime<Utc>>,
+}
+
+/// The namespaced enum of recordable Password Health findings. Only
+/// `PasswordExpired` is emitted in this slice; the remaining kinds
+/// (`PasswordVeryWeak`, `PasswordWeak`, `PasswordReused`) ship in
+/// follow-up slices. See CONTEXT.md → "Password Health Finding Kind".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FindingKind {
+    PasswordExpired,
+}
+
+/// A single recordable Password Health Finding. Each Finding is scoped
+/// to exactly one Entry; an Entry that hits multiple checks produces
+/// multiple Findings rather than one merged Finding because the
+/// remediations differ (see ADR 0002 → consequences).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Finding {
+    pub entry_id: String,
+    pub kind: FindingKind,
+}
+
+/// The output of [`analyze`] — a single periodic snapshot of every
+/// in-scope Entry's health.
+///
+/// `score` is `None` for an empty Vault (no in-scope Entries to assess)
+/// and `Some(0..=100)` otherwise. The score is computed as
+/// `round(100 × healthy / total_in_scope)` — see ADR 0002 for why the
+/// healthy-ratio formula was chosen over weighted finding deficits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PasswordHealthReport {
+    pub score: Option<u32>,
+    pub findings: Vec<Finding>,
+}
+
+pub fn analyze(
+    entries: impl IntoIterator<Item = EntryInput>,
+    now: DateTime<Utc>,
+) -> PasswordHealthReport {
+    let entries: Vec<EntryInput> = entries.into_iter().collect();
+    let total = entries.len();
+    if total == 0 {
+        return PasswordHealthReport {
+            score: None,
+            findings: Vec::new(),
+        };
+    }
+
+    let findings: Vec<Finding> = entries
+        .iter()
+        .filter(|e| is_expired(e, now))
+        .map(|e| Finding {
+            entry_id: e.id.clone(),
+            kind: FindingKind::PasswordExpired,
+        })
+        .collect();
+
+    // In this slice, every emitted Finding is scoped to a distinct
+    // Entry — there is only one Finding Kind — so `findings.len()`
+    // equals the un-healthy Entry count. Once additional Finding Kinds
+    // land, this collapse must move to a distinct-entry-id count.
+    let unhealthy = findings.len();
+    let healthy = total - unhealthy;
+    // `total <= u32::MAX` in any realistic Vault; cast is safe.
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    let score = ((healthy as f64 / total as f64) * 100.0).round() as u32;
+
+    PasswordHealthReport {
+        score: Some(score),
+        findings,
+    }
+}
+
+fn is_expired(entry: &EntryInput, now: DateTime<Utc>) -> bool {
+    entry.expires && entry.expiry_time.is_some_and(|t| t < now)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now_fixed() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap()
+    }
+
+    fn healthy(id: &str) -> EntryInput {
+        EntryInput {
+            id: id.to_string(),
+            expires: false,
+            expiry_time: None,
+        }
+    }
+
+    fn expired(id: &str, now: DateTime<Utc>) -> EntryInput {
+        EntryInput {
+            id: id.to_string(),
+            expires: true,
+            expiry_time: Some(now - chrono::Duration::days(1)),
+        }
+    }
+
+    /// An empty Vault (no in-scope Entries) cannot have a healthy ratio
+    /// — division by zero — so the analyzer reports `score: None`. The
+    /// `/dashboard/security/$dbId` view renders this as an em-dash and
+    /// the "No passwords to analyze" empty state.
+    #[test]
+    fn empty_input_produces_score_none() {
+        let report = analyze(std::iter::empty::<EntryInput>(), now_fixed());
+        assert_eq!(report.score, None);
+        assert!(report.findings.is_empty());
+    }
+
+    /// A Vault whose Entries all clear every check produces the maximum
+    /// score, and no Findings are emitted. The sidebar badge is hidden
+    /// at this score because the un-healthy count is zero.
+    #[test]
+    fn all_healthy_input_produces_score_100_and_no_findings() {
+        let entries = vec![healthy("a"), healthy("b"), healthy("c"), healthy("d")];
+        let report = analyze(entries, now_fixed());
+        assert_eq!(report.score, Some(100));
+        assert!(report.findings.is_empty());
+    }
+
+    /// One expired Entry in a four-Entry Vault: 3 healthy / 4 total =
+    /// 75. Exactly one `PasswordExpired` Finding, scoped to the
+    /// expired Entry's id. Pinned in the issue's acceptance criteria.
+    #[test]
+    fn single_expired_entry_in_four_yields_score_75_and_one_finding() {
+        let now = now_fixed();
+        let entries = vec![
+            healthy("a"),
+            healthy("b"),
+            healthy("c"),
+            expired("d", now),
+        ];
+        let report = analyze(entries, now);
+        assert_eq!(report.score, Some(75));
+        assert_eq!(
+            report.findings,
+            vec![Finding {
+                entry_id: "d".to_string(),
+                kind: FindingKind::PasswordExpired,
+            }]
+        );
+    }
+}

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -90,7 +90,11 @@ pub fn analyze(
     let unhealthy = findings.len();
     let healthy = total - unhealthy;
     // `total <= u32::MAX` in any realistic Vault; cast is safe.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_precision_loss)]
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        clippy::cast_precision_loss
+    )]
     let score = ((healthy as f64 / total as f64) * 100.0).round() as u32;
 
     PasswordHealthReport {
@@ -157,12 +161,7 @@ mod tests {
     #[test]
     fn single_expired_entry_in_four_yields_score_75_and_one_finding() {
         let now = now_fixed();
-        let entries = vec![
-            healthy("a"),
-            healthy("b"),
-            healthy("c"),
-            expired("d", now),
-        ];
+        let entries = vec![healthy("a"), healthy("b"), healthy("c"), expired("d", now)];
         let report = analyze(entries, now);
         assert_eq!(report.score, Some(75));
         assert_eq!(

--- a/src-tauri/src/services/password_health/cache.rs
+++ b/src-tauri/src/services/password_health/cache.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+
+//! `(db_id, generation)`-keyed cache for Password Health reports.
+//!
+//! The cache is a small in-memory map: each open Vault gets at most
+//! one slot, identified by its normalized path. A slot binds the
+//! report to the generation counter that produced it; reads that pass
+//! a different generation miss the cache. Lock drops the slot via
+//! [`CacheStore::evict`].
+//!
+//! Kept as a standalone struct so its semantics (which are the
+//! load-bearing invariant of the freshness story) can be exercised
+//! without spinning up the coordinator, Tauri, or `keepass-rs`.
+
+use std::collections::HashMap;
+
+use super::analyzer::PasswordHealthReport;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CacheEntry {
+    generation: u64,
+    report: PasswordHealthReport,
+}
+
+#[derive(Debug, Default)]
+pub struct CacheStore {
+    entries: HashMap<String, CacheEntry>,
+}
+
+impl CacheStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the cached report only when the slot exists **and** its
+    /// generation matches. A mismatch is a miss — the caller is
+    /// expected to recompute and `insert` the fresh report.
+    pub fn get(&self, db_id: &str, generation: u64) -> Option<&PasswordHealthReport> {
+        let entry = self.entries.get(db_id)?;
+        if entry.generation == generation {
+            Some(&entry.report)
+        } else {
+            None
+        }
+    }
+
+    /// Inserts or replaces the slot for `db_id`. Each Vault has at
+    /// most one cached report; a fresh insert against an existing
+    /// `db_id` overwrites whatever was there. This is intentional —
+    /// the Password Health cache exists to surface the *current*
+    /// report, not a history of past ones.
+    pub fn insert(&mut self, db_id: String, generation: u64, report: PasswordHealthReport) {
+        self.entries
+            .insert(db_id, CacheEntry { generation, report });
+    }
+
+    /// Drops the slot for `db_id`. Called on Vault lock so a re-unlock
+    /// triggers a fresh analysis instead of returning a stale report
+    /// from the previous session.
+    pub fn evict(&mut self, db_id: &str) {
+        self.entries.remove(db_id);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn report_with_score(score: Option<u32>) -> PasswordHealthReport {
+        PasswordHealthReport {
+            score,
+            findings: Vec::new(),
+        }
+    }
+
+    /// The cache only returns a report when the `(db_id, generation)`
+    /// pair matches. Other combinations — empty cache, wrong
+    /// generation, wrong db — are misses. Pinning all four together
+    /// captures the load-bearing freshness invariant in a single read.
+    #[test]
+    fn cache_returns_only_on_matching_db_and_generation() {
+        let mut store = CacheStore::new();
+        assert!(
+            store.get("db1", 0).is_none(),
+            "empty cache misses"
+        );
+
+        let r = report_with_score(Some(75));
+        store.insert("db1".into(), 1, r.clone());
+
+        assert_eq!(store.get("db1", 1), Some(&r), "matching key hits");
+        assert!(
+            store.get("db1", 2).is_none(),
+            "newer generation misses — Vault has mutated, report is stale"
+        );
+        assert!(
+            store.get("db1", 0).is_none(),
+            "older generation misses — caller has a stale handle"
+        );
+        assert!(
+            store.get("db2", 1).is_none(),
+            "different Vault id misses"
+        );
+    }
+
+    /// `evict` drops the slot so the next `get` is a miss regardless
+    /// of the generation passed in. This is the lock-time path — the
+    /// service drops the cached report on Vault lock so the re-unlock
+    /// path is forced to recompute.
+    #[test]
+    fn evict_drops_slot_for_db_id() {
+        let mut store = CacheStore::new();
+        store.insert("db1".into(), 1, report_with_score(Some(100)));
+        store.evict("db1");
+        assert!(store.get("db1", 1).is_none());
+    }
+
+    /// Insert against an existing `db_id` overwrites the previous
+    /// slot rather than accumulating. The cache surfaces the current
+    /// report, not a history.
+    #[test]
+    fn insert_replaces_existing_slot() {
+        let mut store = CacheStore::new();
+        store.insert("db1".into(), 1, report_with_score(Some(75)));
+        store.insert("db1".into(), 2, report_with_score(Some(100)));
+
+        assert!(store.get("db1", 1).is_none(), "old generation must be gone");
+        assert_eq!(store.get("db1", 2), Some(&report_with_score(Some(100))));
+    }
+}

--- a/src-tauri/src/services/password_health/cache.rs
+++ b/src-tauri/src/services/password_health/cache.rs
@@ -8,11 +8,19 @@
 //! a different generation miss the cache. Lock drops the slot via
 //! [`CacheStore::evict`].
 //!
+//! Each slot also carries a `relevant_until` instant — the soonest
+//! future expiry that was still in the future when the report was
+//! computed. Reads after that instant miss the cache so a follow-up
+//! recompute can surface the newly-elapsed `PasswordExpired` Finding
+//! without needing a Vault mutation to bump the generation.
+//!
 //! Kept as a standalone struct so its semantics (which are the
 //! load-bearing invariant of the freshness story) can be exercised
 //! without spinning up the coordinator, Tauri, or `keepass-rs`.
 
 use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
 
 use super::analyzer::PasswordHealthReport;
 
@@ -20,6 +28,10 @@ use super::analyzer::PasswordHealthReport;
 struct CacheEntry {
     generation: u64,
     report: PasswordHealthReport,
+    /// Earliest in-scope expiry that hadn't yet elapsed at compute
+    /// time. `None` means no time-dependent Finding source exists for
+    /// this Vault; the slot is good until the generation changes.
+    relevant_until: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Default)]
@@ -32,16 +44,29 @@ impl CacheStore {
         Self::default()
     }
 
-    /// Returns the cached report only when the slot exists **and** its
-    /// generation matches. A mismatch is a miss — the caller is
-    /// expected to recompute and `insert` the fresh report.
-    pub fn get(&self, db_id: &str, generation: u64) -> Option<&PasswordHealthReport> {
+    /// Returns the cached report only when the slot exists, its
+    /// generation matches, **and** `now` has not yet reached the
+    /// recorded `relevant_until`. A mismatch on any of those is a
+    /// miss — the caller is expected to recompute and `insert` the
+    /// fresh report. Including `now` in the freshness check is what
+    /// keeps the cache from serving a "healthy" snapshot after an
+    /// entry's expiry moment has silently passed.
+    pub fn get(
+        &self,
+        db_id: &str,
+        generation: u64,
+        now: DateTime<Utc>,
+    ) -> Option<&PasswordHealthReport> {
         let entry = self.entries.get(db_id)?;
-        if entry.generation == generation {
-            Some(&entry.report)
-        } else {
-            None
+        if entry.generation != generation {
+            return None;
         }
+        if let Some(boundary) = entry.relevant_until {
+            if now >= boundary {
+                return None;
+            }
+        }
+        Some(&entry.report)
     }
 
     /// Inserts or replaces the slot for `db_id`. Each Vault has at
@@ -49,9 +74,21 @@ impl CacheStore {
     /// `db_id` overwrites whatever was there. This is intentional —
     /// the Password Health cache exists to surface the *current*
     /// report, not a history of past ones.
-    pub fn insert(&mut self, db_id: String, generation: u64, report: PasswordHealthReport) {
-        self.entries
-            .insert(db_id, CacheEntry { generation, report });
+    pub fn insert(
+        &mut self,
+        db_id: String,
+        generation: u64,
+        report: PasswordHealthReport,
+        relevant_until: Option<DateTime<Utc>>,
+    ) {
+        self.entries.insert(
+            db_id,
+            CacheEntry {
+                generation,
+                report,
+                relevant_until,
+            },
+        );
     }
 
     /// Drops the slot for `db_id`. Called on Vault lock so a re-unlock
@@ -66,6 +103,7 @@ impl CacheStore {
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     fn report_with_score(score: Option<u32>) -> PasswordHealthReport {
         PasswordHealthReport {
@@ -75,6 +113,10 @@ mod tests {
         }
     }
 
+    fn now_fixed() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap()
+    }
+
     /// The cache only returns a report when the `(db_id, generation)`
     /// pair matches. Other combinations — empty cache, wrong
     /// generation, wrong db — are misses. Pinning all four together
@@ -82,21 +124,25 @@ mod tests {
     #[test]
     fn cache_returns_only_on_matching_db_and_generation() {
         let mut store = CacheStore::new();
-        assert!(store.get("db1", 0).is_none(), "empty cache misses");
+        let now = now_fixed();
+        assert!(store.get("db1", 0, now).is_none(), "empty cache misses");
 
         let r = report_with_score(Some(75));
-        store.insert("db1".into(), 1, r.clone());
+        store.insert("db1".into(), 1, r.clone(), None);
 
-        assert_eq!(store.get("db1", 1), Some(&r), "matching key hits");
+        assert_eq!(store.get("db1", 1, now), Some(&r), "matching key hits");
         assert!(
-            store.get("db1", 2).is_none(),
+            store.get("db1", 2, now).is_none(),
             "newer generation misses — Vault has mutated, report is stale"
         );
         assert!(
-            store.get("db1", 0).is_none(),
+            store.get("db1", 0, now).is_none(),
             "older generation misses — caller has a stale handle"
         );
-        assert!(store.get("db2", 1).is_none(), "different Vault id misses");
+        assert!(
+            store.get("db2", 1, now).is_none(),
+            "different Vault id misses"
+        );
     }
 
     /// `evict` drops the slot so the next `get` is a miss regardless
@@ -106,9 +152,10 @@ mod tests {
     #[test]
     fn evict_drops_slot_for_db_id() {
         let mut store = CacheStore::new();
-        store.insert("db1".into(), 1, report_with_score(Some(100)));
+        let now = now_fixed();
+        store.insert("db1".into(), 1, report_with_score(Some(100)), None);
         store.evict("db1");
-        assert!(store.get("db1", 1).is_none());
+        assert!(store.get("db1", 1, now).is_none());
     }
 
     /// Insert against an existing `db_id` overwrites the previous
@@ -117,10 +164,48 @@ mod tests {
     #[test]
     fn insert_replaces_existing_slot() {
         let mut store = CacheStore::new();
-        store.insert("db1".into(), 1, report_with_score(Some(75)));
-        store.insert("db1".into(), 2, report_with_score(Some(100)));
+        let now = now_fixed();
+        store.insert("db1".into(), 1, report_with_score(Some(75)), None);
+        store.insert("db1".into(), 2, report_with_score(Some(100)), None);
 
-        assert!(store.get("db1", 1).is_none(), "old generation must be gone");
-        assert_eq!(store.get("db1", 2), Some(&report_with_score(Some(100))));
+        assert!(
+            store.get("db1", 1, now).is_none(),
+            "old generation must be gone"
+        );
+        assert_eq!(
+            store.get("db1", 2, now),
+            Some(&report_with_score(Some(100)))
+        );
+    }
+
+    /// A slot with a `relevant_until` boundary hits while `now` is
+    /// before it and misses once `now` reaches it. This is the
+    /// time-component freshness check that prevents serving a stale
+    /// "healthy" snapshot after an entry's expiry has silently
+    /// elapsed between two reads on an otherwise-unchanged Vault.
+    #[test]
+    fn cache_misses_once_now_reaches_relevant_until() {
+        let mut store = CacheStore::new();
+        let computed_at = now_fixed();
+        let boundary = computed_at + chrono::Duration::hours(1);
+        let r = report_with_score(Some(100));
+
+        store.insert("db1".into(), 1, r.clone(), Some(boundary));
+
+        assert_eq!(
+            store.get("db1", 1, computed_at),
+            Some(&r),
+            "before the boundary the slot still hits"
+        );
+        assert!(
+            store.get("db1", 1, boundary).is_none(),
+            "at the boundary the slot misses — the expiry instant is reached"
+        );
+        assert!(
+            store
+                .get("db1", 1, boundary + chrono::Duration::seconds(1))
+                .is_none(),
+            "past the boundary the slot misses"
+        );
     }
 }

--- a/src-tauri/src/services/password_health/cache.rs
+++ b/src-tauri/src/services/password_health/cache.rs
@@ -71,6 +71,7 @@ mod tests {
         PasswordHealthReport {
             score,
             findings: Vec::new(),
+            totals: super::super::analyzer::HealthTotals::default(),
         }
     }
 
@@ -81,10 +82,7 @@ mod tests {
     #[test]
     fn cache_returns_only_on_matching_db_and_generation() {
         let mut store = CacheStore::new();
-        assert!(
-            store.get("db1", 0).is_none(),
-            "empty cache misses"
-        );
+        assert!(store.get("db1", 0).is_none(), "empty cache misses");
 
         let r = report_with_score(Some(75));
         store.insert("db1".into(), 1, r.clone());
@@ -98,10 +96,7 @@ mod tests {
             store.get("db1", 0).is_none(),
             "older generation misses — caller has a stale handle"
         );
-        assert!(
-            store.get("db2", 1).is_none(),
-            "different Vault id misses"
-        );
+        assert!(store.get("db2", 1).is_none(), "different Vault id misses");
     }
 
     /// `evict` drops the slot so the next `get` is a miss regardless

--- a/src-tauri/src/services/password_health/mod.rs
+++ b/src-tauri/src/services/password_health/mod.rs
@@ -9,4 +9,5 @@
 //! for the architectural decisions this module implements.
 
 pub mod analyzer;
+pub mod cache;
 pub mod service;

--- a/src-tauri/src/services/password_health/mod.rs
+++ b/src-tauri/src/services/password_health/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+//! Password Health report.
+//!
+//! Per-Vault, strictly-local assessment of the cleartext passwords stored
+//! inside an unlocked Vault. The analyzer is a pure function so the policy
+//! can be exercised exhaustively without touching the filesystem, the IPC
+//! layer, or `keepass-rs`. See `docs/adr/0002-password-health-report.md`
+//! for the architectural decisions this module implements.
+
+pub mod analyzer;
+pub mod service;

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+
+//! Password Health service-layer wiring.
+//!
+//! This module owns the bridge between the unlocked KDBX tree and the
+//! pure analyzer in [`super::analyzer`]. It walks the Vault, enforces
+//! the scope rules from ADR 0002 ("exclude Recycle Bin, skip Entries
+//! with `password: None`, include Entries with empty-string password"),
+//! and hands the resulting [`EntryInput`] iterator to the analyzer.
+//!
+//! The eager-on-unlock coordinator, the `(db_id, generation)` cache,
+//! cancellation handles, and the Tauri-event stream layer on top of
+//! this collection step in subsequent cycles.
+
+use keepass::db::EntryRef;
+use keepass::Database;
+
+use super::analyzer::EntryInput;
+
+/// Walks the unlocked Vault and produces one [`EntryInput`] per
+/// in-scope Entry.
+///
+/// Scope rules:
+/// - Entries inside the Recycle Bin group (or any descendant of it)
+///   are excluded — a deleted Entry should not contribute to the
+///   score or surface a warning icon.
+/// - Entries with no `Password` field at all (TOTP-only,
+///   attachment-only) are excluded — there is nothing for the
+///   analyzer to score.
+/// - Entries with an empty-string `Password` are **included**; they
+///   contribute to the total-in-scope denominator even though no
+///   Finding Kind in this slice would emit for them. Once the
+///   Very-Weak check lands they will start emitting that Finding.
+pub fn collect_entry_inputs(db: &Database) -> Vec<EntryInput> {
+    let recycle_uuid = db.meta.recyclebin_uuid;
+    db.iter_all_entries()
+        .filter(|entry| {
+            if let Some(rid) = recycle_uuid {
+                if is_in_recycle_bin(db, entry, rid) {
+                    return false;
+                }
+            }
+            entry.get_password().is_some()
+        })
+        .map(|entry| EntryInput {
+            id: entry.id().uuid().to_string(),
+            expires: entry.times.expires.unwrap_or(false),
+            expiry_time: entry.times.expiry.map(|naive| naive.and_utc()),
+        })
+        .collect()
+}
+
+/// Walks the Entry's ancestor chain looking for `recycle_uuid`. Matches
+/// the equivalent helper in `services::kdbx::entries` — we duplicate
+/// here to keep `password_health` free of dependencies on KDBX
+/// internals beyond the `keepass` crate itself.
+fn is_in_recycle_bin(db: &Database, entry: &EntryRef<'_>, recycle_uuid: uuid::Uuid) -> bool {
+    let mut current_id = Some(entry.parent().id());
+    while let Some(gid) = current_id {
+        if gid.uuid() == recycle_uuid {
+            return true;
+        }
+        let Some(group) = db.group(gid) else {
+            return false;
+        };
+        current_id = group.parent().map(|p| p.id());
+    }
+    false
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use keepass::db::Value;
+    use keepass::Database;
+
+    /// The scope filter must drop Recycle Bin descendants and Entries
+    /// with no Password field, and keep everything else. Empty-string
+    /// passwords stay in scope (they will start emitting Very Weak in
+    /// the follow-up slice).
+    #[test]
+    fn excludes_recycle_bin_and_password_none() {
+        let mut db = Database::new();
+
+        // Add a Recycle Bin group under root and wire it into meta so
+        // the scope filter can find it.
+        let recycle_uuid = {
+            let mut root = db.root_mut();
+            let recycle = root.add_group();
+            recycle.id().uuid()
+        };
+        db.meta.recyclebin_uuid = Some(recycle_uuid);
+
+        // In-scope: regular Entry with a Password field.
+        let in_scope_uuid = {
+            let mut root = db.root_mut();
+            let mut entry = root.add_entry();
+            entry.set("Password", Value::protected("secret"));
+            entry.id().uuid()
+        };
+
+        // Out-of-scope: no Password field at all.
+        let _no_password_uuid = {
+            let mut root = db.root_mut();
+            let entry = root.add_entry();
+            entry.id().uuid()
+        };
+
+        // Out-of-scope: lives inside the Recycle Bin.
+        let _recycled_uuid = {
+            let recycle_id = db
+                .iter_all_groups()
+                .find(|g| g.id().uuid() == recycle_uuid)
+                .expect("recycle bin must exist")
+                .id();
+            let mut recycle = db.group_mut(recycle_id).expect("recycle bin must exist");
+            let mut entry = recycle.add_entry();
+            entry.set("Password", Value::protected("also-secret"));
+            entry.id().uuid()
+        };
+
+        let inputs = collect_entry_inputs(&db);
+
+        let ids: Vec<&str> = inputs.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![in_scope_uuid.to_string().as_str()],
+            "only the in-scope Entry should reach the analyzer"
+        );
+    }
+}

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -8,14 +8,22 @@
 //! with `password: None`, include Entries with empty-string password"),
 //! and hands the resulting [`EntryInput`] iterator to the analyzer.
 //!
-//! The eager-on-unlock coordinator, the `(db_id, generation)` cache,
-//! cancellation handles, and the Tauri-event stream layer on top of
-//! this collection step in subsequent cycles.
+//! [`PasswordHealthService`] is the coordinator the rest of the app
+//! talks to. Right now it is a thin wrapper that materializes a fresh
+//! report on every call; the `(db_id, generation)` cache, cancellation
+//! handles, debounce, and progressive Tauri events layer on top in
+//! subsequent cycles.
 
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
 use keepass::db::EntryRef;
 use keepass::Database;
 
-use super::analyzer::EntryInput;
+use super::analyzer::{analyze, EntryInput, PasswordHealthReport};
+use super::cache::CacheStore;
+use crate::dto::error::AppError;
+use crate::services::kdbx::KdbxService;
 
 /// Walks the unlocked Vault and produces one [`EntryInput`] per
 /// in-scope Entry.
@@ -50,6 +58,79 @@ pub fn collect_entry_inputs(db: &Database) -> Vec<EntryInput> {
         .collect()
 }
 
+/// Coordinator for Password Health analysis across every open Vault.
+///
+/// Holds the `(db_id, generation)`-keyed [`CacheStore`] so repeat
+/// calls against an unchanged Vault are free. Cancellation, debounce,
+/// and event-emission concerns slot onto this type in the cycles that
+/// follow.
+pub struct PasswordHealthService {
+    cache: Mutex<CacheStore>,
+}
+
+impl PasswordHealthService {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(CacheStore::new()),
+        }
+    }
+
+    /// Returns the report for the Vault at `db_id`, computing it only
+    /// if the cache slot is missing or stale.
+    ///
+    /// The generation read and the cache probe happen inside the
+    /// `with_vault` callback so the `(generation, snapshot)` pair is
+    /// taken under a coherent lock. On a miss we drop the Vault lock
+    /// before running the analyzer (which is pure and CPU-only) and
+    /// re-acquire only the cache lock to insert. The clock is
+    /// injected so the analyzer stays a pure function downstream.
+    pub fn generate_report(
+        &self,
+        kdbx: &KdbxService,
+        db_id: &str,
+        now: DateTime<Utc>,
+    ) -> Result<PasswordHealthReport, AppError> {
+        enum Outcome {
+            Hit(PasswordHealthReport),
+            Compute {
+                generation: u64,
+                inputs: Vec<EntryInput>,
+            },
+        }
+
+        let outcome = kdbx.with_vault(db_id, |vault| {
+            let generation = vault.generation();
+            let cache = self.cache.lock().map_err(|_| AppError::Lock)?;
+            if let Some(cached) = cache.get(db_id, generation) {
+                return Ok(Outcome::Hit(cached.clone()));
+            }
+            drop(cache);
+            Ok(Outcome::Compute {
+                generation,
+                inputs: collect_entry_inputs(vault.db()),
+            })
+        })?;
+
+        match outcome {
+            Outcome::Hit(report) => Ok(report),
+            Outcome::Compute { generation, inputs } => {
+                let report = analyze(inputs, now);
+                self.cache
+                    .lock()
+                    .map_err(|_| AppError::Lock)?
+                    .insert(db_id.to_string(), generation, report.clone());
+                Ok(report)
+            }
+        }
+    }
+}
+
+impl Default for PasswordHealthService {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Walks the Entry's ancestor chain looking for `recycle_uuid`. Matches
 /// the equivalent helper in `services::kdbx::entries` — we duplicate
 /// here to keep `password_health` free of dependencies on KDBX
@@ -72,8 +153,37 @@ fn is_in_recycle_bin(db: &Database, entry: &EntryRef<'_>, recycle_uuid: uuid::Uu
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use crate::domain::kdbx::OpenDatabase;
+    use crate::services::password_health::analyzer::FindingKind;
+    use chrono::TimeZone;
     use keepass::db::Value;
     use keepass::Database;
+
+    fn now_fixed() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap()
+    }
+
+    /// Drops a pre-built `keepass::Database` into the `KdbxService`
+    /// open-databases map so the test can drive `with_vault` without
+    /// going through disk-backed `create_database`.
+    fn install_vault(kdbx: &KdbxService, path: &str, db: Database) {
+        let root_id = db.root().id().uuid().to_string();
+        let open = OpenDatabase {
+            db: Some(db),
+            path: path.to_string(),
+            is_modified: false,
+            password: None,
+            keyfile_path: None,
+            version: "test".into(),
+            name: "test".into(),
+            root_group_id: root_id,
+            generation: 0,
+        };
+        let normalized = KdbxService::normalize_path(path);
+        kdbx.lock_databases()
+            .expect("lock databases")
+            .insert(normalized, open);
+    }
 
     /// The scope filter must drop Recycle Bin descendants and Entries
     /// with no Password field, and keep everything else. Empty-string
@@ -127,6 +237,147 @@ mod tests {
             ids,
             vec![in_scope_uuid.to_string().as_str()],
             "only the in-scope Entry should reach the analyzer"
+        );
+    }
+
+    /// End-to-end tracer through the synchronous coordinator: install
+    /// a Vault containing one healthy Entry and one Entry whose
+    /// `times.expires` is set with `times.expiry` in the past, then
+    /// call `generate_report`. The returned report must carry exactly
+    /// one `password.expired` Finding scoped to the expired Entry's
+    /// id, and the score must be below 100. This proves that the
+    /// `KdbxService::with_vault` ↔ `collect_entry_inputs` ↔ `analyze`
+    /// chain plugs together correctly.
+    #[test]
+    fn generate_report_emits_password_expired_for_expired_entry() {
+        let now = now_fixed();
+        let past = (now - chrono::Duration::days(1)).naive_utc();
+
+        let mut db = Database::new();
+        let _healthy_uuid = {
+            let mut root = db.root_mut();
+            let mut entry = root.add_entry();
+            entry.set("Password", Value::protected("ok"));
+            entry.id().uuid()
+        };
+        let expired_uuid = {
+            let mut root = db.root_mut();
+            let mut entry = root.add_entry();
+            entry.set("Password", Value::protected("ok-too"));
+            entry.times.expires = Some(true);
+            entry.times.expiry = Some(past);
+            entry.id().uuid()
+        };
+
+        let kdbx = KdbxService::new();
+        let path = "/tmp/__health_generate_report_test__.kdbx";
+        install_vault(&kdbx, path, db);
+
+        let service = PasswordHealthService::new();
+        let report = service
+            .generate_report(&kdbx, path, now)
+            .expect("generate_report");
+
+        assert!(
+            report.score.is_some_and(|s| s < 100),
+            "score must be below 100 when an Entry is expired (got {:?})",
+            report.score
+        );
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].entry_id, expired_uuid.to_string());
+        assert_eq!(report.findings[0].kind, FindingKind::PasswordExpired);
+    }
+
+    /// A mutation followed by `VaultMut::mark_modified()` advances the
+    /// generation counter; the next `generate_report` call must
+    /// recompute against the new tree state instead of returning the
+    /// stale cached report. This is the user-visible freshness
+    /// guarantee — saving a fix in the entry editor and immediately
+    /// re-opening the Security report must reflect the fix.
+    #[test]
+    fn generate_report_busts_cache_when_mark_modified_advances_generation() {
+        let now = now_fixed();
+        let past = (now - chrono::Duration::days(1)).naive_utc();
+
+        let mut db = Database::new();
+        {
+            let mut root = db.root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("ok"));
+        }
+
+        let kdbx = KdbxService::new();
+        let path = "/tmp/__health_cache_bust_test__.kdbx";
+        install_vault(&kdbx, path, db);
+        let service = PasswordHealthService::new();
+
+        let r1 = service.generate_report(&kdbx, path, now).expect("first");
+        assert!(r1.findings.is_empty());
+
+        kdbx.with_vault_mut(path, |v| {
+            let mut root = v.db_mut().root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("x"));
+            e.times.expires = Some(true);
+            e.times.expiry = Some(past);
+            v.mark_modified();
+            Ok(())
+        })
+        .expect("mutate + mark");
+
+        let r2 = service.generate_report(&kdbx, path, now).expect("second");
+        assert_eq!(
+            r2.findings.len(),
+            1,
+            "report must reflect the newly-added expired Entry"
+        );
+        assert_eq!(r2.findings[0].kind, FindingKind::PasswordExpired);
+    }
+
+    /// Mutations that **don't** call `mark_modified` (e.g. a no-op
+    /// write path, or `report_activity` touching access timestamps)
+    /// must not invalidate the cache — the generation counter is the
+    /// sole freshness signal. This pin doubles as proof that the
+    /// cache actually serves repeat reads: if it weren't caching, the
+    /// second call would walk the freshly-mutated tree and disagree
+    /// with the first.
+    #[test]
+    fn generate_report_hits_cache_when_generation_does_not_advance() {
+        let now = now_fixed();
+        let past = (now - chrono::Duration::days(1)).naive_utc();
+
+        let mut db = Database::new();
+        {
+            let mut root = db.root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("ok"));
+        }
+
+        let kdbx = KdbxService::new();
+        let path = "/tmp/__health_cache_hit_test__.kdbx";
+        install_vault(&kdbx, path, db);
+        let service = PasswordHealthService::new();
+
+        let r1 = service.generate_report(&kdbx, path, now).expect("first");
+        assert!(r1.findings.is_empty());
+
+        kdbx.with_vault_mut(path, |v| {
+            let mut root = v.db_mut().root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("y"));
+            e.times.expires = Some(true);
+            e.times.expiry = Some(past);
+            // NOTE: deliberately not calling v.mark_modified(). The
+            // cache is keyed on generation, and generation only moves
+            // through that one call site.
+            Ok(())
+        })
+        .expect("mutate without marking");
+
+        let r2 = service.generate_report(&kdbx, path, now).expect("second");
+        assert_eq!(
+            r1, r2,
+            "cache must return the previous report when generation hasn't advanced"
         );
     }
 }

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -126,6 +126,19 @@ impl PasswordHealthService {
     }
 }
 
+impl PasswordHealthService {
+    /// Drops the cached report for `db_id`. Called after a successful
+    /// Vault-lock transition so a subsequent unlock + read forces a
+    /// fresh analysis instead of returning a snapshot from the
+    /// previous session. Safe to call against a Vault that has never
+    /// been analysed — the eviction is a no-op when no slot exists.
+    pub fn on_lock(&self, db_id: &str) {
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.evict(db_id);
+        }
+    }
+}
+
 impl Default for PasswordHealthService {
     fn default() -> Self {
         Self::new()
@@ -380,5 +393,50 @@ mod tests {
             r1, r2,
             "cache must return the previous report when generation hasn't advanced"
         );
+    }
+
+    /// `on_lock` drops the cached slot for the Vault. The trick the
+    /// test relies on: mutate without `mark_modified` to keep the
+    /// generation steady (so the cache *would* hit on the next read),
+    /// then call `on_lock`. The follow-up `generate_report` must
+    /// miss-and-recompute — visible because the mutation introduced
+    /// an expired Entry that wasn't there in the seed report.
+    #[test]
+    fn on_lock_evicts_cache_so_next_call_recomputes() {
+        let now = now_fixed();
+        let past = (now - chrono::Duration::days(1)).naive_utc();
+
+        let mut db = Database::new();
+        {
+            let mut root = db.root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("ok"));
+        }
+
+        let kdbx = KdbxService::new();
+        let path = "/tmp/__health_on_lock_evict_test__.kdbx";
+        install_vault(&kdbx, path, db);
+        let service = PasswordHealthService::new();
+
+        let r1 = service.generate_report(&kdbx, path, now).expect("seed");
+        assert!(r1.findings.is_empty());
+
+        kdbx.with_vault_mut(path, |v| {
+            let mut root = v.db_mut().root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("x"));
+            e.times.expires = Some(true);
+            e.times.expiry = Some(past);
+            // Deliberately no mark_modified — the cache would hit
+            // on the next read if not for the explicit eviction.
+            Ok(())
+        })
+        .expect("silent mutation");
+
+        service.on_lock(path);
+
+        let r2 = service.generate_report(&kdbx, path, now).expect("recompute");
+        assert_eq!(r2.findings.len(), 1);
+        assert_eq!(r2.findings[0].kind, FindingKind::PasswordExpired);
     }
 }

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -17,12 +17,12 @@
 use std::sync::Mutex;
 
 use chrono::{DateTime, Utc};
-use keepass::db::EntryRef;
 use keepass::Database;
 
 use super::analyzer::{analyze, EntryInput, PasswordHealthReport};
 use super::cache::CacheStore;
 use crate::dto::error::AppError;
+use crate::services::kdbx::recycle::is_in_recycle_bin;
 use crate::services::kdbx::KdbxService;
 
 /// Walks the unlocked Vault and produces one [`EntryInput`] per
@@ -145,24 +145,6 @@ impl Default for PasswordHealthService {
     }
 }
 
-/// Walks the Entry's ancestor chain looking for `recycle_uuid`. Matches
-/// the equivalent helper in `services::kdbx::entries` — we duplicate
-/// here to keep `password_health` free of dependencies on KDBX
-/// internals beyond the `keepass` crate itself.
-fn is_in_recycle_bin(db: &Database, entry: &EntryRef<'_>, recycle_uuid: uuid::Uuid) -> bool {
-    let mut current_id = Some(entry.parent().id());
-    while let Some(gid) = current_id {
-        if gid.uuid() == recycle_uuid {
-            return true;
-        }
-        let Some(group) = db.group(gid) else {
-            return false;
-        };
-        current_id = group.parent().map(|p| p.id());
-    }
-    false
-}
-
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
@@ -175,6 +157,46 @@ mod tests {
 
     fn now_fixed() -> DateTime<Utc> {
         Utc.with_ymd_and_hms(2026, 5, 18, 12, 0, 0).unwrap()
+    }
+
+    /// Builds a one-Entry Vault keyed on `path` and returns the
+    /// `KdbxService` and `PasswordHealthService` the cache/eviction
+    /// tests share. The seeded Entry is healthy (no expiry).
+    fn seed_single_entry_vault(path: &str) -> (KdbxService, PasswordHealthService) {
+        let mut db = Database::new();
+        {
+            let mut root = db.root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected("ok"));
+        }
+        let kdbx = KdbxService::new();
+        install_vault(&kdbx, path, db);
+        (kdbx, PasswordHealthService::new())
+    }
+
+    /// Adds an expired Entry to the Vault at `path`. When `mark` is
+    /// true, also calls `VaultMut::mark_modified()` so the cache key
+    /// advances; when false, the mutation stays "silent" — useful for
+    /// proving cache hits and `on_lock` eviction.
+    fn insert_expired_entry(
+        kdbx: &KdbxService,
+        path: &str,
+        password: &str,
+        expiry: chrono::NaiveDateTime,
+        mark: bool,
+    ) {
+        kdbx.with_vault_mut(path, |v| {
+            let mut root = v.db_mut().root_mut();
+            let mut e = root.add_entry();
+            e.set("Password", Value::protected(password));
+            e.times.expires = Some(true);
+            e.times.expiry = Some(expiry);
+            if mark {
+                v.mark_modified();
+            }
+            Ok(())
+        })
+        .expect("mutate");
     }
 
     /// Drops a pre-built `keepass::Database` into the `KdbxService`
@@ -312,32 +334,13 @@ mod tests {
     fn generate_report_busts_cache_when_mark_modified_advances_generation() {
         let now = now_fixed();
         let past = (now - chrono::Duration::days(1)).naive_utc();
-
-        let mut db = Database::new();
-        {
-            let mut root = db.root_mut();
-            let mut e = root.add_entry();
-            e.set("Password", Value::protected("ok"));
-        }
-
-        let kdbx = KdbxService::new();
         let path = "/tmp/__health_cache_bust_test__.kdbx";
-        install_vault(&kdbx, path, db);
-        let service = PasswordHealthService::new();
+        let (kdbx, service) = seed_single_entry_vault(path);
 
         let r1 = service.generate_report(&kdbx, path, now).expect("first");
         assert!(r1.findings.is_empty());
 
-        kdbx.with_vault_mut(path, |v| {
-            let mut root = v.db_mut().root_mut();
-            let mut e = root.add_entry();
-            e.set("Password", Value::protected("x"));
-            e.times.expires = Some(true);
-            e.times.expiry = Some(past);
-            v.mark_modified();
-            Ok(())
-        })
-        .expect("mutate + mark");
+        insert_expired_entry(&kdbx, path, "x", past, true);
 
         let r2 = service.generate_report(&kdbx, path, now).expect("second");
         assert_eq!(
@@ -359,34 +362,16 @@ mod tests {
     fn generate_report_hits_cache_when_generation_does_not_advance() {
         let now = now_fixed();
         let past = (now - chrono::Duration::days(1)).naive_utc();
-
-        let mut db = Database::new();
-        {
-            let mut root = db.root_mut();
-            let mut e = root.add_entry();
-            e.set("Password", Value::protected("ok"));
-        }
-
-        let kdbx = KdbxService::new();
         let path = "/tmp/__health_cache_hit_test__.kdbx";
-        install_vault(&kdbx, path, db);
-        let service = PasswordHealthService::new();
+        let (kdbx, service) = seed_single_entry_vault(path);
 
         let r1 = service.generate_report(&kdbx, path, now).expect("first");
         assert!(r1.findings.is_empty());
 
-        kdbx.with_vault_mut(path, |v| {
-            let mut root = v.db_mut().root_mut();
-            let mut e = root.add_entry();
-            e.set("Password", Value::protected("y"));
-            e.times.expires = Some(true);
-            e.times.expiry = Some(past);
-            // NOTE: deliberately not calling v.mark_modified(). The
-            // cache is keyed on generation, and generation only moves
-            // through that one call site.
-            Ok(())
-        })
-        .expect("mutate without marking");
+        // Silent mutation: the cache is keyed on generation, and
+        // generation only advances through `mark_modified`. So the
+        // expired Entry added here must not invalidate the cached r1.
+        insert_expired_entry(&kdbx, path, "y", past, false);
 
         let r2 = service.generate_report(&kdbx, path, now).expect("second");
         assert_eq!(
@@ -405,33 +390,15 @@ mod tests {
     fn on_lock_evicts_cache_so_next_call_recomputes() {
         let now = now_fixed();
         let past = (now - chrono::Duration::days(1)).naive_utc();
-
-        let mut db = Database::new();
-        {
-            let mut root = db.root_mut();
-            let mut e = root.add_entry();
-            e.set("Password", Value::protected("ok"));
-        }
-
-        let kdbx = KdbxService::new();
         let path = "/tmp/__health_on_lock_evict_test__.kdbx";
-        install_vault(&kdbx, path, db);
-        let service = PasswordHealthService::new();
+        let (kdbx, service) = seed_single_entry_vault(path);
 
         let r1 = service.generate_report(&kdbx, path, now).expect("seed");
         assert!(r1.findings.is_empty());
 
-        kdbx.with_vault_mut(path, |v| {
-            let mut root = v.db_mut().root_mut();
-            let mut e = root.add_entry();
-            e.set("Password", Value::protected("x"));
-            e.times.expires = Some(true);
-            e.times.expiry = Some(past);
-            // Deliberately no mark_modified — the cache would hit
-            // on the next read if not for the explicit eviction.
-            Ok(())
-        })
-        .expect("silent mutation");
+        // Silent mutation: without `on_lock` the next read would hit
+        // the cache. The explicit eviction is what forces recompute.
+        insert_expired_entry(&kdbx, path, "x", past, false);
 
         service.on_lock(path);
 

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -115,10 +115,11 @@ impl PasswordHealthService {
             Outcome::Hit(report) => Ok(report),
             Outcome::Compute { generation, inputs } => {
                 let report = analyze(inputs, now);
-                self.cache
-                    .lock()
-                    .map_err(|_| AppError::Lock)?
-                    .insert(db_id.to_string(), generation, report.clone());
+                self.cache.lock().map_err(|_| AppError::Lock)?.insert(
+                    db_id.to_string(),
+                    generation,
+                    report.clone(),
+                );
                 Ok(report)
             }
         }

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -435,7 +435,9 @@ mod tests {
 
         service.on_lock(path);
 
-        let r2 = service.generate_report(&kdbx, path, now).expect("recompute");
+        let r2 = service
+            .generate_report(&kdbx, path, now)
+            .expect("recompute");
         assert_eq!(r2.findings.len(), 1);
         assert_eq!(r2.findings[0].kind, FindingKind::PasswordExpired);
     }

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -101,7 +101,7 @@ impl PasswordHealthService {
         let outcome = kdbx.with_vault(db_id, |vault| {
             let generation = vault.generation();
             let cache = self.cache.lock().map_err(|_| AppError::Lock)?;
-            if let Some(cached) = cache.get(db_id, generation) {
+            if let Some(cached) = cache.get(db_id, generation, now) {
                 return Ok(Outcome::Hit(cached.clone()));
             }
             drop(cache);
@@ -114,11 +114,13 @@ impl PasswordHealthService {
         match outcome {
             Outcome::Hit(report) => Ok(report),
             Outcome::Compute { generation, inputs } => {
+                let relevant_until = earliest_future_expiry(&inputs, now);
                 let report = analyze(inputs, now);
                 self.cache.lock().map_err(|_| AppError::Lock)?.insert(
                     db_id.to_string(),
                     generation,
                     report.clone(),
+                    relevant_until,
                 );
                 Ok(report)
             }
@@ -143,6 +145,19 @@ impl Default for PasswordHealthService {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Returns the soonest in-scope expiry that has not yet elapsed at
+/// `now`, or `None` when no such expiry exists. Used by the cache to
+/// know when to start missing reads that would otherwise serve a
+/// stale "healthy" snapshot across an entry's expiry moment.
+fn earliest_future_expiry(inputs: &[EntryInput], now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    inputs
+        .iter()
+        .filter(|i| i.expires)
+        .filter_map(|i| i.expiry_time)
+        .filter(|t| *t > now)
+        .min()
 }
 
 #[cfg(test)]
@@ -407,5 +422,37 @@ mod tests {
             .expect("recompute");
         assert_eq!(r2.findings.len(), 1);
         assert_eq!(r2.findings[0].kind, FindingKind::PasswordExpired);
+    }
+
+    /// A future-expiring Entry must not produce a cache slot that
+    /// outlives its expiry instant. Caching at `t0` with the Entry's
+    /// expiry at `t1` (one hour later) and reading again at `t1`
+    /// without any Vault mutation must recompute and surface the
+    /// newly-elapsed `PasswordExpired` Finding. Pins the time
+    /// component of the cache key — without it the seed report would
+    /// be served and the entry would silently stay "healthy".
+    #[test]
+    fn generate_report_misses_cache_after_relevant_until_elapses() {
+        let t0 = now_fixed();
+        let t1 = t0 + chrono::Duration::hours(1);
+        let future_expiry = t1.naive_utc();
+        let path = "/tmp/__health_time_invalidation_test__.kdbx";
+        let (kdbx, service) = seed_single_entry_vault(path);
+
+        // Silent mutation: add an entry that expires at t1 but is
+        // healthy at t0. No mark_modified — the only freshness signal
+        // available is `now`.
+        insert_expired_entry(&kdbx, path, "future", future_expiry, false);
+
+        let r0 = service.generate_report(&kdbx, path, t0).expect("at t0");
+        assert!(r0.findings.is_empty(), "before expiry the entry is healthy");
+
+        let r1 = service.generate_report(&kdbx, path, t1).expect("at t1");
+        assert_eq!(
+            r1.findings.len(),
+            1,
+            "at the expiry instant the report must surface the Finding"
+        );
+        assert_eq!(r1.findings[0].kind, FindingKind::PasswordExpired);
     }
 }

--- a/src-tauri/tests/command_handlers_test.rs
+++ b/src-tauri/tests/command_handlers_test.rs
@@ -241,9 +241,12 @@ fn entries_and_groups_commands_fail_when_not_open() {
 fn additional_group_and_database_commands_fail_when_not_open() {
     let app = setup_app();
 
-    let close_err =
-        tauri::async_runtime::block_on(close_database("nonexistent.kdbx".to_string(), app.state()))
-            .expect_err("expected database not found");
+    let close_err = tauri::async_runtime::block_on(close_database(
+        "nonexistent.kdbx".to_string(),
+        app.state(),
+        app.state(),
+    ))
+    .expect_err("expected database not found");
     assert!(matches!(close_err, AppError::DatabaseNotFound(_)));
 
     let save_err = tauri::async_runtime::block_on(save_database(
@@ -389,8 +392,12 @@ fn database_commands_cover_success_paths() {
         tauri::async_runtime::block_on(list_open_databases(app.state())).expect("list open dbs");
     assert_eq!(open_dbs.len(), 1, "One database should be open");
 
-    tauri::async_runtime::block_on(close_database(db_path_str.clone(), app.state()))
-        .expect("close database");
+    tauri::async_runtime::block_on(close_database(
+        db_path_str.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("close database");
 
     let info_after_close =
         tauri::async_runtime::block_on(get_database_info(db_path_str.clone(), app.state()))
@@ -407,8 +414,12 @@ fn database_commands_cover_success_paths() {
     ))
     .expect("open database with keyfile");
 
-    tauri::async_runtime::block_on(close_database(db_path_str.clone(), app.state()))
-        .expect("close database after keyfile open");
+    tauri::async_runtime::block_on(close_database(
+        db_path_str.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("close database after keyfile open");
 
     let key_only_path = temp_dir.path().join("command-key-only.kdbx");
     let key_only_path_str = key_only_path.to_string_lossy().to_string();
@@ -423,8 +434,12 @@ fn database_commands_cover_success_paths() {
     ))
     .expect("create keyfile-only database");
 
-    tauri::async_runtime::block_on(close_database(key_only_path_str.clone(), app.state()))
-        .expect("close keyfile-only database");
+    tauri::async_runtime::block_on(close_database(
+        key_only_path_str.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("close keyfile-only database");
 
     tauri::async_runtime::block_on(open_database_with_keyfile_only(
         key_only_path_str.clone(),
@@ -435,8 +450,12 @@ fn database_commands_cover_success_paths() {
     ))
     .expect("open with keyfile only");
 
-    tauri::async_runtime::block_on(close_database(key_only_path_str.clone(), app.state()))
-        .expect("final close");
+    tauri::async_runtime::block_on(close_database(
+        key_only_path_str.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("final close");
 
     cleanup_app_files(&app);
 }
@@ -497,8 +516,12 @@ fn create_manual_backup_command_writes_manual_snapshot_visible_in_listing() {
         .expect("manual snapshot appears in listing");
     assert_eq!(manual_entry.kind, BackupKind::Manual);
 
-    tauri::async_runtime::block_on(close_database(db_path_str.clone(), app.state()))
-        .expect("close database");
+    tauri::async_runtime::block_on(close_database(
+        db_path_str.clone(),
+        app.state(),
+        app.state(),
+    ))
+    .expect("close database");
     cleanup_app_files(&app);
 }
 

--- a/src-tauri/tests/command_handlers_test.rs
+++ b/src-tauri/tests/command_handlers_test.rs
@@ -164,6 +164,7 @@ fn database_commands_handle_missing_database() {
         "missing.kdbx".to_string(),
         app.state(),
         app.state(),
+        app.state(),
     ))
     .expect_err("expected database not found");
     assert!(matches!(err, AppError::DatabaseNotFound(_)));

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -4,6 +4,8 @@ import { ItemSeparator } from "@/components/ui/item";
 import { useActiveDatabase } from "@/hooks/use-active-database";
 import { useCustomIcons } from "@/hooks/use-custom-icons";
 import { useEntries } from "@/hooks/use-entries";
+import { usePasswordHealthReport } from "@/hooks/use-password-health";
+import { findingsForEntry } from "@/lib/password-health";
 import { useEntryListInteraction } from "@/hooks/use-entry-list-interaction";
 import { useSortedEntries } from "@/hooks/use-sorted-entries";
 import { useSearch } from "@tanstack/react-router";
@@ -25,6 +27,7 @@ export default function EntryList({ onEntrySelect }: EntryListProps) {
   const { dbId } = useActiveDatabase();
   const search = useSearch({ strict: false });
   const { data: customIcons } = useCustomIcons(dbId);
+  const { data: healthReport } = usePasswordHealthReport(dbId ?? null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
   const sortBy: EntrySortField = search.sortBy ?? "title";
@@ -129,6 +132,7 @@ export default function EntryList({ onEntrySelect }: EntryListProps) {
                 customIcons={customIcons ?? EMPTY_ICONS}
                 isSelected={entry.id === selectedEntryId}
                 onClick={handleItemClick}
+                findings={findingsForEntry(healthReport, entry.id)}
               />
               <ItemSeparator />
             </div>

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -1,6 +1,8 @@
-import type { CustomIconMap, Entry } from "@/lib/types";
-import { CircleAlert } from "lucide-react";
+import type { CustomIconMap, Entry, Finding } from "@/lib/types";
+import { TriangleAlert } from "lucide-react";
 import { createElement, memo } from "react";
+import { useTranslation } from "react-i18next";
+import { severityOf } from "@/lib/password-health";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Item,
@@ -10,6 +12,11 @@ import {
   ItemMedia,
   ItemTitle,
 } from "@/components/ui/item";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { getKeepassIcon } from "@/lib/keepass-icons";
 import { cn } from "@/lib/utils";
 
@@ -17,6 +24,10 @@ interface EntryListItemProps extends Entry {
   customIcons: CustomIconMap;
   isSelected?: boolean;
   onClick?: (id: string) => void;
+  /// Password Health Findings scoped to this Entry. The list comes
+  /// from `useEntryFindings(dbId, entry.id)` on the parent. An empty
+  /// array renders no icon; one or more Findings render the warning.
+  findings?: Finding[];
 }
 
 const EntryListItem = memo(function EntryListItem({
@@ -28,7 +39,9 @@ const EntryListItem = memo(function EntryListItem({
   customIcons,
   isSelected,
   onClick,
+  findings,
 }: EntryListItemProps) {
+  const { t } = useTranslation();
   const iconComponent = getKeepassIcon(iconId ?? 0);
   const customIcon = customIconUuid ? customIcons[customIconUuid] : null;
   const customIconSrc = customIcon
@@ -65,8 +78,24 @@ const EntryListItem = memo(function EntryListItem({
           </ItemDescription>
         </ItemContent>
         <ItemActions className="shrink-0">
-          {/* TODO: show warning icon if password is duplicated or compromised */}
-          <CircleAlert className="size-4" />
+          {findings && findings.length > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <TriangleAlert
+                  className={cn(
+                    "size-4",
+                    findings.some((f) => severityOf(f.kind) === "critical")
+                      ? "text-red-600 dark:text-red-500"
+                      : "text-amber-600 dark:text-amber-500"
+                  )}
+                  aria-label={t("passwordHealth.icons.warning")}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                {t("passwordHealth.icons.warning")}
+              </TooltipContent>
+            </Tooltip>
+          )}
         </ItemActions>
       </a>
     </Item>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -23,16 +23,33 @@ import {
 import { Separator } from "@/components/ui/separator.tsx";
 import { GroupTree } from "@/components/groups/GroupTree";
 import { useActiveDatabase } from "@/hooks/use-active-database";
+import { usePasswordHealthSummary } from "@/hooks/use-password-health";
 import NavTags from "@/components/layout/nav-tags.tsx";
 
 export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { dbId } = useActiveDatabase();
+  const { totalUnhealthy, highestSeverity } = usePasswordHealthSummary(
+    dbId ?? null
+  );
 
   if (!dbId) {
     return null;
   }
+
+  const securityBadge =
+    totalUnhealthy > 0 ? (
+      <span
+        className={
+          highestSeverity === "critical"
+            ? "text-red-600 dark:text-red-500"
+            : "text-amber-600 dark:text-amber-500"
+        }
+      >
+        {totalUnhealthy}
+      </span>
+    ) : undefined;
 
   const navMain = [
     {
@@ -50,10 +67,14 @@ export function AppSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
       disabled: true,
     },
     {
-      // TODO: wire security health to backend
       title: t("sidebar.security"),
       icon: ShieldIcon,
-      disabled: true,
+      badge: securityBadge,
+      onSelect: () =>
+        void navigate({
+          to: "/dashboard/security/$dbId",
+          params: { dbId },
+        }),
     },
   ];
 

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -22,7 +22,7 @@ interface PasswordHealthReportViewProps {
 
 export function PasswordHealthReportView({
   dbId,
-}: PasswordHealthReportViewProps) {
+}: Readonly<PasswordHealthReportViewProps>) {
   const { t } = useTranslation();
   const { data: report, isLoading, error } = usePasswordHealthReport(dbId);
   const { data: entries } = useEntries(dbId, null);
@@ -61,7 +61,9 @@ export function PasswordHealthReportView({
   );
 }
 
-function ScoreAndTotals({ report }: { report: PasswordHealthReport }) {
+function ScoreAndTotals({
+  report,
+}: Readonly<{ report: PasswordHealthReport }>) {
   const { t } = useTranslation();
   const isEmpty = report.totals.total === 0;
   const scoreText =
@@ -102,11 +104,11 @@ function TotalsCell({
   label,
   value,
   emphasis,
-}: {
+}: Readonly<{
   label: string;
   value: number;
   emphasis?: "amber";
-}) {
+}>) {
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -126,10 +128,10 @@ function TotalsCell({
 function HighFindingsSection({
   report,
   entries,
-}: {
+}: Readonly<{
   report: PasswordHealthReport;
   entries: Entry[];
-}) {
+}>) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -12,8 +12,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { useActiveDatabase } from "@/hooks/use-active-database";
 import { useEntries } from "@/hooks/use-entries";
 import { usePasswordHealthReport } from "@/hooks/use-password-health";
+import { useDatabaseTabs } from "@/stores/database-tabs";
 import type { Entry, Finding, PasswordHealthReport } from "@/lib/types";
 
 interface PasswordHealthReportViewProps {
@@ -134,6 +136,8 @@ function HighFindingsSection({
 }>) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { tab } = useActiveDatabase();
+  const updateTabState = useDatabaseTabs((s) => s.updateTabState);
 
   // Group findings by entry so the row collapses an Entry that hits
   // multiple Findings of the same severity into a single visual row.
@@ -149,6 +153,18 @@ function HighFindingsSection({
   }
 
   const entryById = new Map(entries.map((e) => [e.id, e]));
+
+  // The entry detail view's Edit action reads `tab.selectedEntryId`,
+  // not the URL param — so we have to mirror the EntryList click
+  // pattern (update tab state, then navigate) instead of navigating
+  // directly. The route's `beforeLoad` already activated this tab via
+  // `requireUnlockedTab`, so `useActiveDatabase` resolves to it.
+  const openEntry = (entryId: string) => {
+    if (tab) {
+      updateTabState(tab.id, { selectedEntryId: entryId });
+    }
+    void navigate({ to: "/dashboard/entry/$id", params: { id: entryId } });
+  };
 
   return (
     <section className="flex flex-col gap-2">
@@ -182,12 +198,7 @@ function HighFindingsSection({
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() =>
-                  void navigate({
-                    to: "/dashboard/entry/$id",
-                    params: { id: entryId },
-                  })
-                }
+                onClick={() => openEntry(entryId)}
               >
                 {t("passwordHealth.actions.openEntry")}
               </Button>

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+import { TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useNavigate } from "@tanstack/react-router";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useEntries } from "@/hooks/use-entries";
+import { usePasswordHealthReport } from "@/hooks/use-password-health";
+import type { Entry, Finding, PasswordHealthReport } from "@/lib/types";
+
+interface PasswordHealthReportViewProps {
+  dbId: string;
+}
+
+export function PasswordHealthReportView({
+  dbId,
+}: PasswordHealthReportViewProps) {
+  const { t } = useTranslation();
+  const { data: report, isLoading } = usePasswordHealthReport(dbId);
+  const { data: entries } = useEntries(dbId, null);
+
+  if (isLoading || !report) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">
+        {t("passwordHealth.loading")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <header className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {t("passwordHealth.title")}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t("passwordHealth.subtitle")}
+        </p>
+      </header>
+
+      <ScoreAndTotals report={report} />
+
+      <HighFindingsSection report={report} entries={entries ?? []} />
+    </div>
+  );
+}
+
+function ScoreAndTotals({ report }: { report: PasswordHealthReport }) {
+  const { t } = useTranslation();
+  const isEmpty = report.totals.total === 0;
+  const scoreText =
+    report.score === null ? t("passwordHealth.noScore") : String(report.score);
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-5">
+      <Card className="sm:col-span-2">
+        <CardHeader className="pb-2">
+          <CardDescription>{t("passwordHealth.scoreLabel")}</CardDescription>
+          <CardTitle className="text-4xl tabular-nums">{scoreText}</CardTitle>
+        </CardHeader>
+        {isEmpty && (
+          <CardContent className="pt-0 text-sm text-muted-foreground">
+            {t("passwordHealth.emptyState")}
+          </CardContent>
+        )}
+      </Card>
+
+      <TotalsCell
+        label={t("passwordHealth.totals.critical")}
+        value={report.totals.critical}
+      />
+      <TotalsCell
+        label={t("passwordHealth.totals.high")}
+        value={report.totals.high}
+        {...(report.totals.high > 0 ? { emphasis: "amber" as const } : {})}
+      />
+      <TotalsCell
+        label={t("passwordHealth.totals.healthy")}
+        value={report.totals.healthy}
+      />
+    </div>
+  );
+}
+
+function TotalsCell({
+  label,
+  value,
+  emphasis,
+}: {
+  label: string;
+  value: number;
+  emphasis?: "amber";
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardDescription>{label}</CardDescription>
+        <CardTitle
+          className={`text-3xl tabular-nums ${
+            emphasis === "amber" ? "text-amber-600 dark:text-amber-500" : ""
+          }`}
+        >
+          {value}
+        </CardTitle>
+      </CardHeader>
+    </Card>
+  );
+}
+
+function HighFindingsSection({
+  report,
+  entries,
+}: {
+  report: PasswordHealthReport;
+  entries: Entry[];
+}) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  // Group findings by entry so the row collapses an Entry that hits
+  // multiple Findings of the same severity into a single visual row.
+  const byEntry = new Map<string, Finding[]>();
+  for (const finding of report.findings) {
+    const list = byEntry.get(finding.entryId) ?? [];
+    list.push(finding);
+    byEntry.set(finding.entryId, list);
+  }
+
+  if (byEntry.size === 0) {
+    return null;
+  }
+
+  const entryById = new Map(entries.map((e) => [e.id, e]));
+
+  return (
+    <section className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <TriangleAlert className="size-4 text-amber-600 dark:text-amber-500" />
+        <h2 className="text-lg font-medium">
+          {t("passwordHealth.sections.high")}
+        </h2>
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {t("passwordHealth.sections.highDescription")}
+      </p>
+      <ul className="divide-y rounded-md border bg-card">
+        {Array.from(byEntry.entries()).map(([entryId, findings]) => {
+          const entry = entryById.get(entryId);
+          return (
+            <li
+              key={entryId}
+              className="flex items-center justify-between gap-3 px-4 py-3"
+            >
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="truncate font-medium">
+                  {entry?.title ?? entryId}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {findings
+                    .map((f) => t(`passwordHealth.findings.${f.kind}`))
+                    .join(" · ")}
+                </span>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() =>
+                  void navigate({
+                    to: "/dashboard/entry/$id",
+                    params: { id: entryId },
+                  })
+                }
+              >
+                {t("passwordHealth.actions.openEntry")}
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -24,8 +24,16 @@ export function PasswordHealthReportView({
   dbId,
 }: PasswordHealthReportViewProps) {
   const { t } = useTranslation();
-  const { data: report, isLoading } = usePasswordHealthReport(dbId);
+  const { data: report, isLoading, error } = usePasswordHealthReport(dbId);
   const { data: entries } = useEntries(dbId, null);
+
+  if (error) {
+    return (
+      <div className="p-6 text-sm text-destructive">
+        {error instanceof Error ? error.message : String(error)}
+      </div>
+    );
+  }
 
   if (isLoading || !report) {
     return (

--- a/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSection.test.tsx
@@ -135,7 +135,7 @@ describe("AuditLogSection", () => {
     const rows = await screen.findAllByRole("listitem");
     expect(rows.length).toBe(2);
     rows.forEach((row) => {
-      expect(row.getAttribute("data-kind")).toBe("vaultUnlockFailed");
+      expect(row.dataset["kind"]).toBe("vaultUnlockFailed");
       // The kind label is rendered inside each row.
       expect(row.textContent).toContain("audit.kind.vaultUnlockFailed");
     });
@@ -269,8 +269,8 @@ describe("AuditLogSection", () => {
     );
 
     const row = await screen.findByRole("listitem");
-    expect(row.getAttribute("data-kind")).toBe("entryPasswordRevealed");
-    expect(row.getAttribute("data-entry-id")).toBe("uuid-abc-1234567890");
+    expect(row.dataset["kind"]).toBe("entryPasswordRevealed");
+    expect(row.dataset["entryId"]).toBe("uuid-abc-1234567890");
     // Title comes from the cache.
     expect(row.textContent).toContain("GitHub");
   });
@@ -297,7 +297,7 @@ describe("AuditLogSection", () => {
     );
 
     const row = await screen.findByRole("listitem");
-    expect(row.getAttribute("data-kind")).toBe("entryPasswordRevealed");
+    expect(row.dataset["kind"]).toBe("entryPasswordRevealed");
     // UUID prefix (first 8 chars) as the visible fallback identifier.
     expect(row.textContent).toContain("8f1c2e3a");
     // The full UUID must NOT be rendered — otherwise the row is unreadably long.
@@ -331,7 +331,7 @@ describe("AuditLogSection", () => {
     );
 
     const row = await screen.findByRole("listitem");
-    expect(row.getAttribute("data-kind")).toBe("entryPasswordCopied");
+    expect(row.dataset["kind"]).toBe("entryPasswordCopied");
     expect(row.textContent).toContain("Bank");
     expect(row.textContent).toContain("audit.kind.entryPasswordCopied");
   });
@@ -361,7 +361,7 @@ describe("AuditLogSection", () => {
     );
 
     const row = await screen.findByRole("listitem");
-    expect(row.getAttribute("data-kind")).toBe("entryProtectedFieldRevealed");
+    expect(row.dataset["kind"]).toBe("entryProtectedFieldRevealed");
     expect(row.textContent).toContain("Recovery codes");
     expect(row.textContent).toContain("audit.kind.entryProtectedFieldRevealed");
   });
@@ -529,7 +529,7 @@ describe("AuditLogSection", () => {
     await waitFor(() => {
       const rows = screen.getAllByRole("listitem");
       expect(rows.length).toBe(1);
-      expect(rows[0]?.getAttribute("data-kind")).toBe("auditCleared");
+      expect(rows[0]?.dataset["kind"]).toBe("auditCleared");
     });
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
@@ -565,7 +565,7 @@ describe("AuditLogSection", () => {
     });
     // Pre-clear event still visible — the original log was preserved.
     const rows = screen.getAllByRole("listitem");
-    expect(rows[0]?.getAttribute("data-kind")).toBe("vaultUnlockFailed");
+    expect(rows[0]?.dataset["kind"]).toBe("vaultUnlockFailed");
   });
 
   it("renders an auditCleared row with the localized kind label", async () => {
@@ -587,7 +587,7 @@ describe("AuditLogSection", () => {
     );
 
     const row = await screen.findByRole("listitem");
-    expect(row.getAttribute("data-kind")).toBe("auditCleared");
+    expect(row.dataset["kind"]).toBe("auditCleared");
     expect(row.textContent).toContain("audit.kind.auditCleared");
   });
 
@@ -611,7 +611,7 @@ describe("AuditLogSection", () => {
     );
 
     const row = await screen.findByRole("listitem");
-    expect(row.getAttribute("data-kind")).toBe("preferencesSecurityChanged");
+    expect(row.dataset["kind"]).toBe("preferencesSecurityChanged");
     expect(row.textContent).toContain("audit.kind.preferencesSecurityChanged");
     // i18n mock echoes keys; the row must render the per-setting label key
     // so each allowlisted leaf gets a human-readable name in production.

--- a/src/hooks/use-entry-mutations.ts
+++ b/src/hooks/use-entry-mutations.ts
@@ -47,6 +47,13 @@ export function useEntryMutations(dbId: string | null) {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.groups.entryCounts(dbId),
       });
+      // Password-health findings (expired/weak/reused) are derived
+      // from entry state — any create/update/move/delete can flip an
+      // entry between healthy and unhealthy, so the sidebar badge and
+      // Security view must refetch instead of holding the prior report.
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.passwordHealth.report(dbId),
+      });
     }
   };
 

--- a/src/hooks/use-group-mutations.ts
+++ b/src/hooks/use-group-mutations.ts
@@ -59,6 +59,13 @@ export function useGroupMutations(dbId: string | null) {
           query.queryKey[0] === queryKeys.entries.all[0] &&
           query.queryKey[1] === dbId,
       });
+      // Moving a subtree into or out of the Recycle Bin changes which
+      // entries the password-health scope filter includes; deleting a
+      // group also tombstones its entries. Invalidate the report so
+      // the next read pulls a fresh analysis instead of stale findings.
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.passwordHealth.report(dbId),
+      });
     }
   };
 

--- a/src/hooks/use-password-health.ts
+++ b/src/hooks/use-password-health.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  findingsForEntry,
+  summarize,
+  type PasswordHealthSummary,
+} from "@/lib/password-health";
+import { queryKeys } from "@/lib/query-keys";
+import { passwordHealth } from "@/lib/tauri";
+import type { Finding, PasswordHealthReport } from "@/lib/types";
+
+/// React Query wrapper around `passwordHealth.getReport`. The backend
+/// caches on `(dbId, generation)`, so this query's cache is mostly a
+/// freshness mirror — the backend is the source of truth. Per-Entry
+/// progressive events will piggyback on this query's cache via
+/// `queryClient.setQueryData` in a follow-up cycle; the wire shape and
+/// React Query key are deliberately stable so that wiring is additive.
+export function usePasswordHealthReport(dbId: string | null | undefined) {
+  return useQuery<PasswordHealthReport>({
+    queryKey: dbId
+      ? queryKeys.passwordHealth.report(dbId)
+      : ["password-health", "idle"],
+    queryFn: () => passwordHealth.getReport(dbId as string),
+    enabled: Boolean(dbId),
+  });
+}
+
+/// Pure-selector hook reading the report-as-cached and deriving the
+/// sidebar badge inputs. Returning an idle summary when the report
+/// isn't loaded yet keeps the sidebar render path simple — the badge
+/// hides on `totalUnhealthy === 0`, which also matches the idle case.
+export function usePasswordHealthSummary(
+  dbId: string | null | undefined
+): PasswordHealthSummary {
+  const { data } = usePasswordHealthReport(dbId);
+  return summarize(data);
+}
+
+/// Returns the Findings scoped to a single Entry. The `EntryListItem`
+/// reads this to decide whether to render the warning icon and which
+/// severity colour to use. Returns an empty array when the report
+/// isn't loaded yet so the list renders icon-less rather than blocking.
+export function useEntryFindings(
+  dbId: string | null | undefined,
+  entryId: string
+): Finding[] {
+  const { data } = usePasswordHealthReport(dbId);
+  return findingsForEntry(data, entryId);
+}

--- a/src/lib/__tests__/password-health.test.ts
+++ b/src/lib/__tests__/password-health.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "vitest";
+
+import type { PasswordHealthReport } from "@/lib/types";
+import { findingsForEntry, severityOf, summarize } from "@/lib/password-health";
+
+const emptyReport: PasswordHealthReport = {
+  score: null,
+  findings: [],
+  totals: { critical: 0, high: 0, healthy: 0, total: 0 },
+  reuseGroups: [],
+};
+
+const noFindingsReport: PasswordHealthReport = {
+  score: 100,
+  findings: [],
+  totals: { critical: 0, high: 0, healthy: 4, total: 4 },
+  reuseGroups: [],
+};
+
+const allHighReport: PasswordHealthReport = {
+  score: 0,
+  findings: [
+    { entryId: "a", kind: "password.expired" },
+    { entryId: "b", kind: "password.expired" },
+    { entryId: "c", kind: "password.expired" },
+  ],
+  totals: { critical: 0, high: 3, healthy: 0, total: 3 },
+  reuseGroups: [],
+};
+
+describe("summarize", () => {
+  it("returns zero unhealthy and null severity for an empty report", () => {
+    expect(summarize(emptyReport)).toEqual({
+      totalUnhealthy: 0,
+      highestSeverity: null,
+    });
+  });
+
+  it("returns zero unhealthy and null severity when there are no findings", () => {
+    expect(summarize(noFindingsReport)).toEqual({
+      totalUnhealthy: 0,
+      highestSeverity: null,
+    });
+  });
+
+  it("returns the un-healthy Entry count and highest severity when every Finding is High", () => {
+    expect(summarize(allHighReport)).toEqual({
+      totalUnhealthy: 3,
+      highestSeverity: "high",
+    });
+  });
+
+  // The sidebar passes `report` straight from React Query; a not-yet-
+  // loaded report is `null` / `undefined`. The sidebar reads
+  // `totalUnhealthy === 0` to hide the badge, so this code path has
+  // to behave like an empty report rather than throwing.
+  it("handles a null/undefined report as zero-unhealthy", () => {
+    expect(summarize(null)).toEqual({
+      totalUnhealthy: 0,
+      highestSeverity: null,
+    });
+    expect(summarize(undefined)).toEqual({
+      totalUnhealthy: 0,
+      highestSeverity: null,
+    });
+  });
+});
+
+describe("severityOf", () => {
+  it("maps password.expired to high", () => {
+    expect(severityOf("password.expired")).toBe("high");
+  });
+});
+
+describe("findingsForEntry", () => {
+  it("returns only findings scoped to the given entry id", () => {
+    expect(findingsForEntry(allHighReport, "b")).toEqual([
+      { entryId: "b", kind: "password.expired" },
+    ]);
+  });
+
+  it("returns an empty array when the report is null or empty", () => {
+    expect(findingsForEntry(null, "a")).toEqual([]);
+    expect(findingsForEntry(emptyReport, "a")).toEqual([]);
+  });
+});

--- a/src/lib/password-health.ts
+++ b/src/lib/password-health.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+
+//! Frontend-side selectors and helpers for the Password Health report.
+//!
+//! The IPC wrapper itself lives in `lib/tauri.ts`; this module owns the
+//! pure derivations (highest-severity per Entry, sidebar summary) that
+//! the route view and sidebar badge read.
+
+import type { Finding, FindingKind, PasswordHealthReport } from "./types";
+
+/// Severity bucket a Finding Kind belongs to. Mirrors the backend's
+/// `analyzer::Severity`: `very_weak` is Critical, every other Finding
+/// Kind (`weak`, `reused`, `expired`) is High. Healthy Entries have no
+/// Findings and therefore no severity.
+export type Severity = "critical" | "high";
+
+export function severityOf(kind: FindingKind): Severity {
+  // Exhaustiveness lives at the union boundary — adding a new Finding
+  // Kind in `types.ts` forces an update here.
+  switch (kind) {
+    case "password.expired":
+      return "high";
+  }
+}
+
+/// Summary the sidebar Security item renders next to its label. The
+/// badge shows the un-healthy Entry count (not the Finding count — an
+/// Entry with two Findings counts once) and the colour is picked from
+/// `highestSeverity`. `highestSeverity` is `null` when there are no
+/// Findings; the sidebar hides the badge entirely in that case.
+export interface PasswordHealthSummary {
+  totalUnhealthy: number;
+  highestSeverity: Severity | null;
+}
+
+export function summarize(
+  report: PasswordHealthReport | null | undefined
+): PasswordHealthSummary {
+  if (!report) {
+    return { totalUnhealthy: 0, highestSeverity: null };
+  }
+
+  // Bucket each Entry by its highest-severity Finding so the badge
+  // count agrees with the report-view totals strip (which also
+  // counts distinct Entries, not Findings).
+  const seen = new Map<string, Severity>();
+  for (const finding of report.findings) {
+    const severity = severityOf(finding.kind);
+    const prior = seen.get(finding.entryId);
+    if (prior === "critical") continue;
+    if (severity === "critical" || prior === undefined) {
+      seen.set(finding.entryId, severity);
+    }
+  }
+
+  let highest: Severity | null = null;
+  for (const severity of seen.values()) {
+    if (severity === "critical") {
+      highest = "critical";
+      break;
+    }
+    highest = "high";
+  }
+
+  return {
+    totalUnhealthy: seen.size,
+    highestSeverity: highest,
+  };
+}
+
+/// Returns every Finding scoped to a given Entry id, in the order the
+/// report emitted them. The list is filtered, not mapped — callers
+/// rely on the raw `Finding` shape for severity-and-kind UI.
+export function findingsForEntry(
+  report: PasswordHealthReport | null | undefined,
+  entryId: string
+): Finding[] {
+  if (!report) return [];
+  return report.findings.filter((f) => f.entryId === entryId);
+}

--- a/src/lib/password-health.ts
+++ b/src/lib/password-health.ts
@@ -15,12 +15,11 @@ import type { Finding, FindingKind, PasswordHealthReport } from "./types";
 export type Severity = "critical" | "high";
 
 export function severityOf(kind: FindingKind): Severity {
+  if (kind === "password.expired") return "high";
   // Exhaustiveness lives at the union boundary — adding a new Finding
-  // Kind in `types.ts` forces an update here.
-  switch (kind) {
-    case "password.expired":
-      return "high";
-  }
+  // Kind in `types.ts` makes this `never` cast fail to compile.
+  const exhaustive: never = kind;
+  return exhaustive;
 }
 
 /// Summary the sidebar Security item renders next to its label. The

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -33,6 +33,11 @@ export const queryKeys = {
       [...queryKeys.audit.all, vaultPath, "list"] as const,
     status: () => [...queryKeys.audit.all, "status"] as const,
   },
+  passwordHealth: {
+    all: ["password-health"] as const,
+    report: (dbId: string) =>
+      [...queryKeys.passwordHealth.all, dbId, "report"] as const,
+  },
   groups: {
     all: ["groups"] as const,
     list: (dbId: string, parentId?: string | null) =>

--- a/src/lib/require-unlocked-tab.ts
+++ b/src/lib/require-unlocked-tab.ts
@@ -1,0 +1,35 @@
+import { redirect } from "@tanstack/react-router";
+
+import { useDatabaseTabs } from "@/stores/database-tabs";
+
+/**
+ * Shared `beforeLoad` guard for routes parameterised by `$dbId`.
+ *
+ * Looks up the tab in the active-tab store, redirects to `/` when the
+ * id is unknown, redirects to `/unlock` when the tab is `unlocking` or
+ * `locked`, and otherwise marks the tab active and returns its id so
+ * the route can stash it in the route context.
+ *
+ * Throws via `redirect(...)` rather than returning; matches how
+ * TanStack Router expects `beforeLoad` to bail out.
+ */
+export function requireUnlockedTab(dbId: string): { tabId: string } {
+  const state = useDatabaseTabs.getState();
+  const tab = state.tabs.find(
+    (item) => item.dbId === dbId || item.path === dbId
+  );
+
+  if (!tab) {
+    throw redirect({ to: "/" });
+  }
+
+  if (tab.state === "unlocking" || tab.state === "locked") {
+    throw redirect({
+      to: "/unlock",
+      search: tab.path ? { path: tab.path } : {},
+    });
+  }
+
+  state.setActiveTab(tab.id);
+  return { tabId: tab.id };
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -706,7 +706,7 @@ export const windowProtection = {
  */
 export const passwordHealth = {
   async getReport(dbId: string): Promise<PasswordHealthReport> {
-    KeepassIdSchema.parse(dbId);
+    DbIdSchema.parse({ dbId });
     const result = await invoke("get_password_health_report", { dbId });
     return PasswordHealthReportSchema.parse(result);
   },

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -23,6 +23,7 @@ import type {
   Group,
   PassphraseGeneratorOptions,
   PasswordGeneratorOptions,
+  PasswordHealthReport,
   RecentDatabase,
   UpdateEntryData,
 } from "./types";
@@ -46,6 +47,7 @@ import {
   GroupSchema,
   PassphraseGeneratorOptionsSchema,
   PasswordGeneratorOptionsSchema,
+  PasswordHealthReportSchema,
   RecentDatabaseSchema,
   UpdateEntryDataSchema,
 } from "./types";
@@ -692,5 +694,20 @@ export const windowProtection = {
   async isSupported(): Promise<boolean> {
     const result = await invoke("get_window_content_protection_supported");
     return z.boolean().parse(result);
+  },
+};
+
+/**
+ * Per-Vault Password Health report. The backend `get_password_health_report`
+ * command caches on `(dbId, generation)`, so repeat calls against an
+ * unchanged Vault are free. Findings stream progressively via Tauri
+ * events in a follow-up slice; the report this returns today is the
+ * full snapshot.
+ */
+export const passwordHealth = {
+  async getReport(dbId: string): Promise<PasswordHealthReport> {
+    KeepassIdSchema.parse(dbId);
+    const result = await invoke("get_password_health_report", { dbId });
+    return PasswordHealthReportSchema.parse(result);
   },
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -410,6 +410,44 @@ export const AuditStatusSchema = z.object({
 });
 export type AuditStatus = z.infer<typeof AuditStatusSchema>;
 
+/// Namespaced enum of Password Health findings. Wire shape mirrors the
+/// backend `FindingKindDto` — additions land here when new check kinds
+/// ship in follow-up slices.
+export const FindingKindSchema = z.enum(["password.expired"]);
+export type FindingKind = z.infer<typeof FindingKindSchema>;
+
+export const FindingSchema = z.object({
+  entryId: z.string().min(1),
+  kind: FindingKindSchema,
+});
+export type Finding = z.infer<typeof FindingSchema>;
+
+export const HealthTotalsSchema = z.object({
+  critical: z.number().int().nonnegative(),
+  high: z.number().int().nonnegative(),
+  healthy: z.number().int().nonnegative(),
+  total: z.number().int().nonnegative(),
+});
+export type HealthTotals = z.infer<typeof HealthTotalsSchema>;
+
+export const ReuseGroupSchema = z.object({
+  passwordHash: z.string().min(1),
+  entryIds: z.array(z.string().min(1)),
+});
+export type ReuseGroup = z.infer<typeof ReuseGroupSchema>;
+
+/// Per-Vault Password Health snapshot. `score` is `null` on an empty
+/// Vault (no in-scope Entries) and a `0..=100` integer otherwise.
+/// `reuseGroups` is on the wire from day one but is empty in the
+/// expired-only tracer slice.
+export const PasswordHealthReportSchema = z.object({
+  score: z.number().int().min(0).max(100).nullable(),
+  findings: z.array(FindingSchema),
+  totals: HealthTotalsSchema,
+  reuseGroups: z.array(ReuseGroupSchema),
+});
+export type PasswordHealthReport = z.infer<typeof PasswordHealthReportSchema>;
+
 export const EntrySortFieldSchema = z.enum([
   "title",
   "username",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -651,7 +651,9 @@
       "highDescription": "Einträge mit mindestens einem schwerwiegenden Problem."
     },
     "findings": {
-      "password.expired": "Abgelaufen"
+      "password": {
+        "expired": "Abgelaufen"
+      }
     },
     "actions": {
       "openEntry": "Eintrag öffnen"

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -632,5 +632,32 @@
       "activeTooltip": "Bildschirmaufnahmeschutz ist aktiv",
       "notSupportedTooltip": "Bildschirmaufnahmeschutz ist aktiviert, wird auf dieser Plattform aber nicht unterstützt"
     }
+  },
+  "passwordHealth": {
+    "title": "Sicherheit",
+    "subtitle": "Passwortzustand für diesen Tresor",
+    "scoreLabel": "Bewertung",
+    "noScore": "—",
+    "emptyState": "Keine Passwörter zu analysieren.",
+    "loading": "Passwörter werden analysiert…",
+    "totals": {
+      "critical": "Kritisch",
+      "high": "Hoch",
+      "healthy": "Gesund",
+      "total": "Gesamt"
+    },
+    "sections": {
+      "high": "Hoch",
+      "highDescription": "Einträge mit mindestens einem schwerwiegenden Problem."
+    },
+    "findings": {
+      "password.expired": "Abgelaufen"
+    },
+    "actions": {
+      "openEntry": "Eintrag öffnen"
+    },
+    "icons": {
+      "warning": "Hat Sicherheitsprobleme"
+    }
   }
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -676,7 +676,9 @@
       "highDescription": "Entries with at least one high-severity issue."
     },
     "findings": {
-      "password.expired": "Expired"
+      "password": {
+        "expired": "Expired"
+      }
     },
     "actions": {
       "openEntry": "Open Entry"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -657,5 +657,32 @@
       "activeTooltip": "Screen capture prevention is active",
       "notSupportedTooltip": "Screen capture prevention is enabled but not supported on this platform"
     }
+  },
+  "passwordHealth": {
+    "title": "Security",
+    "subtitle": "Password health for this vault",
+    "scoreLabel": "Score",
+    "noScore": "—",
+    "emptyState": "No passwords to analyze.",
+    "loading": "Analyzing passwords…",
+    "totals": {
+      "critical": "Critical",
+      "high": "High",
+      "healthy": "Healthy",
+      "total": "Total"
+    },
+    "sections": {
+      "high": "High",
+      "highDescription": "Entries with at least one high-severity issue."
+    },
+    "findings": {
+      "password.expired": "Expired"
+    },
+    "actions": {
+      "openEntry": "Open Entry"
+    },
+    "icons": {
+      "warning": "Has security issues"
+    }
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -632,5 +632,32 @@
       "activeTooltip": "La protección contra capturas de pantalla está activa",
       "notSupportedTooltip": "La protección contra capturas está activada pero no es compatible con esta plataforma"
     }
+  },
+  "passwordHealth": {
+    "title": "Seguridad",
+    "subtitle": "Salud de contraseñas de esta bóveda",
+    "scoreLabel": "Puntuación",
+    "noScore": "—",
+    "emptyState": "No hay contraseñas para analizar.",
+    "loading": "Analizando contraseñas…",
+    "totals": {
+      "critical": "Crítico",
+      "high": "Alto",
+      "healthy": "Saludable",
+      "total": "Total"
+    },
+    "sections": {
+      "high": "Alto",
+      "highDescription": "Entradas con al menos un problema de gravedad alta."
+    },
+    "findings": {
+      "password.expired": "Caducada"
+    },
+    "actions": {
+      "openEntry": "Abrir entrada"
+    },
+    "icons": {
+      "warning": "Tiene problemas de seguridad"
+    }
   }
 }

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -651,7 +651,9 @@
       "highDescription": "Entradas con al menos un problema de gravedad alta."
     },
     "findings": {
-      "password.expired": "Caducada"
+      "password": {
+        "expired": "Caducada"
+      }
     },
     "actions": {
       "openEntry": "Abrir entrada"

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -632,5 +632,32 @@
       "activeTooltip": "La prévention des captures d'écran est active",
       "notSupportedTooltip": "La prévention des captures d'écran est activée mais n'est pas prise en charge sur cette plateforme"
     }
+  },
+  "passwordHealth": {
+    "title": "Sécurité",
+    "subtitle": "Santé des mots de passe de ce coffre",
+    "scoreLabel": "Score",
+    "noScore": "—",
+    "emptyState": "Aucun mot de passe à analyser.",
+    "loading": "Analyse des mots de passe…",
+    "totals": {
+      "critical": "Critique",
+      "high": "Élevé",
+      "healthy": "Sain",
+      "total": "Total"
+    },
+    "sections": {
+      "high": "Élevé",
+      "highDescription": "Entrées présentant au moins un problème de gravité élevée."
+    },
+    "findings": {
+      "password.expired": "Expiré"
+    },
+    "actions": {
+      "openEntry": "Ouvrir l'entrée"
+    },
+    "icons": {
+      "warning": "Présente des problèmes de sécurité"
+    }
   }
 }

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -651,7 +651,9 @@
       "highDescription": "Entrées présentant au moins un problème de gravité élevée."
     },
     "findings": {
-      "password.expired": "Expiré"
+      "password": {
+        "expired": "Expiré"
+      }
     },
     "actions": {
       "openEntry": "Ouvrir l'entrée"

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -651,7 +651,9 @@
       "highDescription": "Unosi sa najmanje jednim problemom visokog prioriteta."
     },
     "findings": {
-      "password.expired": "Isteklo"
+      "password": {
+        "expired": "Isteklo"
+      }
     },
     "actions": {
       "openEntry": "Otvori unos"

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -632,5 +632,32 @@
       "activeTooltip": "Zaštita od snimanja ekrana je aktivna",
       "notSupportedTooltip": "Zaštita od snimanja ekrana je uključena, ali nije podržana na ovoj platformi"
     }
+  },
+  "passwordHealth": {
+    "title": "Bezbednost",
+    "subtitle": "Zdravlje lozinki za ovaj sef",
+    "scoreLabel": "Ocena",
+    "noScore": "—",
+    "emptyState": "Nema lozinki za analizu.",
+    "loading": "Analiza lozinki…",
+    "totals": {
+      "critical": "Kritično",
+      "high": "Visoko",
+      "healthy": "Zdravo",
+      "total": "Ukupno"
+    },
+    "sections": {
+      "high": "Visoko",
+      "highDescription": "Unosi sa najmanje jednim problemom visokog prioriteta."
+    },
+    "findings": {
+      "password.expired": "Isteklo"
+    },
+    "actions": {
+      "openEntry": "Otvori unos"
+    },
+    "icons": {
+      "warning": "Ima bezbednosne probleme"
+    }
   }
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as authUnlockRouteImport } from './routes/(auth)/unlock'
 import { Route as authNewRouteImport } from './routes/(auth)/new'
 import { Route as authImportFileRouteImport } from './routes/(auth)/import-file'
 import { Route as DashboardIndexDbIdRouteImport } from './routes/dashboard/index.$dbId'
+import { Route as DashboardSecurityDbIdRouteImport } from './routes/dashboard/security.$dbId'
 import { Route as DashboardEntryNewRouteImport } from './routes/dashboard/entry/new'
 import { Route as DashboardEntryEditRouteImport } from './routes/dashboard/entry/edit'
 import { Route as DashboardEntryIdRouteImport } from './routes/dashboard/entry/$id'
@@ -66,6 +67,11 @@ const DashboardIndexDbIdRoute = DashboardIndexDbIdRouteImport.update({
   path: '/index/$dbId',
   getParentRoute: () => DashboardRouteRoute,
 } as any)
+const DashboardSecurityDbIdRoute = DashboardSecurityDbIdRouteImport.update({
+  id: '/security/$dbId',
+  path: '/security/$dbId',
+  getParentRoute: () => DashboardRouteRoute,
+} as any)
 const DashboardEntryNewRoute = DashboardEntryNewRouteImport.update({
   id: '/entry/new',
   path: '/entry/new',
@@ -93,6 +99,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/entry/$id': typeof DashboardEntryIdRoute
   '/dashboard/entry/edit': typeof DashboardEntryEditRoute
   '/dashboard/entry/new': typeof DashboardEntryNewRoute
+  '/dashboard/security/$dbId': typeof DashboardSecurityDbIdRoute
   '/dashboard/index/$dbId': typeof DashboardIndexDbIdRoute
 }
 export interface FileRoutesByTo {
@@ -105,6 +112,7 @@ export interface FileRoutesByTo {
   '/dashboard/entry/$id': typeof DashboardEntryIdRoute
   '/dashboard/entry/edit': typeof DashboardEntryEditRoute
   '/dashboard/entry/new': typeof DashboardEntryNewRoute
+  '/dashboard/security/$dbId': typeof DashboardSecurityDbIdRoute
   '/dashboard/index/$dbId': typeof DashboardIndexDbIdRoute
 }
 export interface FileRoutesById {
@@ -120,6 +128,7 @@ export interface FileRoutesById {
   '/dashboard/entry/$id': typeof DashboardEntryIdRoute
   '/dashboard/entry/edit': typeof DashboardEntryEditRoute
   '/dashboard/entry/new': typeof DashboardEntryNewRoute
+  '/dashboard/security/$dbId': typeof DashboardSecurityDbIdRoute
   '/dashboard/index/$dbId': typeof DashboardIndexDbIdRoute
 }
 export interface FileRouteTypes {
@@ -135,6 +144,7 @@ export interface FileRouteTypes {
     | '/dashboard/entry/$id'
     | '/dashboard/entry/edit'
     | '/dashboard/entry/new'
+    | '/dashboard/security/$dbId'
     | '/dashboard/index/$dbId'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -147,6 +157,7 @@ export interface FileRouteTypes {
     | '/dashboard/entry/$id'
     | '/dashboard/entry/edit'
     | '/dashboard/entry/new'
+    | '/dashboard/security/$dbId'
     | '/dashboard/index/$dbId'
   id:
     | '__root__'
@@ -161,6 +172,7 @@ export interface FileRouteTypes {
     | '/dashboard/entry/$id'
     | '/dashboard/entry/edit'
     | '/dashboard/entry/new'
+    | '/dashboard/security/$dbId'
     | '/dashboard/index/$dbId'
   fileRoutesById: FileRoutesById
 }
@@ -235,6 +247,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DashboardIndexDbIdRouteImport
       parentRoute: typeof DashboardRouteRoute
     }
+    '/dashboard/security/$dbId': {
+      id: '/dashboard/security/$dbId'
+      path: '/security/$dbId'
+      fullPath: '/dashboard/security/$dbId'
+      preLoaderRoute: typeof DashboardSecurityDbIdRouteImport
+      parentRoute: typeof DashboardRouteRoute
+    }
     '/dashboard/entry/new': {
       id: '/dashboard/entry/new'
       path: '/entry/new'
@@ -282,6 +301,7 @@ interface DashboardRouteRouteChildren {
   DashboardEntryIdRoute: typeof DashboardEntryIdRoute
   DashboardEntryEditRoute: typeof DashboardEntryEditRoute
   DashboardEntryNewRoute: typeof DashboardEntryNewRoute
+  DashboardSecurityDbIdRoute: typeof DashboardSecurityDbIdRoute
   DashboardIndexDbIdRoute: typeof DashboardIndexDbIdRoute
 }
 
@@ -290,6 +310,7 @@ const DashboardRouteRouteChildren: DashboardRouteRouteChildren = {
   DashboardEntryIdRoute: DashboardEntryIdRoute,
   DashboardEntryEditRoute: DashboardEntryEditRoute,
   DashboardEntryNewRoute: DashboardEntryNewRoute,
+  DashboardSecurityDbIdRoute: DashboardSecurityDbIdRoute,
   DashboardIndexDbIdRoute: DashboardIndexDbIdRoute,
 }
 

--- a/src/routes/dashboard/index.$dbId.tsx
+++ b/src/routes/dashboard/index.$dbId.tsx
@@ -1,9 +1,9 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { useIsMobile } from "@/hooks/use-mobile";
 import MobileContentArea from "@/views/MobileContentArea.tsx";
 import DesktopContentArea from "@/views/DesktopContentArea.tsx";
 import { database, KeepassIdSchema } from "@/lib/tauri";
-import { useDatabaseTabs } from "@/stores/database-tabs";
+import { requireUnlockedTab } from "@/lib/require-unlocked-tab";
 import { z } from "zod/v4";
 import { EntrySortFieldSchema, SortOrderSchema } from "@/lib/types";
 
@@ -15,27 +15,7 @@ const DashboardSearchSchema = z.object({
 });
 
 export const Route = createFileRoute("/dashboard/index/$dbId")({
-  beforeLoad: ({ params }) => {
-    const state = useDatabaseTabs.getState();
-    const tab = state.tabs.find(
-      (item) => item.dbId === params.dbId || item.path === params.dbId
-    );
-
-    if (!tab) {
-      throw redirect({ to: "/" });
-    }
-
-    if (tab.state === "unlocking" || tab.state === "locked") {
-      throw redirect({
-        to: "/unlock",
-        search: tab.path ? { path: tab.path } : {},
-      });
-    }
-
-    state.setActiveTab(tab.id);
-
-    return { tabId: tab.id };
-  },
+  beforeLoad: ({ params }) => requireUnlockedTab(params.dbId),
   loaderDeps: ({ search }) => ({ groupId: search.groupId ?? null }),
   loader: async ({ params }) => {
     const info = await database.getInfo(params.dbId);

--- a/src/routes/dashboard/security.$dbId.tsx
+++ b/src/routes/dashboard/security.$dbId.tsx
@@ -1,29 +1,10 @@
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 
 import { PasswordHealthReportView } from "@/components/security/PasswordHealthReportView";
-import { useDatabaseTabs } from "@/stores/database-tabs";
+import { requireUnlockedTab } from "@/lib/require-unlocked-tab";
 
 export const Route = createFileRoute("/dashboard/security/$dbId")({
-  beforeLoad: ({ params }) => {
-    const state = useDatabaseTabs.getState();
-    const tab = state.tabs.find(
-      (item) => item.dbId === params.dbId || item.path === params.dbId
-    );
-
-    if (!tab) {
-      throw redirect({ to: "/" });
-    }
-
-    if (tab.state === "unlocking" || tab.state === "locked") {
-      throw redirect({
-        to: "/unlock",
-        search: tab.path ? { path: tab.path } : {},
-      });
-    }
-
-    state.setActiveTab(tab.id);
-    return { tabId: tab.id };
-  },
+  beforeLoad: ({ params }) => requireUnlockedTab(params.dbId),
   component: SecurityRoutePage,
 });
 

--- a/src/routes/dashboard/security.$dbId.tsx
+++ b/src/routes/dashboard/security.$dbId.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+import { PasswordHealthReportView } from "@/components/security/PasswordHealthReportView";
+import { useDatabaseTabs } from "@/stores/database-tabs";
+
+export const Route = createFileRoute("/dashboard/security/$dbId")({
+  beforeLoad: ({ params }) => {
+    const state = useDatabaseTabs.getState();
+    const tab = state.tabs.find(
+      (item) => item.dbId === params.dbId || item.path === params.dbId
+    );
+
+    if (!tab) {
+      throw redirect({ to: "/" });
+    }
+
+    if (tab.state === "unlocking" || tab.state === "locked") {
+      throw redirect({
+        to: "/unlock",
+        search: tab.path ? { path: tab.path } : {},
+      });
+    }
+
+    state.setActiveTab(tab.id);
+    return { tabId: tab.id };
+  },
+  component: SecurityRoutePage,
+});
+
+function SecurityRoutePage() {
+  const { dbId } = Route.useParams();
+  return <PasswordHealthReportView dbId={dbId} />;
+}


### PR DESCRIPTION
## Summary

Tracer-bullet slice for #241 — Password Health, expired-only. Wires the full pipe across every layer: pure analyzer → service-layer scope filter → `(db_id, generation)` cache → Tauri command → React Query hook → sidebar badge / entry-list amber icon / `/dashboard/security/$dbId` route. Translations in en/de/es/fr/sr.

Async progressive events (`password-health://entry-scored` / `complete`), per-`db_id` cancellation, eager-on-unlock debounce, and `cancel_password_health_analysis` are deliberately deferred — tracked in #246. The synchronous command satisfies every user-visible acceptance criterion in this slice; the deferred items are the don't-freeze-large-Vaults optimisation.

## What's in this PR

**Backend (Rust)**

- `services::password_health::analyzer` — pure function `analyze(entries, now) -> PasswordHealthReport { score, findings, totals }`. Score is `round(100 × healthy / total_in_scope)`, `None` on an empty Vault. `FindingKind::PasswordExpired` is the only emitted kind in this slice. `HealthTotals` bucket each Entry by highest severity so `critical + high + healthy == total`. Clock is injected.
- `services::password_health::service::collect_entry_inputs(&Database)` — scope filter: drops Recycle Bin descendants and Entries with `password: None`; keeps empty-string passwords.
- `services::password_health::service::PasswordHealthService` — coordinator with `(db_id, generation)`-keyed cache and `on_lock` eviction hook.
- `services::password_health::cache::CacheStore` — standalone `(db_id, generation)`-keyed map, unit-tested in isolation.
- `OpenDatabase.generation: u64` — monotonic per-unlock counter bumped inside `VaultMut::mark_modified()`, exposed via `Vault::generation()` / `VaultMut::generation()`.
- `dto::password_health` — `PasswordHealthReportDto`, `FindingDto`, `FindingKindDto`, `HealthTotalsDto`, `ReuseGroupDto`. Wire shape is camelCase; `FindingKindDto::PasswordExpired` serialises as the namespaced string `"password.expired"`; `reuseGroups` is on the wire empty from day one so slice 2 is wire-additive.
- `commands::password_health::get_password_health_report` Tauri command. `lock_database` evicts the cache on a successful lock transition.

**Frontend (TypeScript / React)**

- `lib/types.ts` — types + Zod schemas mirroring the backend wire shape.
- `lib/password-health.ts` — pure `summarize(report)`, `findingsForEntry(report, id)`, `severityOf(kind)`. Seven tests pin: empty / no-findings / all-High / null/undefined / severity mapping / find-by-id.
- `lib/tauri.ts` + `lib/query-keys.ts` — `passwordHealth.getReport(dbId)`, query key `["password-health", dbId, "report"]`.
- `hooks/use-password-health.ts` — `usePasswordHealthReport`, `usePasswordHealthSummary`, `useEntryFindings`. Selector hooks compose over the React Query cache.
- `components/entries/EntryListItem.tsx` — replaces the unconditional placeholder with an optional `findings` prop. Renders amber `TriangleAlert` only when an Entry has at least one Finding, with tooltip + `aria-label`.
- `components/layout/app-sidebar.tsx` — Security item flipped from `disabled: true` to navigation + coloured count badge (hidden at zero).
- `components/security/PasswordHealthReportView.tsx` — score panel (em-dash on empty Vault), four-cell totals strip, High section listing un-healthy Entries with Open Entry button per row.
- `routes/dashboard/security.$dbId.tsx` — new route with the same beforeLoad-redirects-on-lock shape as the dashboard index.
- `locales/{en,de,es,fr,sr}/common.json` — `passwordHealth.*` keys.

## Tests

- 296 Rust tests pass (+12 new tests across analyzer / cache / service / dto / vault generation).
- 415 frontend tests pass (+7 new selector tests).
- Clippy clean, TypeScript clean, ESLint clean.

## Acceptance criteria — status

- [x] `analyzer::analyze` is a pure function `(impl IntoIterator<Item = EntryInput>) -> PasswordHealthReport`; no Tauri, no KDBX, no I/O imports.
- [x] Empty Vault → `score: None`. All-healthy → `score: 100`. Single expired in a 4-Entry Vault → `score: 75` and exactly one `password.expired` finding.
- [x] Recycle Bin Entries and `password: None` Entries are excluded from analyzer input.
- [x] `Vault::mark_modified()` bumps the generation counter; next `get_password_health_report` returns a fresh report.
- [x] Locking a Vault drops its cache entry. (Aborting in-flight tasks: deferred — see #246.)
- [ ] Unlocking schedules new analysis automatically after ~1s. (Deferred — see #246. Today React Query auto-fetches on mount.)
- [ ] `password-health://entry-scored` events stream per Entry. (Deferred — see #246.)
- [x] `EntryListItem` renders no icon when zero findings; amber `TriangleAlert` with tooltip + `aria-label` when at least one finding.
- [x] Sidebar Security item navigates to `/dashboard/security/$dbId`; count badge for un-healthy Entries; hidden when zero.
- [x] `/dashboard/security/$dbId` renders score, totals breakdown, High section with Open Entry buttons. Empty-Vault shows `—` and "No passwords to analyze."
- [x] Open Entry navigates to `/dashboard/entry/$id`; back returns to the report.
- [x] No new Audit Event Kind; no report data persisted to disk.
- [x] Translations exist for all surfaces in en/de/es/fr/sr.
- [x] Analyzer unit tests cover empty, all-healthy, single Expired, score rounding.
- [x] Service-layer integration test: in-memory Vault, scope filter assertion + cache-bust after `mark_modified`.
- [x] Pure-selector tests for `usePasswordHealthSummary` covering empty / no-findings / all-High.
- [ ] Render-doesn't-crash smoke test for `usePasswordHealthReport`. (Deferred — selector tests cover the data path; the hook is a 4-line React Query wrapper.)

## Test plan

- [x] Open a Vault with at least one expired entry.
- [x] Sidebar Security item is enabled; badge shows the un-healthy count in amber.
- [x] Entry-list rows for expired entries show the amber `TriangleAlert`; hover tooltip reads "Has security issues".
- [x] Clicking Security opens `/dashboard/security/$dbId`; score, four-cell totals, High section all render; `critical + high + healthy === total`.
- [x] Open Entry navigates to `/dashboard/entry/$id`; browser back returns.
- [ ] Edit an expired entry to no longer expire and save; on next Security visit the count drops and the row disappears from the High section.
- [ ] Lock + unlock the Vault: report still works, no stale data.
- [ ] Switch locale to de/es/fr/sr: Security view and tooltip are translated.

## Follow-ups

- #246 — async coordinator (debounce, progressive events, cancellation, on_unlock auto-schedule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)