### PR TITLE
refactor(core): dedup KDBX open paths via install_open_database helper

### DIFF
--- a/src-tauri/src/services/kdbx/open.rs
+++ b/src-tauri/src/services/kdbx/open.rs
@@ -11,10 +11,55 @@ use keepass::error::{
     Kdbx4OuterHeaderError, KdfConfigError, OuterCipherConfigError,
 };
 use keepass::{Database, DatabaseKey};
+use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
 use super::KdbxService;
+
+/// Installs a freshly-decrypted `Database` into the open-databases map
+/// and returns the `DatabaseInfo` snapshot the command layer surfaces.
+///
+/// All three `open*` entry points (`open`, `open_with_keyfile`,
+/// `open_with_keyfile_only`) share this tail — only the credential
+/// payload differs. Folding it here eliminates the structurally
+/// identical `OpenDatabase { … }` literal that `SonarCloud` flagged
+/// as duplicated.
+fn install_open_database(
+    databases: &mut HashMap<String, OpenDatabase>,
+    db: Database,
+    normalized_path: String,
+    path: &str,
+    password: Option<SecureString>,
+    keyfile_path: Option<String>,
+) -> DatabaseInfo {
+    let root_group_id = db.root().id().uuid().to_string();
+    let name = db.root().name.clone();
+    let version = format_database_version(&db.config.version);
+
+    databases.insert(
+        normalized_path,
+        OpenDatabase {
+            db: Some(db),
+            path: path.to_string(),
+            is_modified: false,
+            password,
+            keyfile_path,
+            version: version.clone(),
+            name: name.clone(),
+            root_group_id: root_group_id.clone(),
+        },
+    );
+
+    DatabaseInfo {
+        name,
+        path: path.to_string(),
+        is_modified: false,
+        is_locked: false,
+        root_group_id,
+        version,
+    }
+}
 
 impl KdbxService {
     /// Opens a database with a password.
@@ -33,32 +78,14 @@ impl KdbxService {
         let key = DatabaseKey::new().with_password(password);
         let db = Database::open(&mut file, key).map_err(map_open_error)?;
 
-        let root_group_id = db.root().id().uuid().to_string();
-        let name = db.root().name.clone();
-        let version = format_database_version(&db.config.version);
-
-        databases.insert(
+        Ok(install_open_database(
+            &mut databases,
+            db,
             normalized_path,
-            OpenDatabase {
-                db: Some(db),
-                path: path.to_string(),
-                is_modified: false,
-                password: Some(SecureString::from(password)),
-                keyfile_path: None,
-                version: version.clone(),
-                name: name.clone(),
-                root_group_id: root_group_id.clone(),
-            },
-        );
-
-        Ok(DatabaseInfo {
-            name,
-            path: path.to_string(),
-            is_modified: false,
-            is_locked: false,
-            root_group_id,
-            version,
-        })
+            path,
+            Some(SecureString::from(password)),
+            None,
+        ))
     }
 
     /// Opens a database with a password and keyfile.
@@ -87,32 +114,14 @@ impl KdbxService {
 
         let db = Database::open(&mut file, key).map_err(map_open_error)?;
 
-        let root_group_id = db.root().id().uuid().to_string();
-        let name = db.root().name.clone();
-        let version = format_database_version(&db.config.version);
-
-        databases.insert(
+        Ok(install_open_database(
+            &mut databases,
+            db,
             normalized_path,
-            OpenDatabase {
-                db: Some(db),
-                path: path.to_string(),
-                is_modified: false,
-                password: Some(SecureString::from(password)),
-                keyfile_path: Some(keyfile_path.to_string()),
-                version: version.clone(),
-                name: name.clone(),
-                root_group_id: root_group_id.clone(),
-            },
-        );
-
-        Ok(DatabaseInfo {
-            name,
-            path: path.to_string(),
-            is_modified: false,
-            is_locked: false,
-            root_group_id,
-            version,
-        })
+            path,
+            Some(SecureString::from(password)),
+            Some(keyfile_path.to_string()),
+        ))
     }
 
     /// Opens a database using only a keyfile.
@@ -138,32 +147,14 @@ impl KdbxService {
 
         let db = Database::open(&mut file, key).map_err(map_open_error)?;
 
-        let root_group_id = db.root().id().uuid().to_string();
-        let name = db.root().name.clone();
-        let version = format_database_version(&db.config.version);
-
-        databases.insert(
+        Ok(install_open_database(
+            &mut databases,
+            db,
             normalized_path,
-            OpenDatabase {
-                db: Some(db),
-                path: path.to_string(),
-                is_modified: false,
-                password: None,
-                keyfile_path: Some(keyfile_path.to_string()),
-                version: version.clone(),
-                name: name.clone(),
-                root_group_id: root_group_id.clone(),
-            },
-        );
-
-        Ok(DatabaseInfo {
-            name,
-            path: path.to_string(),
-            is_modified: false,
-            is_locked: false,
-            root_group_id,
-            version,
-        })
+            path,
+            None,
+            Some(keyfile_path.to_string()),
+        ))
     }
 
     /// Closes a specific database by its path.


### PR DESCRIPTION
## Summary

- Extracts a private `install_open_database(...)` helper in `services/kdbx/open.rs`. The three `open*` entry points (`open`, `open_with_keyfile`, `open_with_keyfile_only`) now end with one call instead of repeating the `OpenDatabase { … }` literal + `DatabaseInfo { … }` construction (~15 lines each).
- No behaviour change. The credential payload is the only thing the three paths disagree on; the helper takes `password: Option<SecureString>` and `keyfile_path: Option<String>` so each caller passes exactly its variant.

## Why split out of #245

SonarCloud flagged this duplication on PR #245 even though it is pre-existing on `main`. The reason: #245's only edit to `open.rs` was `+ generation: 0,` on each branch, which pulled the whole surrounding block into Sonar's *new code* window. Splitting the refactor here keeps #245 scoped to password-health and gives this cleanup an independent review surface. After this merges, `mcp__sonarqube__search_duplicated_files` on `main` should drop `open.rs`.

## Test plan

- [x] `cd src-tauri && cargo test` — 272 lib tests pass.
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings` — clean.
- [x] Manual smoke: open a Vault with password (open path), open a Vault with password + keyfile (open_with_keyfile path), open a Vault with keyfile only (open_with_keyfile_only path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)