### PR TITLE
feat: password health — weak / very-weak via zxcvbn (#242)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1040,12 +1040,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1064,11 +1088,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.114",
 ]
@@ -1118,6 +1153,37 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
  "syn 2.0.114",
 ]
 
@@ -1391,6 +1457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,6 +1580,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2669,6 +2752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d101775d2bc8f99f4ac18bf29b9ed70c0dd138b9a1e88d7b80179470cbbe8bd2"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2821,6 +2913,12 @@ dependencies = [
  "indexmap 2.13.0",
  "selectors 0.24.0",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -3106,6 +3204,7 @@ dependencies = [
  "url",
  "uuid",
  "zeroize",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -4271,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4820,7 +4919,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -7493,4 +7592,21 @@ dependencies = [
  "serde",
  "syn 2.0.114",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eaee90f4a795d1eb4ba6c51e1c1721d4784d550e8efa7b2600f29c867365e0"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,9 @@ chrono = { version = "0.4", features = ["serde"] } # Timestamp handling
 psl = "2"
 chacha20poly1305 = "0.10"
 fs4 = { version = "0.13", features = ["sync"] }
+# Password Health analyzer's strength check (zxcvbn score 0/1).
+# Entropy/pattern detection only; no network.
+zxcvbn = "3"
 
 [profile.dev.package.scrypt]
 opt-level = 3

--- a/src-tauri/src/dto/password_health.rs
+++ b/src-tauri/src/dto/password_health.rs
@@ -37,6 +37,10 @@ pub struct FindingDto {
 /// a new variant in a follow-up slice is wire-additive.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum FindingKindDto {
+    #[serde(rename = "password.very_weak")]
+    PasswordVeryWeak,
+    #[serde(rename = "password.weak")]
+    PasswordWeak,
     #[serde(rename = "password.expired")]
     PasswordExpired,
 }
@@ -80,6 +84,8 @@ impl From<Finding> for FindingDto {
 impl From<FindingKind> for FindingKindDto {
     fn from(kind: FindingKind) -> Self {
         match kind {
+            FindingKind::PasswordVeryWeak => FindingKindDto::PasswordVeryWeak,
+            FindingKind::PasswordWeak => FindingKindDto::PasswordWeak,
             FindingKind::PasswordExpired => FindingKindDto::PasswordExpired,
         }
     }
@@ -110,6 +116,37 @@ mod tests {
     fn finding_kind_serializes_as_namespaced_string() {
         let json = serde_json::to_string(&FindingKindDto::PasswordExpired).expect("serialize");
         assert_eq!(json, r#""password.expired""#);
+    }
+
+    /// The strength-based Finding Kinds serialize on the same
+    /// `password.<kind>` shape. The frontend `FindingKindSchema` is
+    /// keyed off these exact strings — if a future refactor renamed
+    /// them, the schema parse would reject every report.
+    #[test]
+    fn strength_finding_kinds_serialize_as_namespaced_strings() {
+        assert_eq!(
+            serde_json::to_string(&FindingKindDto::PasswordVeryWeak).expect("very_weak"),
+            r#""password.very_weak""#
+        );
+        assert_eq!(
+            serde_json::to_string(&FindingKindDto::PasswordWeak).expect("weak"),
+            r#""password.weak""#
+        );
+    }
+
+    /// End-to-end conversion from the domain `FindingKind` enum to
+    /// the DTO must preserve the new strength variants. Pins the
+    /// `From` impl so the two enums cannot drift.
+    #[test]
+    fn domain_to_dto_preserves_strength_variants() {
+        assert_eq!(
+            FindingKindDto::from(FindingKind::PasswordVeryWeak),
+            FindingKindDto::PasswordVeryWeak
+        );
+        assert_eq!(
+            FindingKindDto::from(FindingKind::PasswordWeak),
+            FindingKindDto::PasswordWeak
+        );
     }
 
     /// End-to-end conversion: a domain report with one expired Finding

--- a/src-tauri/src/services/generator.rs
+++ b/src-tauri/src/services/generator.rs
@@ -602,11 +602,19 @@ mod tests {
         );
     }
 
+    // The EFF large diceware wordlist contains four hyphenated
+    // entries (`drop-down`, `felt-tip`, `t-shirt`, `yo-yo`). The
+    // default `"-"` separator would make `split('-')` ambiguous and
+    // these tests would flake at ~0.3% per 6-word passphrase. Pin a
+    // separator that is guaranteed not to appear in any EFF word.
+    const TEST_SEPARATOR: &str = "_";
+
     #[test]
     fn generates_passphrase_with_correct_word_count() {
         let options = PassphraseGeneratorOptions {
             word_count: 6,
             include_number: false,
+            separator: TEST_SEPARATOR.into(),
             ..Default::default()
         };
 
@@ -616,7 +624,7 @@ mod tests {
             passphrase: String::new(),
             entropy_bits: 0.0,
         });
-        let word_count = generated.passphrase.split('-').count();
+        let word_count = generated.passphrase.split(TEST_SEPARATOR).count();
         assert_eq!(word_count, 6);
     }
 
@@ -626,7 +634,7 @@ mod tests {
             word_count: 4,
             capitalize: true,
             include_number: false,
-            ..Default::default()
+            separator: TEST_SEPARATOR.into(),
         };
 
         let result = generate_passphrase(&options);
@@ -635,7 +643,7 @@ mod tests {
             passphrase: String::new(),
             entropy_bits: 0.0,
         });
-        for word in generated.passphrase.split('-') {
+        for word in generated.passphrase.split(TEST_SEPARATOR) {
             let first = word.chars().next();
             assert!(
                 first.is_some_and(char::is_uppercase),

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -17,6 +17,8 @@ use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 
+use crate::domain::secure::SecureString;
+
 /// Per-Entry input the analyzer consumes. The service layer assembles
 /// one of these for every in-scope Entry before invoking [`analyze`].
 ///
@@ -24,14 +26,22 @@ use chrono::{DateTime, Utc};
 /// associated timestamp. Both come straight from the Entry record — the
 /// analyzer does not resolve "expired" until [`analyze`] compares them
 /// against the injected `now`.
-#[derive(Debug, Clone)]
+/// `Debug` is derived but the [`SecureString`] password field renders
+/// as `[REDACTED]`, so panic-printing or accidental logging cannot
+/// leak the cleartext. `Clone` is intentionally **not** derived —
+/// every additional copy is another heap region the analyzer has to
+/// zeroize, and the pipeline never needs more than one copy per
+/// Entry (the analyzer borrows). Consumers that need another copy
+/// should clone the inner `SecureString` explicitly.
+#[derive(Debug)]
 pub struct EntryInput {
     pub id: String,
-    /// Cleartext password for this Entry. Empty string is a valid
-    /// in-scope value and triggers the empty-string Very-Weak path
-    /// without consulting zxcvbn. The cleartext lives only inside the
-    /// analyzer's stack frame and is dropped when `analyze` returns.
-    pub password: String,
+    /// Cleartext password for this Entry, held in a zeroizing
+    /// wrapper. Empty string is a valid in-scope value and triggers
+    /// the empty-string Very-Weak path without consulting zxcvbn.
+    /// The cleartext lives only inside the analyzer's stack frame
+    /// and is wiped from memory when `analyze` drops the `Vec`.
+    pub password: SecureString,
     pub expires: bool,
     pub expiry_time: Option<DateTime<Utc>>,
 }
@@ -121,7 +131,7 @@ pub fn analyze(
 
     let mut findings: Vec<Finding> = Vec::new();
     for entry in &entries {
-        if let Some(kind) = classify_strength(&entry.password) {
+        if let Some(kind) = classify_strength(entry.password.as_str()) {
             findings.push(Finding {
                 entry_id: entry.id.clone(),
                 kind,
@@ -223,7 +233,7 @@ mod tests {
     fn healthy(id: &str) -> EntryInput {
         EntryInput {
             id: id.to_string(),
-            password: "correct horse battery staple".to_string(),
+            password: SecureString::from("correct horse battery staple"),
             expires: false,
             expiry_time: None,
         }
@@ -232,7 +242,7 @@ mod tests {
     fn expired(id: &str, now: DateTime<Utc>) -> EntryInput {
         EntryInput {
             id: id.to_string(),
-            password: "correct horse battery staple".to_string(),
+            password: SecureString::from("correct horse battery staple"),
             expires: true,
             expiry_time: Some(now - chrono::Duration::days(1)),
         }
@@ -241,7 +251,7 @@ mod tests {
     fn with_password(id: &str, password: &str) -> EntryInput {
         EntryInput {
             id: id.to_string(),
-            password: password.to_string(),
+            password: SecureString::from(password),
             expires: false,
             expiry_time: None,
         }
@@ -314,7 +324,7 @@ mod tests {
         let now = now_fixed();
         let entry = EntryInput {
             id: "boundary".to_string(),
-            password: "correct horse battery staple".to_string(),
+            password: SecureString::from("correct horse battery staple"),
             expires: true,
             expiry_time: Some(now),
         };
@@ -385,7 +395,7 @@ mod tests {
         let past = now - chrono::Duration::days(1);
         let entry = EntryInput {
             id: "a".to_string(),
-            password: "password".to_string(),
+            password: SecureString::from("password"),
             expires: true,
             expiry_time: Some(past),
         };
@@ -402,6 +412,25 @@ mod tests {
                 healthy: 0,
                 total: 1,
             }
+        );
+    }
+
+    /// The cleartext password on `EntryInput` is held in a
+    /// [`SecureString`] so a stray `{:?}` or `panic!` never leaks it.
+    /// If a future refactor swaps the field back to plain `String`,
+    /// the assertion below would print the actual password instead of
+    /// `[REDACTED]` and this test would fail loudly.
+    #[test]
+    fn entry_input_debug_redacts_cleartext_password() {
+        let entry = with_password("a", "hunter2-leak-canary");
+        let debug = format!("{entry:?}");
+        assert!(
+            !debug.contains("hunter2-leak-canary"),
+            "EntryInput Debug must redact the cleartext password; got: {debug}"
+        );
+        assert!(
+            debug.contains("[REDACTED]"),
+            "EntryInput Debug must show [REDACTED] for the password; got: {debug}"
         );
     }
 

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -27,24 +27,30 @@ use chrono::{DateTime, Utc};
 #[derive(Debug, Clone)]
 pub struct EntryInput {
     pub id: String,
+    /// Cleartext password for this Entry. Empty string is a valid
+    /// in-scope value and triggers the empty-string Very-Weak path
+    /// without consulting zxcvbn. The cleartext lives only inside the
+    /// analyzer's stack frame and is dropped when `analyze` returns.
+    pub password: String,
     pub expires: bool,
     pub expiry_time: Option<DateTime<Utc>>,
 }
 
-/// The namespaced enum of recordable Password Health findings. Only
-/// `PasswordExpired` is emitted in this slice; the remaining kinds
-/// (`PasswordVeryWeak`, `PasswordWeak`, `PasswordReused`) ship in
-/// follow-up slices. See CONTEXT.md → "Password Health Finding Kind".
+/// The namespaced enum of recordable Password Health findings. The
+/// reuse check (`PasswordReused`) lands in a follow-up slice. See
+/// CONTEXT.md → "Password Health Finding Kind".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FindingKind {
+    PasswordVeryWeak,
+    PasswordWeak,
     PasswordExpired,
 }
 
 /// Two-bucket severity used to populate [`HealthTotals`] and decide
 /// which Section of the Security report an Entry surfaces in. Mirrors
-/// the wording in ADR 0002 — `Very Weak` is the only Critical Finding
-/// Kind; everything else (`Weak`, `Reused`, `Expired`) is High. Healthy
-/// Entries have no Findings and therefore no severity.
+/// the wording in ADR 0002: `Very Weak` is the only Critical Finding
+/// Kind; `Weak`, `Reused`, and `Expired` are High. Healthy Entries
+/// have no Findings and therefore no severity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Severity {
     Critical,
@@ -54,7 +60,8 @@ pub enum Severity {
 impl FindingKind {
     pub fn severity(&self) -> Severity {
         match self {
-            FindingKind::PasswordExpired => Severity::High,
+            FindingKind::PasswordVeryWeak => Severity::Critical,
+            FindingKind::PasswordWeak | FindingKind::PasswordExpired => Severity::High,
         }
     }
 }
@@ -112,14 +119,21 @@ pub fn analyze(
         };
     }
 
-    let findings: Vec<Finding> = entries
-        .iter()
-        .filter(|e| is_expired(e, now))
-        .map(|e| Finding {
-            entry_id: e.id.clone(),
-            kind: FindingKind::PasswordExpired,
-        })
-        .collect();
+    let mut findings: Vec<Finding> = Vec::new();
+    for entry in &entries {
+        if let Some(kind) = classify_strength(&entry.password) {
+            findings.push(Finding {
+                entry_id: entry.id.clone(),
+                kind,
+            });
+        }
+        if is_expired(entry, now) {
+            findings.push(Finding {
+                entry_id: entry.id.clone(),
+                kind: FindingKind::PasswordExpired,
+            });
+        }
+    }
 
     // Bucket each Entry by its highest-severity Finding so
     // `critical + high + healthy == total` holds (the Security view
@@ -167,6 +181,27 @@ pub fn analyze(
     }
 }
 
+/// Classify a password's strength into a Finding Kind, or return
+/// `None` if it does not warrant a Weak/Very-Weak Finding.
+///
+/// Empty strings are special-cased to Very Weak without invoking
+/// zxcvbn — the crate's behaviour on empty input is not part of the
+/// contract this analyzer wants to depend on. Non-empty passwords go
+/// through `zxcvbn::zxcvbn` with no user-context inputs; score 0 maps
+/// to Very Weak (Critical), score 1 to Weak (High), and everything
+/// 2-or-higher is left un-flagged.
+fn classify_strength(password: &str) -> Option<FindingKind> {
+    if password.is_empty() {
+        return Some(FindingKind::PasswordVeryWeak);
+    }
+    let score = u8::from(zxcvbn::zxcvbn(password, &[]).score());
+    match score {
+        0 => Some(FindingKind::PasswordVeryWeak),
+        1 => Some(FindingKind::PasswordWeak),
+        _ => None,
+    }
+}
+
 fn is_expired(entry: &EntryInput, now: DateTime<Utc>) -> bool {
     // `KeePass` expiry semantics are "not in the future": an entry
     // whose expiry instant equals `now` is already expired. Using `<`
@@ -188,6 +223,7 @@ mod tests {
     fn healthy(id: &str) -> EntryInput {
         EntryInput {
             id: id.to_string(),
+            password: "correct horse battery staple".to_string(),
             expires: false,
             expiry_time: None,
         }
@@ -196,8 +232,18 @@ mod tests {
     fn expired(id: &str, now: DateTime<Utc>) -> EntryInput {
         EntryInput {
             id: id.to_string(),
+            password: "correct horse battery staple".to_string(),
             expires: true,
             expiry_time: Some(now - chrono::Duration::days(1)),
+        }
+    }
+
+    fn with_password(id: &str, password: &str) -> EntryInput {
+        EntryInput {
+            id: id.to_string(),
+            password: password.to_string(),
+            expires: false,
+            expiry_time: None,
         }
     }
 
@@ -268,12 +314,111 @@ mod tests {
         let now = now_fixed();
         let entry = EntryInput {
             id: "boundary".to_string(),
+            password: "correct horse battery staple".to_string(),
             expires: true,
             expiry_time: Some(now),
         };
         let report = analyze(vec![entry], now);
         assert_eq!(report.findings.len(), 1);
         assert_eq!(report.findings[0].kind, FindingKind::PasswordExpired);
+    }
+
+    /// A password the zxcvbn dictionary rates score 0 (the top hits in
+    /// the leaked-credentials corpora) must emit Very Weak. "password"
+    /// is the canonical example — it is the most common password ever
+    /// observed in breach dumps, and zxcvbn scores it 0.
+    #[test]
+    fn zxcvbn_score_zero_password_emits_very_weak() {
+        let report = analyze(vec![with_password("a", "password")], now_fixed());
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, FindingKind::PasswordVeryWeak);
+        assert_eq!(report.totals.critical, 1);
+    }
+
+    /// A password that zxcvbn rates score 1 (a common pattern with a
+    /// small substitution — still trivially guessable within an hour
+    /// of offline attack) emits Weak (High severity). The fixture
+    /// string is chosen to be deterministic against the bundled
+    /// dictionary; if a future zxcvbn release shifts the score this
+    /// pin will fail loudly and we re-calibrate.
+    #[test]
+    fn zxcvbn_score_one_password_emits_weak_high() {
+        let report = analyze(vec![with_password("a", "P@ssword1")], now_fixed());
+        let score = u8::from(zxcvbn::zxcvbn("P@ssword1", &[]).score());
+        assert_eq!(
+            score, 1,
+            "fixture password must score exactly 1 in the bundled zxcvbn dictionary; got {score}"
+        );
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].kind, FindingKind::PasswordWeak);
+        assert_eq!(FindingKind::PasswordWeak.severity(), Severity::High);
+        assert_eq!(report.totals.high, 1);
+        assert_eq!(report.totals.critical, 0);
+    }
+
+    /// Passwords zxcvbn rates ≥ 2 do not produce a Weak or Very-Weak
+    /// Finding. The xkcd-style passphrase is the canonical
+    /// "high-entropy memorable" example and scores 3; the analyzer
+    /// must let it through. Pins the boundary against an over-eager
+    /// future tweak.
+    #[test]
+    fn zxcvbn_score_two_or_higher_emits_no_strength_finding() {
+        let report = analyze(vec![with_password("a", "Tr0ub4dor!")], now_fixed());
+        let score = u8::from(zxcvbn::zxcvbn("Tr0ub4dor!", &[]).score());
+        assert!(
+            score >= 2,
+            "fixture password must score ≥2 in zxcvbn; got {score}"
+        );
+        assert!(report.findings.is_empty());
+        assert_eq!(report.totals.healthy, 1);
+    }
+
+    /// An Entry that is both Expired and zxcvbn-score-0 emits **two**
+    /// independent Findings (the remediations differ — fix expiry vs.
+    /// regenerate the password) but counts as **one** un-healthy
+    /// contribution in the totals breakdown. The Entry lands in
+    /// `critical` (the more severe of its two Findings), not in
+    /// `high`; the un-healthy denominator is one, not two.
+    #[test]
+    fn weak_and_expired_on_same_entry_emits_two_findings_one_unhealthy() {
+        let now = now_fixed();
+        let past = now - chrono::Duration::days(1);
+        let entry = EntryInput {
+            id: "a".to_string(),
+            password: "password".to_string(),
+            expires: true,
+            expiry_time: Some(past),
+        };
+        let report = analyze(vec![entry], now);
+        assert_eq!(report.findings.len(), 2);
+        let kinds: Vec<&FindingKind> = report.findings.iter().map(|f| &f.kind).collect();
+        assert!(kinds.contains(&&FindingKind::PasswordVeryWeak));
+        assert!(kinds.contains(&&FindingKind::PasswordExpired));
+        assert_eq!(
+            report.totals,
+            HealthTotals {
+                critical: 1,
+                high: 0,
+                healthy: 0,
+                total: 1,
+            }
+        );
+    }
+
+    /// Empty-string passwords are special-cased to Very Weak without
+    /// invoking zxcvbn (which has ambiguous behaviour on empty input).
+    /// The Entry stays in scope — empty is what the analyzer is here
+    /// to call out — and the resulting Finding is Critical, so the
+    /// totals breakdown puts the Entry in `critical`, not `high`.
+    #[test]
+    fn empty_password_emits_one_very_weak_finding() {
+        let report = analyze(vec![with_password("a", "")], now_fixed());
+        assert_eq!(report.findings.len(), 1);
+        assert_eq!(report.findings[0].entry_id, "a");
+        assert_eq!(report.findings[0].kind, FindingKind::PasswordVeryWeak);
+        assert_eq!(FindingKind::PasswordVeryWeak.severity(), Severity::Critical);
+        assert_eq!(report.totals.critical, 1);
+        assert_eq!(report.totals.high, 0);
     }
 
     /// One expired Entry in a four-Entry Vault: 3 healthy / 4 total =

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -21,6 +21,7 @@ use keepass::Database;
 
 use super::analyzer::{analyze, EntryInput, PasswordHealthReport};
 use super::cache::CacheStore;
+use crate::domain::secure::SecureString;
 use crate::dto::error::AppError;
 use crate::services::kdbx::recycle::is_in_recycle_bin;
 use crate::services::kdbx::KdbxService;
@@ -51,7 +52,7 @@ pub fn collect_entry_inputs(db: &Database) -> Vec<EntryInput> {
         })
         .map(|entry| EntryInput {
             id: entry.id().uuid().to_string(),
-            password: entry.get_password().unwrap_or("").to_string(),
+            password: SecureString::from(entry.get_password().unwrap_or("")),
             expires: entry.times.expires.unwrap_or(false),
             expiry_time: entry.times.expiry.map(|naive| naive.and_utc()),
         })

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -36,9 +36,8 @@ use crate::services::kdbx::KdbxService;
 ///   attachment-only) are excluded — there is nothing for the
 ///   analyzer to score.
 /// - Entries with an empty-string `Password` are **included**; they
-///   contribute to the total-in-scope denominator even though no
-///   Finding Kind in this slice would emit for them. Once the
-///   Very-Weak check lands they will start emitting that Finding.
+///   contribute to the total-in-scope denominator and trigger the
+///   special-cased Very-Weak Finding inside the analyzer.
 pub fn collect_entry_inputs(db: &Database) -> Vec<EntryInput> {
     let recycle_uuid = db.meta.recyclebin_uuid;
     db.iter_all_entries()
@@ -52,6 +51,7 @@ pub fn collect_entry_inputs(db: &Database) -> Vec<EntryInput> {
         })
         .map(|entry| EntryInput {
             id: entry.id().uuid().to_string(),
+            password: entry.get_password().unwrap_or("").to_string(),
             expires: entry.times.expires.unwrap_or(false),
             expiry_time: entry.times.expiry.map(|naive| naive.and_utc()),
         })
@@ -182,7 +182,10 @@ mod tests {
         {
             let mut root = db.root_mut();
             let mut e = root.add_entry();
-            e.set("Password", Value::protected("ok"));
+            e.set(
+                "Password",
+                Value::protected("Tr0ub4dor&horse staple battery"),
+            );
         }
         let kdbx = KdbxService::new();
         install_vault(&kdbx, path, db);
@@ -257,7 +260,10 @@ mod tests {
         let in_scope_uuid = {
             let mut root = db.root_mut();
             let mut entry = root.add_entry();
-            entry.set("Password", Value::protected("secret"));
+            entry.set(
+                "Password",
+                Value::protected("Tr0ub4dor&horse staple secret"),
+            );
             entry.id().uuid()
         };
 
@@ -277,7 +283,7 @@ mod tests {
                 .id();
             let mut recycle = db.group_mut(recycle_id).expect("recycle bin must exist");
             let mut entry = recycle.add_entry();
-            entry.set("Password", Value::protected("also-secret"));
+            entry.set("Password", Value::protected("Tr0ub4dor&horse staple alt"));
             entry.id().uuid()
         };
 
@@ -308,13 +314,16 @@ mod tests {
         let _healthy_uuid = {
             let mut root = db.root_mut();
             let mut entry = root.add_entry();
-            entry.set("Password", Value::protected("ok"));
+            entry.set(
+                "Password",
+                Value::protected("Tr0ub4dor&horse staple battery"),
+            );
             entry.id().uuid()
         };
         let expired_uuid = {
             let mut root = db.root_mut();
             let mut entry = root.add_entry();
-            entry.set("Password", Value::protected("ok-too"));
+            entry.set("Password", Value::protected("Tr0ub4dor&horse staple wagon"));
             entry.times.expires = Some(true);
             entry.times.expiry = Some(past);
             entry.id().uuid()
@@ -355,7 +364,7 @@ mod tests {
         let r1 = service.generate_report(&kdbx, path, now).expect("first");
         assert!(r1.findings.is_empty());
 
-        insert_expired_entry(&kdbx, path, "x", past, true);
+        insert_expired_entry(&kdbx, path, "Tr0ub4dor&horse staple x", past, true);
 
         let r2 = service.generate_report(&kdbx, path, now).expect("second");
         assert_eq!(
@@ -386,7 +395,7 @@ mod tests {
         // Silent mutation: the cache is keyed on generation, and
         // generation only advances through `mark_modified`. So the
         // expired Entry added here must not invalidate the cached r1.
-        insert_expired_entry(&kdbx, path, "y", past, false);
+        insert_expired_entry(&kdbx, path, "Tr0ub4dor&horse staple y", past, false);
 
         let r2 = service.generate_report(&kdbx, path, now).expect("second");
         assert_eq!(
@@ -413,7 +422,7 @@ mod tests {
 
         // Silent mutation: without `on_lock` the next read would hit
         // the cache. The explicit eviction is what forces recompute.
-        insert_expired_entry(&kdbx, path, "x", past, false);
+        insert_expired_entry(&kdbx, path, "Tr0ub4dor&horse staple x", past, false);
 
         service.on_lock(path);
 
@@ -442,7 +451,13 @@ mod tests {
         // Silent mutation: add an entry that expires at t1 but is
         // healthy at t0. No mark_modified — the only freshness signal
         // available is `now`.
-        insert_expired_entry(&kdbx, path, "future", future_expiry, false);
+        insert_expired_entry(
+            &kdbx,
+            path,
+            "Tr0ub4dor&horse staple future",
+            future_expiry,
+            false,
+        );
 
         let r0 = service.generate_report(&kdbx, path, t0).expect("at t0");
         assert!(r0.findings.is_empty(), "before expiry the entry is healthy");

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -1,5 +1,5 @@
 import type { CustomIconMap, Entry, Finding } from "@/lib/types";
-import { TriangleAlert } from "lucide-react";
+import { OctagonAlert, TriangleAlert } from "lucide-react";
 import { createElement, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { severityOf } from "@/lib/password-health";
@@ -41,7 +41,6 @@ const EntryListItem = memo(function EntryListItem({
   onClick,
   findings,
 }: EntryListItemProps) {
-  const { t } = useTranslation();
   const iconComponent = getKeepassIcon(iconId ?? 0);
   const customIcon = customIconUuid ? customIcons[customIconUuid] : null;
   const customIconSrc = customIcon
@@ -79,27 +78,42 @@ const EntryListItem = memo(function EntryListItem({
         </ItemContent>
         <ItemActions className="shrink-0">
           {findings && findings.length > 0 && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <TriangleAlert
-                  className={cn(
-                    "size-4",
-                    findings.some((f) => severityOf(f.kind) === "critical")
-                      ? "text-red-600 dark:text-red-500"
-                      : "text-amber-600 dark:text-amber-500"
-                  )}
-                  aria-label={t("passwordHealth.icons.warning")}
-                />
-              </TooltipTrigger>
-              <TooltipContent>
-                {t("passwordHealth.icons.warning")}
-              </TooltipContent>
-            </Tooltip>
+            <FindingsIndicator findings={findings} />
           )}
         </ItemActions>
       </a>
     </Item>
   );
 });
+
+/// Renders the per-Entry warning icon for the EntryList. Critical
+/// findings (e.g. very_weak / empty password) use a red OctagonAlert;
+/// High-only findings keep the amber TriangleAlert. The tooltip and
+/// aria-label spell out each Finding Kind in plain language so screen
+/// readers don't read out enum identifiers.
+function FindingsIndicator({ findings }: Readonly<{ findings: Finding[] }>) {
+  const { t } = useTranslation();
+  const hasCritical = findings.some((f) => severityOf(f.kind) === "critical");
+  // De-duplicate Finding Kinds before formatting — an Entry with two
+  // expired-style Findings (theoretical) should still show one row.
+  const uniqueKinds = Array.from(new Set(findings.map((f) => f.kind)));
+  const label = uniqueKinds
+    .map((kind) => t(`passwordHealth.findings.${kind}`))
+    .join(" · ");
+
+  const Icon = hasCritical ? OctagonAlert : TriangleAlert;
+  const colorClass = hasCritical
+    ? "text-red-600 dark:text-red-500"
+    : "text-amber-600 dark:text-amber-500";
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Icon className={cn("size-4", colorClass)} aria-label={label} />
+      </TooltipTrigger>
+      <TooltipContent>{label}</TooltipContent>
+    </Tooltip>
+  );
+}
 
 export default EntryListItem;

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -47,7 +47,11 @@ export function PasswordHealthReportView({
   }
 
   return (
-    <div className="flex flex-col gap-6 p-6">
+    // The dashboard SidebarInset sets `overflow-hidden`, so this view
+    // must own its own scroll container. Without `flex-1 min-h-0
+    // overflow-auto` the page silently clips on Vaults with many
+    // findings — the user can't reach the tail of the list.
+    <div className="flex flex-1 min-h-0 flex-col gap-6 overflow-auto p-6">
       <header className="flex flex-col gap-1">
         <h1 className="text-2xl font-semibold tracking-tight">
           {t("passwordHealth.title")}

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-import { TriangleAlert } from "lucide-react";
+import { OctagonAlert, TriangleAlert } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "@tanstack/react-router";
 
@@ -15,6 +15,7 @@ import {
 import { useActiveDatabase } from "@/hooks/use-active-database";
 import { useEntries } from "@/hooks/use-entries";
 import { usePasswordHealthReport } from "@/hooks/use-password-health";
+import { severityOf, type Severity } from "@/lib/password-health";
 import { useDatabaseTabs } from "@/stores/database-tabs";
 import type { Entry, Finding, PasswordHealthReport } from "@/lib/types";
 
@@ -58,7 +59,16 @@ export function PasswordHealthReportView({
 
       <ScoreAndTotals report={report} />
 
-      <HighFindingsSection report={report} entries={entries ?? []} />
+      <FindingsSection
+        severity="critical"
+        report={report}
+        entries={entries ?? []}
+      />
+      <FindingsSection
+        severity="high"
+        report={report}
+        entries={entries ?? []}
+      />
     </div>
   );
 }
@@ -127,10 +137,49 @@ function TotalsCell({
   );
 }
 
-function HighFindingsSection({
+// Bucket each Entry by its highest-severity Finding so an Entry that
+// is both Very Weak and Expired surfaces only in the Critical section,
+// not both. Mirrors the totals-strip rule in the backend analyzer.
+function bucketEntriesBySeverity(
+  findings: Finding[]
+): Map<Severity, Map<string, Finding[]>> {
+  const highestPerEntry = new Map<string, Severity>();
+  for (const finding of findings) {
+    const severity = severityOf(finding.kind);
+    const prior = highestPerEntry.get(finding.entryId);
+    if (prior === "critical") continue;
+    if (severity === "critical" || prior === undefined) {
+      highestPerEntry.set(finding.entryId, severity);
+    }
+  }
+
+  const buckets = new Map<Severity, Map<string, Finding[]>>([
+    ["critical", new Map()],
+    ["high", new Map()],
+  ]);
+  for (const finding of findings) {
+    const bucket = highestPerEntry.get(finding.entryId);
+    if (!bucket) continue;
+    const list = buckets.get(bucket)?.get(finding.entryId) ?? [];
+    list.push(finding);
+    buckets.get(bucket)?.set(finding.entryId, list);
+  }
+  return buckets;
+}
+
+interface SectionChrome {
+  Icon: typeof TriangleAlert;
+  iconClass: string;
+  title: string;
+  description: string;
+}
+
+function FindingsSection({
+  severity,
   report,
   entries,
 }: Readonly<{
+  severity: Severity;
   report: PasswordHealthReport;
   entries: Entry[];
 }>) {
@@ -139,16 +188,8 @@ function HighFindingsSection({
   const { tab } = useActiveDatabase();
   const updateTabState = useDatabaseTabs((s) => s.updateTabState);
 
-  // Group findings by entry so the row collapses an Entry that hits
-  // multiple Findings of the same severity into a single visual row.
-  const byEntry = new Map<string, Finding[]>();
-  for (const finding of report.findings) {
-    const list = byEntry.get(finding.entryId) ?? [];
-    list.push(finding);
-    byEntry.set(finding.entryId, list);
-  }
-
-  if (byEntry.size === 0) {
+  const byEntry = bucketEntriesBySeverity(report.findings).get(severity);
+  if (!byEntry || byEntry.size === 0) {
     return null;
   }
 
@@ -166,17 +207,28 @@ function HighFindingsSection({
     void navigate({ to: "/dashboard/entry/$id", params: { id: entryId } });
   };
 
+  const chrome: SectionChrome =
+    severity === "critical"
+      ? {
+          Icon: OctagonAlert,
+          iconClass: "text-red-600 dark:text-red-500",
+          title: t("passwordHealth.sections.critical"),
+          description: t("passwordHealth.sections.criticalDescription"),
+        }
+      : {
+          Icon: TriangleAlert,
+          iconClass: "text-amber-600 dark:text-amber-500",
+          title: t("passwordHealth.sections.high"),
+          description: t("passwordHealth.sections.highDescription"),
+        };
+
   return (
     <section className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
-        <TriangleAlert className="size-4 text-amber-600 dark:text-amber-500" />
-        <h2 className="text-lg font-medium">
-          {t("passwordHealth.sections.high")}
-        </h2>
+        <chrome.Icon className={`size-4 ${chrome.iconClass}`} />
+        <h2 className="text-lg font-medium">{chrome.title}</h2>
       </div>
-      <p className="text-sm text-muted-foreground">
-        {t("passwordHealth.sections.highDescription")}
-      </p>
+      <p className="text-sm text-muted-foreground">{chrome.description}</p>
       <ul className="divide-y rounded-md border bg-card">
         {Array.from(byEntry.entries()).map(([entryId, findings]) => {
           const entry = entryById.get(entryId);

--- a/src/lib/__tests__/password-health.test.ts
+++ b/src/lib/__tests__/password-health.test.ts
@@ -72,6 +72,58 @@ describe("severityOf", () => {
   it("maps password.expired to high", () => {
     expect(severityOf("password.expired")).toBe("high");
   });
+
+  it("maps password.very_weak to critical", () => {
+    expect(severityOf("password.very_weak")).toBe("critical");
+  });
+
+  it("maps password.weak to high", () => {
+    expect(severityOf("password.weak")).toBe("high");
+  });
+});
+
+describe("summarize with critical findings", () => {
+  // The sidebar badge picks its colour from `highestSeverity`. The
+  // moment any Critical Finding shows up in the report, the colour
+  // flips from amber to red. Pin the rule independently of how many
+  // High Findings the Vault also has — Critical wins.
+  const criticalAndHighReport: PasswordHealthReport = {
+    score: 50,
+    findings: [
+      { entryId: "a", kind: "password.very_weak" },
+      { entryId: "b", kind: "password.expired" },
+    ],
+    totals: { critical: 1, high: 1, healthy: 0, total: 2 },
+    reuseGroups: [],
+  };
+
+  // An Entry that is both very_weak and expired (its own two
+  // Findings) must count once in `totalUnhealthy` and must be
+  // labelled Critical because that is the more severe of its two
+  // Findings. This is the per-Entry tie-breaker.
+  const sameEntryBothFindings: PasswordHealthReport = {
+    score: 0,
+    findings: [
+      { entryId: "a", kind: "password.expired" },
+      { entryId: "a", kind: "password.very_weak" },
+    ],
+    totals: { critical: 1, high: 0, healthy: 0, total: 1 },
+    reuseGroups: [],
+  };
+
+  it("returns highestSeverity 'critical' when any critical finding is present", () => {
+    expect(summarize(criticalAndHighReport)).toEqual({
+      totalUnhealthy: 2,
+      highestSeverity: "critical",
+    });
+  });
+
+  it("collapses two findings on one entry into one un-healthy entry labelled critical", () => {
+    expect(summarize(sameEntryBothFindings)).toEqual({
+      totalUnhealthy: 1,
+      highestSeverity: "critical",
+    });
+  });
 });
 
 describe("findingsForEntry", () => {

--- a/src/lib/password-health.ts
+++ b/src/lib/password-health.ts
@@ -15,7 +15,8 @@ import type { Finding, FindingKind, PasswordHealthReport } from "./types";
 export type Severity = "critical" | "high";
 
 export function severityOf(kind: FindingKind): Severity {
-  if (kind === "password.expired") return "high";
+  if (kind === "password.very_weak") return "critical";
+  if (kind === "password.weak" || kind === "password.expired") return "high";
   // Exhaustiveness lives at the union boundary — adding a new Finding
   // Kind in `types.ts` makes this `never` cast fail to compile.
   const exhaustive: never = kind;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -413,7 +413,11 @@ export type AuditStatus = z.infer<typeof AuditStatusSchema>;
 /// Namespaced enum of Password Health findings. Wire shape mirrors the
 /// backend `FindingKindDto` — additions land here when new check kinds
 /// ship in follow-up slices.
-export const FindingKindSchema = z.enum(["password.expired"]);
+export const FindingKindSchema = z.enum([
+  "password.very_weak",
+  "password.weak",
+  "password.expired",
+]);
 export type FindingKind = z.infer<typeof FindingKindSchema>;
 
 export const FindingSchema = z.object({

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -647,11 +647,15 @@
       "total": "Gesamt"
     },
     "sections": {
+      "critical": "Kritisch",
+      "criticalDescription": "Einträge mit mindestens einem kritischen Problem. Diese zuerst beheben.",
       "high": "Hoch",
       "highDescription": "Einträge mit mindestens einem schwerwiegenden Problem."
     },
     "findings": {
       "password": {
+        "very_weak": "Sehr schwaches Passwort",
+        "weak": "Schwaches Passwort",
         "expired": "Abgelaufen"
       }
     },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -672,11 +672,15 @@
       "total": "Total"
     },
     "sections": {
+      "critical": "Critical",
+      "criticalDescription": "Entries with at least one critical issue. Fix these first.",
       "high": "High",
       "highDescription": "Entries with at least one high-severity issue."
     },
     "findings": {
       "password": {
+        "very_weak": "Very weak password",
+        "weak": "Weak password",
         "expired": "Expired"
       }
     },

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -647,11 +647,15 @@
       "total": "Total"
     },
     "sections": {
+      "critical": "Crítico",
+      "criticalDescription": "Entradas con al menos un problema crítico. Corrige estos primero.",
       "high": "Alto",
       "highDescription": "Entradas con al menos un problema de gravedad alta."
     },
     "findings": {
       "password": {
+        "very_weak": "Contraseña muy débil",
+        "weak": "Contraseña débil",
         "expired": "Caducada"
       }
     },

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -647,11 +647,15 @@
       "total": "Total"
     },
     "sections": {
+      "critical": "Critique",
+      "criticalDescription": "Entrées présentant au moins un problème critique. Corrigez-les en premier.",
       "high": "Élevé",
       "highDescription": "Entrées présentant au moins un problème de gravité élevée."
     },
     "findings": {
       "password": {
+        "very_weak": "Mot de passe très faible",
+        "weak": "Mot de passe faible",
         "expired": "Expiré"
       }
     },

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -647,11 +647,15 @@
       "total": "Ukupno"
     },
     "sections": {
+      "critical": "Kritično",
+      "criticalDescription": "Unosi sa najmanje jednim kritičnim problemom. Njih prvo popravite.",
       "high": "Visoko",
       "highDescription": "Unosi sa najmanje jednim problemom visokog prioriteta."
     },
     "findings": {
       "password": {
+        "very_weak": "Vrlo slaba lozinka",
+        "weak": "Slaba lozinka",
         "expired": "Isteklo"
       }
     },


### PR DESCRIPTION
## Summary

Closes #242. Extends Password Health with strength-based Finding Kinds.

- **Analyzer** integrates the `zxcvbn` Rust crate. Empty string → `password.very_weak` (Critical) without consulting zxcvbn. Score 0 → `password.very_weak`. Score 1 → `password.weak` (High). Score ≥ 2 produces no Weak/Very-Weak Finding.
- **DTO** gains `"password.very_weak"` and `"password.weak"` on the wire.
- **Report view** renders a Critical section (red `OctagonAlert`) above the existing High section. Sections with zero findings render nothing.
- **`EntryListItem`** swaps the icon to red `OctagonAlert` when any Finding on the Entry is Critical; tooltip + aria-label now list each Finding Kind's translated label (deduped).
- **Sidebar badge** colour: no code change — `usePasswordHealthSummary` already propagates `highestSeverity: "critical"` to the red conditional from #241.
- **i18n**: new keys in en/de/es/fr/sr (`sections.critical*`, `findings.password.very_weak`, `findings.password.weak`).

Per ADR 0002, an Entry that is both Very Weak and Expired emits two independent Findings but counts once in the un-healthy denominator and surfaces under Critical (the more severe of its labels).

## Test plan

- [x] Rust: `cargo test --lib` (300 passing) — five new analyzer tests + DTO serialization tests.
- [x] Frontend: `bun run test --run` (419 passing) — new pure-selector tests for `severityOf` and `summarize` with Critical findings.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `bun run check` clean (lint + prettier).
- [x] Manual: open a Vault, add an entry with password `"password"`, verify red `OctagonAlert` in the entry list, "Critical" section above "High" in the Security view, and the sidebar badge turns red.
- [x] Manual: verify all five locales render the new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)