### PR TITLE
feat(core,ui): password health reused detection with inline group expansion

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -402,6 +402,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,6 +3194,7 @@ version = "0.2.0"
 dependencies = [
  "arboard",
  "base64 0.22.1",
+ "blake3",
  "chacha20poly1305",
  "chrono",
  "fs4",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,10 @@ fs4 = { version = "0.13", features = ["sync"] }
 # Password Health analyzer's strength check (zxcvbn score 0/1).
 # Entropy/pattern detection only; no network.
 zxcvbn = "3"
+# Password Health reuse grouping. Keyed BLAKE3 with a fresh random key
+# generated per analysis run — the hash is never persisted and the key
+# is dropped with the analyzer's stack frame.
+blake3 = "1.8.5"
 
 [profile.dev.package.scrypt]
 opt-level = 3

--- a/src-tauri/src/dto/password_health.rs
+++ b/src-tauri/src/dto/password_health.rs
@@ -12,7 +12,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::services::password_health::analyzer::{
-    Finding, FindingKind, HealthTotals, PasswordHealthReport,
+    Finding, FindingKind, HealthTotals, PasswordHealthReport, ReuseGroup,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -21,7 +21,6 @@ pub struct PasswordHealthReportDto {
     pub score: Option<u32>,
     pub findings: Vec<FindingDto>,
     pub totals: HealthTotalsDto,
-    /// Empty in this slice — the reuse check ships in slice 2.
     pub reuse_groups: Vec<ReuseGroupDto>,
 }
 
@@ -41,6 +40,8 @@ pub enum FindingKindDto {
     PasswordVeryWeak,
     #[serde(rename = "password.weak")]
     PasswordWeak,
+    #[serde(rename = "password.reused")]
+    PasswordReused,
     #[serde(rename = "password.expired")]
     PasswordExpired,
 }
@@ -54,10 +55,14 @@ pub struct HealthTotalsDto {
     pub total: u32,
 }
 
+/// Wire shape per the PRD: only the member Entry ids — the per-analysis
+/// hash bytes stay backend-internal. Hash values are key-randomized per
+/// run, so leaking them would be a "what was in your Vault" signal even
+/// across re-analyses; the frontend doesn't need them to render the
+/// inline-expanded member list.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReuseGroupDto {
-    pub password_hash: String,
     pub entry_ids: Vec<String>,
 }
 
@@ -67,7 +72,19 @@ impl From<PasswordHealthReport> for PasswordHealthReportDto {
             score: report.score,
             findings: report.findings.into_iter().map(FindingDto::from).collect(),
             totals: report.totals.into(),
-            reuse_groups: Vec::new(),
+            reuse_groups: report
+                .reuse_groups
+                .into_iter()
+                .map(ReuseGroupDto::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<ReuseGroup> for ReuseGroupDto {
+    fn from(group: ReuseGroup) -> Self {
+        Self {
+            entry_ids: group.entry_ids,
         }
     }
 }
@@ -86,6 +103,7 @@ impl From<FindingKind> for FindingKindDto {
         match kind {
             FindingKind::PasswordVeryWeak => FindingKindDto::PasswordVeryWeak,
             FindingKind::PasswordWeak => FindingKindDto::PasswordWeak,
+            FindingKind::PasswordReused => FindingKindDto::PasswordReused,
             FindingKind::PasswordExpired => FindingKindDto::PasswordExpired,
         }
     }
@@ -134,6 +152,67 @@ mod tests {
         );
     }
 
+    /// `password.reused` is the wire identifier the frontend pattern
+    /// matches on (matches the dotted convention shared by the other
+    /// Finding Kinds). Pinning the exact JSON catches a refactor that
+    /// silently renames the variant to `"PasswordReused"` or
+    /// `"password_reused"` and breaks the report view.
+    #[test]
+    fn reused_finding_kind_serializes_as_namespaced_string() {
+        assert_eq!(
+            serde_json::to_string(&FindingKindDto::PasswordReused).expect("reused"),
+            r#""password.reused""#
+        );
+    }
+
+    /// The domain `FindingKind::PasswordReused` maps to the matching
+    /// DTO variant. Pins the From impl so adding the new variant on
+    /// either side doesn't silently lose information at the IPC edge.
+    #[test]
+    fn domain_to_dto_preserves_reused_variant() {
+        assert_eq!(
+            FindingKindDto::from(FindingKind::PasswordReused),
+            FindingKindDto::PasswordReused,
+        );
+    }
+
+    /// `ReuseGroupDto` carries only `entryIds` on the wire — the
+    /// per-analysis hash bytes never leave Rust. Pinning the JSON
+    /// shape catches a refactor that resurrects the previous
+    /// `passwordHash` field.
+    #[test]
+    fn reuse_group_dto_serializes_with_entry_ids_only() {
+        let dto = ReuseGroupDto {
+            entry_ids: vec!["a".into(), "b".into()],
+        };
+        let value: serde_json::Value = serde_json::to_value(&dto).expect("serialize");
+        let obj = value.as_object().expect("object");
+        assert!(obj.contains_key("entryIds"));
+        assert!(!obj.contains_key("passwordHash"));
+        assert_eq!(obj.len(), 1, "ReuseGroupDto must expose only entryIds");
+    }
+
+    /// End-to-end conversion: a domain report carrying a `ReuseGroup`
+    /// maps to a DTO whose `reuseGroups` Vec has one matching entry.
+    /// Pins the new `From<PasswordHealthReport>` arm.
+    #[test]
+    fn report_dto_carries_reuse_groups_from_domain() {
+        use crate::services::password_health::analyzer::ReuseGroup;
+
+        let domain = PasswordHealthReport {
+            score: Some(100),
+            findings: Vec::new(),
+            totals: HealthTotals::default(),
+            reuse_groups: vec![ReuseGroup {
+                entry_ids: vec!["a".into(), "b".into()],
+            }],
+        };
+
+        let dto: PasswordHealthReportDto = domain.into();
+        assert_eq!(dto.reuse_groups.len(), 1);
+        assert_eq!(dto.reuse_groups[0].entry_ids, vec!["a", "b"]);
+    }
+
     /// End-to-end conversion from the domain `FindingKind` enum to
     /// the DTO must preserve the new strength variants. Pins the
     /// `From` impl so the two enums cannot drift.
@@ -168,6 +247,7 @@ mod tests {
                 healthy: 3,
                 total: 4,
             },
+            reuse_groups: Vec::new(),
         };
 
         let dto: PasswordHealthReportDto = domain.into();

--- a/src-tauri/src/services/password_health/analyzer.rs
+++ b/src-tauri/src/services/password_health/analyzer.rs
@@ -13,9 +13,11 @@
 //! pure function — tests pin the clock; the service supplies
 //! `Utc::now()`.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 
 use chrono::{DateTime, Utc};
+use rand::rand_core::TryRng;
+use rand::rngs::SysRng;
 
 use crate::domain::secure::SecureString;
 
@@ -46,13 +48,13 @@ pub struct EntryInput {
     pub expiry_time: Option<DateTime<Utc>>,
 }
 
-/// The namespaced enum of recordable Password Health findings. The
-/// reuse check (`PasswordReused`) lands in a follow-up slice. See
+/// The namespaced enum of recordable Password Health findings. See
 /// CONTEXT.md → "Password Health Finding Kind".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FindingKind {
     PasswordVeryWeak,
     PasswordWeak,
+    PasswordReused,
     PasswordExpired,
 }
 
@@ -71,9 +73,20 @@ impl FindingKind {
     pub fn severity(&self) -> Severity {
         match self {
             FindingKind::PasswordVeryWeak => Severity::Critical,
-            FindingKind::PasswordWeak | FindingKind::PasswordExpired => Severity::High,
+            FindingKind::PasswordWeak
+            | FindingKind::PasswordReused
+            | FindingKind::PasswordExpired => Severity::High,
         }
     }
+}
+
+/// A set of in-scope Entries in this Vault whose passwords are byte-equal.
+/// Each member is also emitted as an individual `PasswordReused` Finding;
+/// the group exists so the UI can render one expandable row per shared
+/// password instead of N independent rows. `entry_ids` always has size ≥ 2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReuseGroup {
+    pub entry_ids: Vec<String>,
 }
 
 /// A single recordable Password Health Finding. Each Finding is scoped
@@ -113,6 +126,10 @@ pub struct PasswordHealthReport {
     pub score: Option<u32>,
     pub findings: Vec<Finding>,
     pub totals: HealthTotals,
+    /// One entry per byte-equal-password cluster of size ≥ 2.
+    /// Empty-string passwords are excluded — they reach `findings` as
+    /// `PasswordVeryWeak` but never group together.
+    pub reuse_groups: Vec<ReuseGroup>,
 }
 
 pub fn analyze(
@@ -126,8 +143,15 @@ pub fn analyze(
             score: None,
             findings: Vec::new(),
             totals: HealthTotals::default(),
+            reuse_groups: Vec::new(),
         };
     }
+
+    let reuse_groups = compute_reuse_groups(&entries);
+    let reused_ids: HashSet<&str> = reuse_groups
+        .iter()
+        .flat_map(|g| g.entry_ids.iter().map(String::as_str))
+        .collect();
 
     let mut findings: Vec<Finding> = Vec::new();
     for entry in &entries {
@@ -135,6 +159,12 @@ pub fn analyze(
             findings.push(Finding {
                 entry_id: entry.id.clone(),
                 kind,
+            });
+        }
+        if reused_ids.contains(entry.id.as_str()) {
+            findings.push(Finding {
+                entry_id: entry.id.clone(),
+                kind: FindingKind::PasswordReused,
             });
         }
         if is_expired(entry, now) {
@@ -188,7 +218,73 @@ pub fn analyze(
         score: Some(score),
         findings,
         totals,
+        reuse_groups,
     }
+}
+
+/// Cluster Entries by byte-equal password and return one
+/// [`ReuseGroup`] per cluster of size ≥ 2.
+///
+/// Passwords are hashed with keyed BLAKE3 using a fresh 32-byte key
+/// generated per call so the in-memory hash bytes are unlinkable
+/// across analysis runs. The cluster membership is independent of
+/// the key — same inputs always yield the same partition; only the
+/// hash bytes (used internally as map keys) shift between runs.
+/// Empty-string passwords are skipped (per ADR 0002): the Very-Weak
+/// Finding from [`classify_strength`] already names the remediation,
+/// and an "all empty" group isn't a meaningful "shared secret".
+fn compute_reuse_groups(entries: &[EntryInput]) -> Vec<ReuseGroup> {
+    let mut hash_key = [0u8; blake3::KEY_LEN];
+    // `SysRng::try_fill_bytes` can only fail if the OS RNG itself
+    // fails — at that point the process can't safely produce any
+    // randomness and reuse grouping is the least of our worries. Fall
+    // back to an all-zero key: the partition is still correct (the
+    // hash is deterministic for that run) and the only loss is the
+    // per-run unlinkability of the in-memory bytes, which we treat
+    // as best-effort rather than a soundness guarantee.
+    if SysRng.try_fill_bytes(&mut hash_key).is_err() {
+        hash_key = [0u8; blake3::KEY_LEN];
+    }
+    // `BTreeMap` keeps iteration order stable across runs (only the
+    // hash bytes — used as keys — shift). We reorder by first-seen
+    // Entry index below so the wire ordering doesn't leak the
+    // per-run randomness.
+    let mut by_hash: BTreeMap<[u8; blake3::OUT_LEN], Vec<&str>> = BTreeMap::new();
+    for entry in entries {
+        let password = entry.password.as_str();
+        if password.is_empty() {
+            continue;
+        }
+        let hash = blake3::keyed_hash(&hash_key, password.as_bytes());
+        by_hash
+            .entry(*hash.as_bytes())
+            .or_default()
+            .push(entry.id.as_str());
+    }
+
+    let order: std::collections::HashMap<&str, usize> = entries
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (e.id.as_str(), i))
+        .collect();
+    let mut groups: Vec<ReuseGroup> = by_hash
+        .into_values()
+        .filter(|ids| ids.len() >= 2)
+        .map(|ids| ReuseGroup {
+            entry_ids: ids.into_iter().map(String::from).collect(),
+        })
+        .collect();
+    for g in &mut groups {
+        g.entry_ids
+            .sort_by_key(|id| *order.get(id.as_str()).unwrap_or(&usize::MAX));
+    }
+    groups.sort_by_key(|g| {
+        g.entry_ids
+            .first()
+            .and_then(|id| order.get(id.as_str()).copied())
+            .unwrap_or(usize::MAX)
+    });
+    groups
 }
 
 /// Classify a password's strength into a Finding Kind, or return
@@ -233,7 +329,10 @@ mod tests {
     fn healthy(id: &str) -> EntryInput {
         EntryInput {
             id: id.to_string(),
-            password: SecureString::from("correct horse battery staple"),
+            // Per-id suffix so the helper Entries don't reuse-group
+            // with one another. The string still scores ≥ 2 on zxcvbn
+            // because the diceware prefix dominates the entropy.
+            password: SecureString::from(format!("correct horse battery staple {id}")),
             expires: false,
             expiry_time: None,
         }
@@ -242,7 +341,7 @@ mod tests {
     fn expired(id: &str, now: DateTime<Utc>) -> EntryInput {
         EntryInput {
             id: id.to_string(),
-            password: SecureString::from("correct horse battery staple"),
+            password: SecureString::from(format!("correct horse battery staple {id}")),
             expires: true,
             expiry_time: Some(now - chrono::Duration::days(1)),
         }
@@ -448,6 +547,199 @@ mod tests {
         assert_eq!(FindingKind::PasswordVeryWeak.severity(), Severity::Critical);
         assert_eq!(report.totals.critical, 1);
         assert_eq!(report.totals.high, 0);
+    }
+
+    /// Two in-scope Entries sharing a byte-equal non-empty password
+    /// must each emit a `PasswordReused` Finding, and the report must
+    /// carry exactly one `ReuseGroup` whose `entry_ids` contain both
+    /// Entry ids. Pinned in the issue's acceptance criteria.
+    #[test]
+    fn two_entries_with_same_password_emit_reused_findings_and_one_group() {
+        let report = analyze(
+            vec![
+                with_password("a", "shared-passw0rd-Tr0ub4dor!"),
+                with_password("b", "shared-passw0rd-Tr0ub4dor!"),
+            ],
+            now_fixed(),
+        );
+
+        let reused: Vec<&Finding> = report
+            .findings
+            .iter()
+            .filter(|f| f.kind == FindingKind::PasswordReused)
+            .collect();
+        let reused_ids: HashSet<&str> = reused.iter().map(|f| f.entry_id.as_str()).collect();
+        assert_eq!(reused_ids, HashSet::from(["a", "b"]));
+
+        assert_eq!(report.reuse_groups.len(), 1);
+        let group_ids: HashSet<&str> = report.reuse_groups[0]
+            .entry_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(group_ids, HashSet::from(["a", "b"]));
+    }
+
+    /// Determinism: the per-analysis hash-key randomness must not
+    /// influence grouping outcomes. Two runs with the same input
+    /// Entries must produce `reuse_groups` whose memberships and
+    /// order match exactly. (The raw hash bytes underlying the
+    /// partition shift between runs, but `reuse_groups` only carries
+    /// `entry_ids`.) Pinned in the issue's acceptance criteria.
+    #[test]
+    fn reuse_groups_deterministic_across_runs() {
+        let inputs = || {
+            vec![
+                with_password("a", "Tr0ub4dor-staple-horse-d1"),
+                with_password("b", "Tr0ub4dor-staple-horse-d2"),
+                with_password("c", "Tr0ub4dor-staple-horse-d1"),
+                with_password("d", "Tr0ub4dor-staple-horse-d2"),
+                with_password("e", "Tr0ub4dor-staple-horse-d1"),
+            ]
+        };
+        let r1 = analyze(inputs(), now_fixed());
+        let r2 = analyze(inputs(), now_fixed());
+        assert_eq!(
+            r1.reuse_groups, r2.reuse_groups,
+            "reuse_groups must be deterministic across runs"
+        );
+        // Two groups expected: {a, c, e} and {b, d}, in first-seen
+        // input order. Pin the exact ordering to catch a regression
+        // that lets the hash-key randomness leak through.
+        assert_eq!(r1.reuse_groups.len(), 2);
+        assert_eq!(
+            r1.reuse_groups[0].entry_ids,
+            vec!["a".to_string(), "c".to_string(), "e".to_string()]
+        );
+        assert_eq!(
+            r1.reuse_groups[1].entry_ids,
+            vec!["b".to_string(), "d".to_string()]
+        );
+    }
+
+    /// An Entry that is both Reused (with one other Entry) and
+    /// zxcvbn-score-0 (Very Weak) emits two independent Findings —
+    /// remediations differ — but lands in the `critical` totals
+    /// bucket once. The reused partner is the only other Entry in
+    /// scope and emits its own Reused Finding; the unhealthy
+    /// denominator is two, not three. Pinned in the issue's
+    /// acceptance criteria.
+    #[test]
+    fn reused_and_very_weak_on_same_entry_emits_two_findings_one_unhealthy() {
+        // "password" is the canonical zxcvbn-score-0 string. Both
+        // Entries share it, so both also reuse-flag.
+        let report = analyze(
+            vec![
+                with_password("a", "password"),
+                with_password("b", "password"),
+            ],
+            now_fixed(),
+        );
+
+        // Both Entries get the Reused Finding (group of two).
+        let reused_count = report
+            .findings
+            .iter()
+            .filter(|f| f.kind == FindingKind::PasswordReused)
+            .count();
+        assert_eq!(reused_count, 2, "each member of the group must emit Reused");
+
+        // Both Entries also get Very Weak (zxcvbn score 0).
+        let very_weak_count = report
+            .findings
+            .iter()
+            .filter(|f| f.kind == FindingKind::PasswordVeryWeak)
+            .count();
+        assert_eq!(
+            very_weak_count, 2,
+            "each Entry must independently emit Very Weak"
+        );
+
+        // Critical wins over High when an Entry has Findings in both
+        // buckets. Both Entries land in `critical`.
+        assert_eq!(
+            report.totals,
+            HealthTotals {
+                critical: 2,
+                high: 0,
+                healthy: 0,
+                total: 2,
+            }
+        );
+    }
+
+    /// Three in-scope Entries sharing one byte-equal password produce
+    /// three `PasswordReused` Findings (one per Entry) and a single
+    /// `ReuseGroup` whose `entry_ids` enumerate all three members.
+    /// Pinned in the issue's acceptance criteria — proves the
+    /// grouping logic scales beyond the pair-only case.
+    #[test]
+    fn three_entries_with_same_password_emit_three_findings_one_group_with_three() {
+        let report = analyze(
+            vec![
+                with_password("a", "Tr0ub4dor-staple-horse-3"),
+                with_password("b", "Tr0ub4dor-staple-horse-3"),
+                with_password("c", "Tr0ub4dor-staple-horse-3"),
+            ],
+            now_fixed(),
+        );
+
+        let reused_ids: HashSet<&str> = report
+            .findings
+            .iter()
+            .filter(|f| f.kind == FindingKind::PasswordReused)
+            .map(|f| f.entry_id.as_str())
+            .collect();
+        assert_eq!(reused_ids, HashSet::from(["a", "b", "c"]));
+
+        assert_eq!(report.reuse_groups.len(), 1);
+        let group_ids: HashSet<&str> = report.reuse_groups[0]
+            .entry_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(group_ids, HashSet::from(["a", "b", "c"]));
+    }
+
+    /// Empty-string passwords must NOT reuse-group with one another:
+    /// per ADR 0002 they are "each has no secret" rather than "sharing
+    /// the same secret", and the Very-Weak finding carries the
+    /// remediation. Two empty-password Entries produce two
+    /// `PasswordVeryWeak` Findings, zero `PasswordReused` Findings,
+    /// and no `ReuseGroup`.
+    #[test]
+    fn empty_passwords_do_not_reuse_group_only_very_weak() {
+        let report = analyze(
+            vec![with_password("a", ""), with_password("b", "")],
+            now_fixed(),
+        );
+        let kinds: Vec<&FindingKind> = report.findings.iter().map(|f| &f.kind).collect();
+        assert!(
+            !kinds.contains(&&FindingKind::PasswordReused),
+            "empty passwords must not emit PasswordReused; got {kinds:?}"
+        );
+        assert_eq!(
+            kinds
+                .iter()
+                .filter(|k| **k == &FindingKind::PasswordVeryWeak)
+                .count(),
+            2,
+            "both empty-password Entries must each emit one PasswordVeryWeak; got {kinds:?}"
+        );
+        assert!(
+            report.reuse_groups.is_empty(),
+            "empty-password Entries must not produce a ReuseGroup; got {:?}",
+            report.reuse_groups
+        );
+    }
+
+    /// `PasswordReused` is a High-severity Finding Kind (per ADR 0002
+    /// → "Password Health Finding Kind"). Pinning the mapping protects
+    /// the totals-bucket math: an Entry that is only Reused must land
+    /// in `high`, not `critical`.
+    #[test]
+    fn password_reused_is_high_severity() {
+        assert_eq!(FindingKind::PasswordReused.severity(), Severity::High);
     }
 
     /// One expired Entry in a four-Entry Vault: 3 healthy / 4 total =

--- a/src-tauri/src/services/password_health/cache.rs
+++ b/src-tauri/src/services/password_health/cache.rs
@@ -110,6 +110,7 @@ mod tests {
             score,
             findings: Vec::new(),
             totals: super::super::analyzer::HealthTotals::default(),
+            reuse_groups: Vec::new(),
         }
     }
 

--- a/src-tauri/src/services/password_health/service.rs
+++ b/src-tauri/src/services/password_health/service.rs
@@ -39,6 +39,15 @@ use crate::services::kdbx::KdbxService;
 /// - Entries with an empty-string `Password` are **included**; they
 ///   contribute to the total-in-scope denominator and trigger the
 ///   special-cased Very-Weak Finding inside the analyzer.
+///
+/// `{REF:...}` references: the upstream `keepass 0.12.x` crate's
+/// `Entry::get_password` returns the literal field value and does
+/// not expose resolved placeholders. The analyzer therefore treats
+/// the literal `{REF:...}` string as the password and may emit a
+/// Very-Weak or unique-but-actually-shared classification for it.
+/// When the crate later exposes resolution, swap the call here for
+/// the resolved accessor — the analyzer itself does not need to
+/// change. Tracked in ADR 0002 → "Reference resolution".
 pub fn collect_entry_inputs(db: &Database) -> Vec<EntryInput> {
     let recycle_uuid = db.meta.recyclebin_uuid;
     db.iter_all_entries()

--- a/src/components/entries/EntryList.tsx
+++ b/src/components/entries/EntryList.tsx
@@ -42,6 +42,20 @@ export default function EntryList({ onEntrySelect }: EntryListProps) {
 
   const sortedEntries = useSortedEntries(entries, sortBy, sortOrder);
 
+  // Pre-index reuse-group sizes per Entry id so the per-row tooltip
+  // can stitch in "Reused (N entries)" without iterating the
+  // `reuseGroups` array for every row in the virtualized list.
+  const reusedGroupSizeByEntryId = useMemo(() => {
+    const map = new Map<string, number>();
+    if (!healthReport) return map;
+    for (const group of healthReport.reuseGroups) {
+      for (const id of group.entryIds) {
+        map.set(id, group.entryIds.length);
+      }
+    }
+    return map;
+  }, [healthReport]);
+
   const tagFilter = search.tag as string | undefined;
   const displayEntries = useMemo(
     () =>
@@ -133,6 +147,7 @@ export default function EntryList({ onEntrySelect }: EntryListProps) {
                 isSelected={entry.id === selectedEntryId}
                 onClick={handleItemClick}
                 findings={findingsForEntry(healthReport, entry.id)}
+                reusedGroupSize={reusedGroupSizeByEntryId.get(entry.id)}
               />
               <ItemSeparator />
             </div>

--- a/src/components/entries/EntryListItem.test.tsx
+++ b/src/components/entries/EntryListItem.test.tsx
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import EntryListItem from "./EntryListItem";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+// Override the global setup mock for this file so opts.count flows
+// through into the key — the production translation reads
+// `Reused ({{count}} entries)`, and we need a substitute the test
+// can introspect. We append `:<count>` so a key like
+// `passwordHealth.reused.tooltip` rendered with count 3 turns into
+// `passwordHealth.reused.tooltip:3`.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts.count === "number") {
+        return `${key}:${opts.count}`;
+      }
+      return key;
+    },
+    i18n: { language: "en", changeLanguage: vi.fn() },
+  }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  initReactI18next: {
+    type: "3rdParty",
+    init: () => {
+      /* noop */
+    },
+  },
+}));
+
+const baseProps = {
+  id: "entry-1",
+  groupId: "root",
+  title: "GitHub",
+  username: "octocat",
+  url: null,
+  notes: null,
+  iconId: 0,
+  customIconUuid: null,
+  tags: [],
+  customFields: {},
+  customFieldMeta: [],
+  createdAt: "",
+  modifiedAt: "",
+  accessedAt: "",
+  customIcons: {},
+};
+
+function renderItem(extra: Record<string, unknown>) {
+  return render(
+    <TooltipProvider>
+      <EntryListItem {...baseProps} {...extra} />
+    </TooltipProvider>
+  );
+}
+
+describe("EntryListItem findings indicator", () => {
+  // The indicator's aria-label is what a screen reader announces;
+  // when an Entry is reused we want that label to include the
+  // member count so the user knows the scale of the remediation
+  // ("Reused (3 entries)") rather than just "Reused".
+  it("includes Reused (N entries) in the aria-label when reusedGroupSize is set", () => {
+    renderItem({
+      findings: [{ entryId: "entry-1", kind: "password.reused" }],
+      reusedGroupSize: 3,
+    });
+    const icon = screen.getByLabelText(/passwordHealth\.reused\.tooltip/);
+    expect(icon.getAttribute("aria-label")).toContain("3");
+  });
+
+  // When an Entry has no reused finding, the prop is ignored — the
+  // tooltip is just the per-kind label list. Pinning this guards
+  // against a regression that always appends the reused-tooltip
+  // string regardless of the actual findings.
+  it("does not include the reused tooltip when there is no reused finding", () => {
+    renderItem({
+      findings: [{ entryId: "entry-1", kind: "password.expired" }],
+      reusedGroupSize: 5,
+    });
+    const icon = screen.getByLabelText(
+      "passwordHealth.findings.password.expired"
+    );
+    expect(icon.getAttribute("aria-label")).not.toContain(
+      "passwordHealth.reused.tooltip"
+    );
+  });
+});

--- a/src/components/entries/EntryListItem.test.tsx
+++ b/src/components/entries/EntryListItem.test.tsx
@@ -15,8 +15,8 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => {
-      if (opts && typeof opts.count === "number") {
-        return `${key}:${opts.count}`;
+      if (opts && typeof opts["count"] === "number") {
+        return `${key}:${opts["count"]}`;
       }
       return key;
     },

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -28,6 +28,13 @@ interface EntryListItemProps extends Entry {
   /// from `useEntryFindings(dbId, entry.id)` on the parent. An empty
   /// array renders no icon; one or more Findings render the warning.
   findings?: Finding[];
+  /// Size of the reuse group this Entry belongs to, when applicable
+  /// (≥ 2). Used to fill the "Reused (N entries)" tooltip — the
+  /// number is not derivable from the Finding alone, so the parent
+  /// passes it in. `undefined` when the Entry has no reused finding
+  /// or the report isn't loaded yet; falsy renders the plain kind
+  /// label without the count.
+  reusedGroupSize?: number;
 }
 
 const EntryListItem = memo(function EntryListItem({
@@ -40,6 +47,7 @@ const EntryListItem = memo(function EntryListItem({
   isSelected,
   onClick,
   findings,
+  reusedGroupSize,
 }: EntryListItemProps) {
   const iconComponent = getKeepassIcon(iconId ?? 0);
   const customIcon = customIconUuid ? customIcons[customIconUuid] : null;
@@ -78,7 +86,10 @@ const EntryListItem = memo(function EntryListItem({
         </ItemContent>
         <ItemActions className="shrink-0">
           {findings && findings.length > 0 && (
-            <FindingsIndicator findings={findings} />
+            <FindingsIndicator
+              findings={findings}
+              reusedGroupSize={reusedGroupSize}
+            />
           )}
         </ItemActions>
       </a>
@@ -91,14 +102,25 @@ const EntryListItem = memo(function EntryListItem({
 /// High-only findings keep the amber TriangleAlert. The tooltip and
 /// aria-label spell out each Finding Kind in plain language so screen
 /// readers don't read out enum identifiers.
-function FindingsIndicator({ findings }: Readonly<{ findings: Finding[] }>) {
+function FindingsIndicator({
+  findings,
+  reusedGroupSize,
+}: Readonly<{ findings: Finding[]; reusedGroupSize?: number }>) {
   const { t } = useTranslation();
   const hasCritical = findings.some((f) => severityOf(f.kind) === "critical");
   // De-duplicate Finding Kinds before formatting — an Entry with two
   // expired-style Findings (theoretical) should still show one row.
   const uniqueKinds = Array.from(new Set(findings.map((f) => f.kind)));
   const label = uniqueKinds
-    .map((kind) => t(`passwordHealth.findings.${kind}`))
+    .map((kind) => {
+      // Reused gets the member-count suffix from the parent. Without
+      // the count we fall back to the plain kind label so the
+      // indicator still renders when the report is still loading.
+      if (kind === "password.reused" && reusedGroupSize) {
+        return t("passwordHealth.reused.tooltip", { count: reusedGroupSize });
+      }
+      return t(`passwordHealth.findings.${kind}`);
+    })
     .join(" · ");
 
   const Icon = hasCritical ? OctagonAlert : TriangleAlert;

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -34,7 +34,7 @@ interface EntryListItemProps extends Entry {
   /// passes it in. `undefined` when the Entry has no reused finding
   /// or the report isn't loaded yet; falsy renders the plain kind
   /// label without the count.
-  reusedGroupSize?: number;
+  reusedGroupSize?: number | undefined;
 }
 
 const EntryListItem = memo(function EntryListItem({
@@ -105,7 +105,7 @@ const EntryListItem = memo(function EntryListItem({
 function FindingsIndicator({
   findings,
   reusedGroupSize,
-}: Readonly<{ findings: Finding[]; reusedGroupSize?: number }>) {
+}: Readonly<{ findings: Finding[]; reusedGroupSize?: number | undefined }>) {
   const { t } = useTranslation();
   const hasCritical = findings.some((f) => severityOf(f.kind) === "critical");
   // De-duplicate Finding Kinds before formatting — an Entry with two

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -18,6 +18,7 @@ import { usePasswordHealthReport } from "@/hooks/use-password-health";
 import { severityOf, type Severity } from "@/lib/password-health";
 import { useDatabaseTabs } from "@/stores/database-tabs";
 import type { Entry, Finding, PasswordHealthReport } from "@/lib/types";
+import { ReusedGroupRow } from "./ReusedGroupRow";
 
 interface PasswordHealthReportViewProps {
   dbId: string;
@@ -144,11 +145,22 @@ function TotalsCell({
 // Bucket each Entry by its highest-severity Finding so an Entry that
 // is both Very Weak and Expired surfaces only in the Critical section,
 // not both. Mirrors the totals-strip rule in the backend analyzer.
+//
+// `Reused` Findings are not surfaced as per-Entry rows — they live
+// in the dedicated `ReusedGroupRow` (one row per shared password,
+// inline-expandable) so the High section doesn't duplicate the group
+// membership. An Entry that is Reused-only therefore has no
+// per-Entry row at all; an Entry that is Reused + Very Weak still
+// appears in the Critical section because Very Weak wins on
+// severity and carries its own remediation message.
 function bucketEntriesBySeverity(
   findings: Finding[]
 ): Map<Severity, Map<string, Finding[]>> {
+  const findingsExcludingReused = findings.filter(
+    (f) => f.kind !== "password.reused"
+  );
   const highestPerEntry = new Map<string, Severity>();
-  for (const finding of findings) {
+  for (const finding of findingsExcludingReused) {
     const severity = severityOf(finding.kind);
     const prior = highestPerEntry.get(finding.entryId);
     if (prior === "critical") continue;
@@ -161,7 +173,7 @@ function bucketEntriesBySeverity(
     ["critical", new Map()],
     ["high", new Map()],
   ]);
-  for (const finding of findings) {
+  for (const finding of findingsExcludingReused) {
     const bucket = highestPerEntry.get(finding.entryId);
     if (!bucket) continue;
     const list = buckets.get(bucket)?.get(finding.entryId) ?? [];
@@ -193,7 +205,10 @@ function FindingsSection({
   const updateTabState = useDatabaseTabs((s) => s.updateTabState);
 
   const byEntry = bucketEntriesBySeverity(report.findings).get(severity);
-  if (!byEntry || byEntry.size === 0) {
+  // Reused groups live in the High section (per ADR 0002).
+  const reuseGroups = severity === "high" ? report.reuseGroups : [];
+  const perEntryCount = byEntry?.size ?? 0;
+  if (perEntryCount === 0 && reuseGroups.length === 0) {
     return null;
   }
 
@@ -234,33 +249,42 @@ function FindingsSection({
       </div>
       <p className="text-sm text-muted-foreground">{chrome.description}</p>
       <ul className="divide-y rounded-md border bg-card">
-        {Array.from(byEntry.entries()).map(([entryId, findings]) => {
-          const entry = entryById.get(entryId);
-          return (
-            <li
-              key={entryId}
-              className="flex items-center justify-between gap-3 px-4 py-3"
-            >
-              <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="truncate font-medium">
-                  {entry?.title ?? entryId}
-                </span>
-                <span className="text-xs text-muted-foreground">
-                  {findings
-                    .map((f) => t(`passwordHealth.findings.${f.kind}`))
-                    .join(" · ")}
-                </span>
-              </div>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => openEntry(entryId)}
+        {reuseGroups.map((group, index) => (
+          <ReusedGroupRow
+            key={`reuse-${index}-${group.entryIds[0]}`}
+            entryIds={group.entryIds}
+            entries={entries}
+            onOpenEntry={openEntry}
+          />
+        ))}
+        {byEntry &&
+          Array.from(byEntry.entries()).map(([entryId, findings]) => {
+            const entry = entryById.get(entryId);
+            return (
+              <li
+                key={entryId}
+                className="flex items-center justify-between gap-3 px-4 py-3"
               >
-                {t("passwordHealth.actions.openEntry")}
-              </Button>
-            </li>
-          );
-        })}
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="truncate font-medium">
+                    {entry?.title ?? entryId}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {findings
+                      .map((f) => t(`passwordHealth.findings.${f.kind}`))
+                      .join(" · ")}
+                  </span>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => openEntry(entryId)}
+                >
+                  {t("passwordHealth.actions.openEntry")}
+                </Button>
+              </li>
+            );
+          })}
       </ul>
     </section>
   );

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -15,7 +15,11 @@ import {
 import { useActiveDatabase } from "@/hooks/use-active-database";
 import { useEntries } from "@/hooks/use-entries";
 import { usePasswordHealthReport } from "@/hooks/use-password-health";
-import { severityOf, type Severity } from "@/lib/password-health";
+import {
+  reuseGroupsForHighSection,
+  severityOf,
+  type Severity,
+} from "@/lib/password-health";
 import { useDatabaseTabs } from "@/stores/database-tabs";
 import type { Entry, Finding, PasswordHealthReport } from "@/lib/types";
 import { ReusedGroupRow } from "./ReusedGroupRow";
@@ -205,8 +209,13 @@ function FindingsSection({
   const updateTabState = useDatabaseTabs((s) => s.updateTabState);
 
   const byEntry = bucketEntriesBySeverity(report.findings).get(severity);
-  // Reused groups live in the High section (per ADR 0002).
-  const reuseGroups = severity === "high" ? report.reuseGroups : [];
+  // Reused groups live in the High section (per ADR 0002), but a
+  // group whose every member is also Very Weak is hidden — those
+  // entries are bucketed Critical, so the High total subtracts them
+  // and the section would otherwise show "High 0" alongside a
+  // reused-password row.
+  const reuseGroups =
+    severity === "high" ? reuseGroupsForHighSection(report) : [];
   const perEntryCount = byEntry?.size ?? 0;
   if (perEntryCount === 0 && reuseGroups.length === 0) {
     return null;

--- a/src/components/security/PasswordHealthReportView.tsx
+++ b/src/components/security/PasswordHealthReportView.tsx
@@ -16,7 +16,7 @@ import { useActiveDatabase } from "@/hooks/use-active-database";
 import { useEntries } from "@/hooks/use-entries";
 import { usePasswordHealthReport } from "@/hooks/use-password-health";
 import {
-  reuseGroupsForHighSection,
+  reuseGroupsForSection,
   severityOf,
   type Severity,
 } from "@/lib/password-health";
@@ -209,13 +209,13 @@ function FindingsSection({
   const updateTabState = useDatabaseTabs((s) => s.updateTabState);
 
   const byEntry = bucketEntriesBySeverity(report.findings).get(severity);
-  // Reused groups live in the High section (per ADR 0002), but a
-  // group whose every member is also Very Weak is hidden — those
-  // entries are bucketed Critical, so the High total subtracts them
-  // and the section would otherwise show "High 0" alongside a
-  // reused-password row.
-  const reuseGroups =
-    severity === "high" ? reuseGroupsForHighSection(report) : [];
+  // Reused groups default to High (per ADR 0002), but a group whose
+  // every member is also Very Weak is promoted to Critical — those
+  // entries are bucketed Critical, so leaving the group in High
+  // would mean "High 0" plus a reused-password row. The helper
+  // partitions the report's `reuseGroups` between the two sections
+  // so every emitted group renders exactly once.
+  const reuseGroups = reuseGroupsForSection(report, severity);
   const perEntryCount = byEntry?.size ?? 0;
   if (perEntryCount === 0 && reuseGroups.length === 0) {
     return null;

--- a/src/components/security/ReusedGroupRow.test.tsx
+++ b/src/components/security/ReusedGroupRow.test.tsx
@@ -100,7 +100,9 @@ describe("ReusedGroupRow", () => {
     const openButtons = screen.getAllByRole("button", {
       name: "passwordHealth.actions.openEntry",
     });
-    fireEvent.click(openButtons[1]);
+    const secondMemberButton = openButtons[1];
+    expect(secondMemberButton).toBeDefined();
+    fireEvent.click(secondMemberButton as HTMLElement);
     expect(onOpenEntry).toHaveBeenCalledWith("b");
   });
 

--- a/src/components/security/ReusedGroupRow.test.tsx
+++ b/src/components/security/ReusedGroupRow.test.tsx
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ReusedGroupRow } from "./ReusedGroupRow";
+import type { Entry } from "@/lib/types";
+
+// Minimal Entry stub — only the title / id pair drives the row, the
+// rest of the Entry shape is irrelevant to the inline-expand UI.
+function entry(id: string, title: string): Entry {
+  return {
+    id,
+    groupId: "root",
+    title,
+    username: "",
+    tags: [],
+    customFields: {},
+    customFieldMeta: [],
+    createdAt: "",
+    modifiedAt: "",
+    accessedAt: "",
+  };
+}
+
+const memberIds = ["a", "b", "c"];
+const entries = [
+  entry("a", "GitHub"),
+  entry("b", "GitLab"),
+  entry("c", "Bitbucket"),
+];
+
+describe("ReusedGroupRow", () => {
+  // The collapsed row is the default. It announces the member count
+  // (the High-section "Reused (N entries)" copy) so a screen reader
+  // user knows what they're expanding before they expand it. The
+  // member titles are not yet in the DOM.
+  it("renders collapsed by default with the member count", () => {
+    render(
+      <ReusedGroupRow
+        entryIds={memberIds}
+        entries={entries}
+        onOpenEntry={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByText("passwordHealth.findings.password.reused")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("passwordHealth.reused.memberCount")
+    ).toBeInTheDocument();
+    // Members are hidden until the row is expanded.
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+    expect(screen.queryByText("GitLab")).not.toBeInTheDocument();
+  });
+
+  // Clicking the toggle expands the row inline (no navigation): each
+  // member Entry's title appears with an "Open Entry" action. The
+  // expand toggle stays in place — collapsing must be possible
+  // without leaving the report view.
+  it("expands inline to show member titles and Open Entry buttons", () => {
+    render(
+      <ReusedGroupRow
+        entryIds={memberIds}
+        entries={entries}
+        onOpenEntry={vi.fn()}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "passwordHealth.reused.expand" })
+    );
+
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByText("GitLab")).toBeInTheDocument();
+    expect(screen.getByText("Bitbucket")).toBeInTheDocument();
+    // One Open Entry button per member.
+    expect(
+      screen.getAllByRole("button", {
+        name: "passwordHealth.actions.openEntry",
+      })
+    ).toHaveLength(memberIds.length);
+  });
+
+  // Clicking Open Entry on a member fires `onOpenEntry(entryId)` so
+  // the parent can navigate. The row stays expanded — the click is
+  // not a side effect of collapse.
+  it("calls onOpenEntry with the member id when Open Entry is clicked", () => {
+    const onOpenEntry = vi.fn();
+    render(
+      <ReusedGroupRow
+        entryIds={memberIds}
+        entries={entries}
+        onOpenEntry={onOpenEntry}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "passwordHealth.reused.expand" })
+    );
+    const openButtons = screen.getAllByRole("button", {
+      name: "passwordHealth.actions.openEntry",
+    });
+    fireEvent.click(openButtons[1]);
+    expect(onOpenEntry).toHaveBeenCalledWith("b");
+  });
+
+  // Toggling collapses the row again — pinning bi-directional
+  // behaviour so a future refactor that only handles the expand
+  // half (e.g. by switching to a one-shot disclosure) fails loudly.
+  it("collapses back when the toggle is clicked twice", () => {
+    render(
+      <ReusedGroupRow
+        entryIds={memberIds}
+        entries={entries}
+        onOpenEntry={vi.fn()}
+      />
+    );
+    const toggle = screen.getByRole("button", {
+      name: "passwordHealth.reused.expand",
+    });
+    fireEvent.click(toggle);
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", { name: "passwordHealth.reused.collapse" })
+    );
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
+  // A member id with no matching Entry (e.g. the Entry list is stale
+  // while a re-fetch is in flight) must still render so the row
+  // count stays accurate. The id is the fallback label.
+  it("falls back to the entry id when no matching Entry is in the lookup", () => {
+    render(
+      <ReusedGroupRow
+        entryIds={["a", "missing"]}
+        entries={[entry("a", "GitHub")]}
+        onOpenEntry={vi.fn()}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "passwordHealth.reused.expand" })
+    );
+    expect(screen.getByText("missing")).toBeInTheDocument();
+  });
+});

--- a/src/components/security/ReusedGroupRow.tsx
+++ b/src/components/security/ReusedGroupRow.tsx
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { Button } from "@/components/ui/button";
+import type { Entry } from "@/lib/types";
+
+interface ReusedGroupRowProps {
+  /// Member Entry ids. Always size ≥ 2 — the backend elides singleton
+  /// groups before serializing, so the row's existence already means
+  /// "two or more Entries share this password".
+  entryIds: string[];
+  /// Live Entry list used to look up titles. A stale list (member id
+  /// not present) falls back to the id string so the row stays
+  /// readable while a re-fetch completes.
+  entries: Entry[];
+  /// Parent navigates to the Entry detail view. Kept as a callback so
+  /// the row stays decoupled from the router and the tab store and
+  /// is testable in isolation.
+  onOpenEntry: (entryId: string) => void;
+}
+
+export function ReusedGroupRow({
+  entryIds,
+  entries,
+  onOpenEntry,
+}: Readonly<ReusedGroupRowProps>) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const entryById = new Map(entries.map((e) => [e.id, e]));
+
+  return (
+    <li className="flex flex-col gap-2 px-4 py-3">
+      <button
+        type="button"
+        className="flex items-center justify-between gap-3 text-left"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-label={
+          expanded
+            ? t("passwordHealth.reused.collapse")
+            : t("passwordHealth.reused.expand")
+        }
+      >
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <span className="font-medium">
+            {t("passwordHealth.findings.password.reused")}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {t("passwordHealth.reused.memberCount", { count: entryIds.length })}
+          </span>
+        </div>
+        {expanded ? (
+          <ChevronDown className="size-4 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="size-4 text-muted-foreground" />
+        )}
+      </button>
+
+      {expanded && (
+        <ul className="flex flex-col divide-y rounded-md border bg-background">
+          {entryIds.map((memberId) => {
+            const memberEntry = entryById.get(memberId);
+            return (
+              <li
+                key={memberId}
+                className="flex items-center justify-between gap-3 px-3 py-2"
+              >
+                <span className="truncate text-sm">
+                  {memberEntry?.title ?? memberId}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => onOpenEntry(memberId)}
+                >
+                  {t("passwordHealth.actions.openEntry")}
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/src/lib/__tests__/password-health.test.ts
+++ b/src/lib/__tests__/password-health.test.ts
@@ -80,6 +80,14 @@ describe("severityOf", () => {
   it("maps password.weak to high", () => {
     expect(severityOf("password.weak")).toBe("high");
   });
+
+  // Pinning the wire identifier *and* the severity here catches both
+  // a backend rename (the Zod schema would reject the parse) and a
+  // future bucket reshuffle that would put reused into Critical and
+  // bring it to parity with very_weak in the report-view layout.
+  it("maps password.reused to high", () => {
+    expect(severityOf("password.reused")).toBe("high");
+  });
 });
 
 describe("summarize with critical findings", () => {

--- a/src/lib/__tests__/password-health.test.ts
+++ b/src/lib/__tests__/password-health.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { PasswordHealthReport } from "@/lib/types";
 import {
   findingsForEntry,
-  reuseGroupsForHighSection,
+  reuseGroupsForSection,
   severityOf,
   summarize,
 } from "@/lib/password-health";
@@ -139,11 +139,11 @@ describe("summarize with critical findings", () => {
   });
 });
 
-describe("reuseGroupsForHighSection", () => {
+describe("reuseGroupsForSection", () => {
   // The common case: members of a reuse group have no other Findings
   // (or only High Findings) and the group must appear in the High
   // section so the report agrees with the High totals strip.
-  it("keeps a reuse group when at least one member has no Critical Finding", () => {
+  it("returns a reuse group in 'high' when every member is High-only", () => {
     const report: PasswordHealthReport = {
       score: 50,
       findings: [
@@ -153,19 +153,20 @@ describe("reuseGroupsForHighSection", () => {
       totals: { critical: 0, high: 2, healthy: 0, total: 2 },
       reuseGroups: [{ entryIds: ["a", "b"] }],
     };
-    expect(reuseGroupsForHighSection(report)).toEqual([
+    expect(reuseGroupsForSection(report, "high")).toEqual([
       { entryIds: ["a", "b"] },
     ]);
+    expect(reuseGroupsForSection(report, "critical")).toEqual([]);
   });
 
   // Both members of the group are also Very Weak. The backend totals
-  // intentionally count them as Critical and remove them from High,
-  // so the High section would show "High 0" alongside a reused row —
-  // confusing. The group must be hidden from the High section; the
-  // per-Entry Critical rows already surface the reuse signal because
-  // each one carries the Very Weak Finding from the same shared
-  // password. Pinned in the PR-256 review.
-  it("drops a reuse group whose every member is in the Critical bucket", () => {
+  // count them as Critical and remove them from High, so rendering
+  // the reuse group in High would produce "High 0" alongside a
+  // reused-password row. Moving the group to Critical keeps the
+  // shared-password signal visible — different remediation from
+  // Very Weak — without misleading the totals strip. Pinned in the
+  // PR-256 review.
+  it("returns a reuse group in 'critical' when every member is Critical", () => {
     const report: PasswordHealthReport = {
       score: 0,
       findings: [
@@ -177,14 +178,19 @@ describe("reuseGroupsForHighSection", () => {
       totals: { critical: 2, high: 0, healthy: 0, total: 2 },
       reuseGroups: [{ entryIds: ["a", "b"] }],
     };
-    expect(reuseGroupsForHighSection(report)).toEqual([]);
+    expect(reuseGroupsForSection(report, "critical")).toEqual([
+      { entryIds: ["a", "b"] },
+    ]);
+    expect(reuseGroupsForSection(report, "high")).toEqual([]);
   });
 
   // Mixed group: one member is Very Weak (Critical bucket), the
-  // others are not. The group still renders in High because the
+  // others are not. The group renders in High because the
   // shared-password problem applies to the non-Critical members —
-  // their remediation depends on knowing the group exists.
-  it("keeps a mixed group where at least one member is High-only", () => {
+  // their remediation depends on knowing the group exists. Pinning
+  // the rule "any non-Critical member ⇒ High" so a future refactor
+  // can't quietly flip mixed groups into Critical.
+  it("returns a mixed group in 'high' when at least one member is non-Critical", () => {
     const report: PasswordHealthReport = {
       score: 33,
       findings: [
@@ -196,17 +202,18 @@ describe("reuseGroupsForHighSection", () => {
       totals: { critical: 1, high: 2, healthy: 0, total: 3 },
       reuseGroups: [{ entryIds: ["a", "b", "c"] }],
     };
-    expect(reuseGroupsForHighSection(report)).toEqual([
+    expect(reuseGroupsForSection(report, "high")).toEqual([
       { entryIds: ["a", "b", "c"] },
     ]);
+    expect(reuseGroupsForSection(report, "critical")).toEqual([]);
   });
 
   // The helper accepts a possibly-undefined report so callers don't
   // need to gate it; pre-loaded states return an empty list rather
   // than throwing.
   it("returns [] for null/undefined reports", () => {
-    expect(reuseGroupsForHighSection(null)).toEqual([]);
-    expect(reuseGroupsForHighSection(undefined)).toEqual([]);
+    expect(reuseGroupsForSection(null, "high")).toEqual([]);
+    expect(reuseGroupsForSection(undefined, "critical")).toEqual([]);
   });
 });
 

--- a/src/lib/__tests__/password-health.test.ts
+++ b/src/lib/__tests__/password-health.test.ts
@@ -3,7 +3,12 @@
 import { describe, expect, it } from "vitest";
 
 import type { PasswordHealthReport } from "@/lib/types";
-import { findingsForEntry, severityOf, summarize } from "@/lib/password-health";
+import {
+  findingsForEntry,
+  reuseGroupsForHighSection,
+  severityOf,
+  summarize,
+} from "@/lib/password-health";
 
 const emptyReport: PasswordHealthReport = {
   score: null,
@@ -131,6 +136,77 @@ describe("summarize with critical findings", () => {
       totalUnhealthy: 1,
       highestSeverity: "critical",
     });
+  });
+});
+
+describe("reuseGroupsForHighSection", () => {
+  // The common case: members of a reuse group have no other Findings
+  // (or only High Findings) and the group must appear in the High
+  // section so the report agrees with the High totals strip.
+  it("keeps a reuse group when at least one member has no Critical Finding", () => {
+    const report: PasswordHealthReport = {
+      score: 50,
+      findings: [
+        { entryId: "a", kind: "password.reused" },
+        { entryId: "b", kind: "password.reused" },
+      ],
+      totals: { critical: 0, high: 2, healthy: 0, total: 2 },
+      reuseGroups: [{ entryIds: ["a", "b"] }],
+    };
+    expect(reuseGroupsForHighSection(report)).toEqual([
+      { entryIds: ["a", "b"] },
+    ]);
+  });
+
+  // Both members of the group are also Very Weak. The backend totals
+  // intentionally count them as Critical and remove them from High,
+  // so the High section would show "High 0" alongside a reused row —
+  // confusing. The group must be hidden from the High section; the
+  // per-Entry Critical rows already surface the reuse signal because
+  // each one carries the Very Weak Finding from the same shared
+  // password. Pinned in the PR-256 review.
+  it("drops a reuse group whose every member is in the Critical bucket", () => {
+    const report: PasswordHealthReport = {
+      score: 0,
+      findings: [
+        { entryId: "a", kind: "password.very_weak" },
+        { entryId: "a", kind: "password.reused" },
+        { entryId: "b", kind: "password.very_weak" },
+        { entryId: "b", kind: "password.reused" },
+      ],
+      totals: { critical: 2, high: 0, healthy: 0, total: 2 },
+      reuseGroups: [{ entryIds: ["a", "b"] }],
+    };
+    expect(reuseGroupsForHighSection(report)).toEqual([]);
+  });
+
+  // Mixed group: one member is Very Weak (Critical bucket), the
+  // others are not. The group still renders in High because the
+  // shared-password problem applies to the non-Critical members —
+  // their remediation depends on knowing the group exists.
+  it("keeps a mixed group where at least one member is High-only", () => {
+    const report: PasswordHealthReport = {
+      score: 33,
+      findings: [
+        { entryId: "a", kind: "password.very_weak" },
+        { entryId: "a", kind: "password.reused" },
+        { entryId: "b", kind: "password.reused" },
+        { entryId: "c", kind: "password.reused" },
+      ],
+      totals: { critical: 1, high: 2, healthy: 0, total: 3 },
+      reuseGroups: [{ entryIds: ["a", "b", "c"] }],
+    };
+    expect(reuseGroupsForHighSection(report)).toEqual([
+      { entryIds: ["a", "b", "c"] },
+    ]);
+  });
+
+  // The helper accepts a possibly-undefined report so callers don't
+  // need to gate it; pre-loaded states return an empty list rather
+  // than throwing.
+  it("returns [] for null/undefined reports", () => {
+    expect(reuseGroupsForHighSection(null)).toEqual([]);
+    expect(reuseGroupsForHighSection(undefined)).toEqual([]);
   });
 });
 

--- a/src/lib/password-health.ts
+++ b/src/lib/password-health.ts
@@ -6,7 +6,12 @@
 //! pure derivations (highest-severity per Entry, sidebar summary) that
 //! the route view and sidebar badge read.
 
-import type { Finding, FindingKind, PasswordHealthReport } from "./types";
+import type {
+  Finding,
+  FindingKind,
+  PasswordHealthReport,
+  ReuseGroup,
+} from "./types";
 
 /// Severity bucket a Finding Kind belongs to. Mirrors the backend's
 /// `analyzer::Severity`: `very_weak` is Critical, every other Finding
@@ -71,6 +76,33 @@ export function summarize(
     totalUnhealthy: seen.size,
     highestSeverity: highest,
   };
+}
+
+/// Reuse groups that should render in the High section of the report
+/// view. Drops groups whose every member is already in the Critical
+/// bucket (e.g. two Entries sharing a zxcvbn score-0 password) — the
+/// backend's `high` total intentionally subtracts those Entries, so
+/// rendering a "Reused" row in High when `High: 0` would mislead the
+/// reader. The Critical per-Entry rows already surface the reuse
+/// signal via their Very-Weak finding.
+///
+/// A member is in the Critical bucket iff it has at least one
+/// non-`password.reused` Finding whose kind maps to `critical` —
+/// matches the bucketing rule in `PasswordHealthReportView`.
+export function reuseGroupsForHighSection(
+  report: PasswordHealthReport | null | undefined
+): ReuseGroup[] {
+  if (!report) return [];
+  const criticalEntryIds = new Set<string>();
+  for (const finding of report.findings) {
+    if (finding.kind === "password.reused") continue;
+    if (severityOf(finding.kind) === "critical") {
+      criticalEntryIds.add(finding.entryId);
+    }
+  }
+  return report.reuseGroups.filter((group) =>
+    group.entryIds.some((id) => !criticalEntryIds.has(id))
+  );
 }
 
 /// Returns every Finding scoped to a given Entry id, in the order the

--- a/src/lib/password-health.ts
+++ b/src/lib/password-health.ts
@@ -78,19 +78,24 @@ export function summarize(
   };
 }
 
-/// Reuse groups that should render in the High section of the report
-/// view. Drops groups whose every member is already in the Critical
-/// bucket (e.g. two Entries sharing a zxcvbn score-0 password) — the
-/// backend's `high` total intentionally subtracts those Entries, so
-/// rendering a "Reused" row in High when `High: 0` would mislead the
-/// reader. The Critical per-Entry rows already surface the reuse
-/// signal via their Very-Weak finding.
+/// Reuse groups that should render in the requested section of the
+/// report view. A group's "section severity" is the worst-case
+/// severity of any of its members:
+/// - if at least one member has a non-`password.reused` Critical
+///   Finding (Very Weak), the whole group lives in Critical;
+/// - otherwise it lives in High (the default per ADR 0002).
 ///
-/// A member is in the Critical bucket iff it has at least one
-/// non-`password.reused` Finding whose kind maps to `critical` —
-/// matches the bucketing rule in `PasswordHealthReportView`.
-export function reuseGroupsForHighSection(
-  report: PasswordHealthReport | null | undefined
+/// This keeps every emitted reuse group visible somewhere — moving
+/// instead of hiding — so the inline-expandable "one row per shared
+/// password" UX survives the case where every member also has Very
+/// Weak. It also keeps the totals strip honest: a Critical-bucketed
+/// Entry no longer adds a row to a "High 0" section.
+///
+/// Membership in the Critical bucket mirrors the rule in
+/// `PasswordHealthReportView::bucketEntriesBySeverity`.
+export function reuseGroupsForSection(
+  report: PasswordHealthReport | null | undefined,
+  severity: Severity
 ): ReuseGroup[] {
   if (!report) return [];
   const criticalEntryIds = new Set<string>();
@@ -100,9 +105,10 @@ export function reuseGroupsForHighSection(
       criticalEntryIds.add(finding.entryId);
     }
   }
-  return report.reuseGroups.filter((group) =>
-    group.entryIds.some((id) => !criticalEntryIds.has(id))
-  );
+  return report.reuseGroups.filter((group) => {
+    const allCritical = group.entryIds.every((id) => criticalEntryIds.has(id));
+    return severity === "critical" ? allCritical : !allCritical;
+  });
 }
 
 /// Returns every Finding scoped to a given Entry id, in the order the

--- a/src/lib/password-health.ts
+++ b/src/lib/password-health.ts
@@ -16,7 +16,12 @@ export type Severity = "critical" | "high";
 
 export function severityOf(kind: FindingKind): Severity {
   if (kind === "password.very_weak") return "critical";
-  if (kind === "password.weak" || kind === "password.expired") return "high";
+  if (
+    kind === "password.weak" ||
+    kind === "password.reused" ||
+    kind === "password.expired"
+  )
+    return "high";
   // Exhaustiveness lives at the union boundary — adding a new Finding
   // Kind in `types.ts` makes this `never` cast fail to compile.
   const exhaustive: never = kind;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -416,6 +416,7 @@ export type AuditStatus = z.infer<typeof AuditStatusSchema>;
 export const FindingKindSchema = z.enum([
   "password.very_weak",
   "password.weak",
+  "password.reused",
   "password.expired",
 ]);
 export type FindingKind = z.infer<typeof FindingKindSchema>;
@@ -434,9 +435,12 @@ export const HealthTotalsSchema = z.object({
 });
 export type HealthTotals = z.infer<typeof HealthTotalsSchema>;
 
+/// Group of in-scope Entries whose passwords are byte-equal. The
+/// backend hashes with a per-analysis-run keyed BLAKE3; the hash bytes
+/// never cross IPC. Members always count ≥ 2 — singleton groups are
+/// elided before serialization.
 export const ReuseGroupSchema = z.object({
-  passwordHash: z.string().min(1),
-  entryIds: z.array(z.string().min(1)),
+  entryIds: z.array(z.string().min(1)).min(2),
 });
 export type ReuseGroup = z.infer<typeof ReuseGroupSchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -656,8 +656,17 @@
       "password": {
         "very_weak": "Sehr schwaches Passwort",
         "weak": "Schwaches Passwort",
+        "reused": "Wiederverwendetes Passwort",
         "expired": "Abgelaufen"
       }
+    },
+    "reused": {
+      "memberCount_one": "{{count}} Eintrag teilt dieses Passwort",
+      "memberCount_other": "{{count}} Einträge teilen dieses Passwort",
+      "tooltip_one": "Wiederverwendet ({{count}} Eintrag)",
+      "tooltip_other": "Wiederverwendet ({{count}} Einträge)",
+      "expand": "Einträge mit demselben Passwort anzeigen",
+      "collapse": "Einträge mit demselben Passwort ausblenden"
     },
     "actions": {
       "openEntry": "Eintrag öffnen"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -681,8 +681,17 @@
       "password": {
         "very_weak": "Very weak password",
         "weak": "Weak password",
+        "reused": "Reused password",
         "expired": "Expired"
       }
+    },
+    "reused": {
+      "memberCount_one": "{{count}} entry shares this password",
+      "memberCount_other": "{{count}} entries share this password",
+      "tooltip_one": "Reused ({{count}} entry)",
+      "tooltip_other": "Reused ({{count}} entries)",
+      "expand": "Show entries that share this password",
+      "collapse": "Hide entries that share this password"
     },
     "actions": {
       "openEntry": "Open Entry"

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -656,8 +656,17 @@
       "password": {
         "very_weak": "Contraseña muy débil",
         "weak": "Contraseña débil",
+        "reused": "Contraseña reutilizada",
         "expired": "Caducada"
       }
+    },
+    "reused": {
+      "memberCount_one": "{{count}} entrada comparte esta contraseña",
+      "memberCount_other": "{{count}} entradas comparten esta contraseña",
+      "tooltip_one": "Reutilizada ({{count}} entrada)",
+      "tooltip_other": "Reutilizada ({{count}} entradas)",
+      "expand": "Mostrar entradas que comparten esta contraseña",
+      "collapse": "Ocultar entradas que comparten esta contraseña"
     },
     "actions": {
       "openEntry": "Abrir entrada"

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -656,8 +656,17 @@
       "password": {
         "very_weak": "Mot de passe très faible",
         "weak": "Mot de passe faible",
+        "reused": "Mot de passe réutilisé",
         "expired": "Expiré"
       }
+    },
+    "reused": {
+      "memberCount_one": "{{count}} entrée partage ce mot de passe",
+      "memberCount_other": "{{count}} entrées partagent ce mot de passe",
+      "tooltip_one": "Réutilisé ({{count}} entrée)",
+      "tooltip_other": "Réutilisé ({{count}} entrées)",
+      "expand": "Afficher les entrées partageant ce mot de passe",
+      "collapse": "Masquer les entrées partageant ce mot de passe"
     },
     "actions": {
       "openEntry": "Ouvrir l'entrée"

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -656,8 +656,19 @@
       "password": {
         "very_weak": "Vrlo slaba lozinka",
         "weak": "Slaba lozinka",
+        "reused": "Ponovo upotrebljena lozinka",
         "expired": "Isteklo"
       }
+    },
+    "reused": {
+      "memberCount_one": "{{count}} unos deli ovu lozinku",
+      "memberCount_few": "{{count}} unosa dele ovu lozinku",
+      "memberCount_other": "{{count}} unosa deli ovu lozinku",
+      "tooltip_one": "Ponovo upotrebljena ({{count}} unos)",
+      "tooltip_few": "Ponovo upotrebljena ({{count}} unosa)",
+      "tooltip_other": "Ponovo upotrebljena ({{count}} unosa)",
+      "expand": "Prikaži unose koji dele ovu lozinku",
+      "collapse": "Sakrij unose koji dele ovu lozinku"
     },
     "actions": {
       "openEntry": "Otvori unos"


### PR DESCRIPTION
Closes #243.

## Summary
- **Backend**: keyed-BLAKE3 reuse grouping in the Password Health analyzer with a fresh random key per analysis run — in-memory hash bytes are unlinkable across runs but the partition is deterministic. Empty-string passwords are excluded from grouping (Very-Weak covers them). Each member of a group ≥ 2 emits a `password.reused` finding; one `ReuseGroup { entry_ids }` per cluster lands on the report DTO (`entryIds` only on the wire — hash bytes never cross IPC).
- **Frontend**: Report view renders each reuse group as a single inline-expandable row in the High section (toggle expand/collapse without navigating away). `EntryListItem`'s tooltip on a reused Entry surfaces "Reused (N entries)" using the member count from `report.reuseGroups`. Reused-only Findings no longer surface as separate per-Entry rows; Entries that are Reused + Very Weak still appear in Critical because Very Weak wins on severity.
- **i18n**: Translations added in en/de/es/fr/sr with appropriate plural forms (`_one`/`_other`, plus `_few` for sr).
- **REF resolution**: keepass-rs 0.12 doesn't expose resolved `{REF:...}` references, so the analyzer hashes the literal string — documented inline in `service.rs`. When the crate later exposes resolution, the analyzer itself doesn't need to change.

## Test plan
- [ ] Analyzer unit tests cover all acceptance criteria: 2-entry reuse, 3-entry reuse, empty-string exclusion, Reused + Very-Weak overlap (one unhealthy in Critical bucket), determinism across runs, and `PasswordReused` severity classification.
- [ ] DTO tests cover the namespaced `"password.reused"` wire string and the `entryIds`-only `ReuseGroupDto` JSON shape.
- [ ] `ReusedGroupRow` tests cover: collapsed-by-default, expand to reveal member titles + Open Entry buttons, click Open Entry → `onOpenEntry(memberId)`, toggle back to collapsed, fallback to id when the Entry lookup is stale.
- [ ] `EntryListItem` test pins that the tooltip aria-label includes the member count when the Entry is reused, and ignores `reusedGroupSize` when there's no reused Finding.
- [ ] `severityOf("password.reused")` returns `"high"`.
- [ ] Manual: open a Vault with two Entries that share a password; verify both surface the High warning icon in the entry list, the report view shows one inline-expandable reused row in the High section, expanding lists both members with Open Entry buttons, and `EntryListItem` tooltip reads "Reused (2 entries)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)