### PR TITLE
feat(ui): entry expiry editor field (checkbox + presets + picker)

### DIFF
--- a/src/components/entries/EntryEditForm.tsx
+++ b/src/components/entries/EntryEditForm.tsx
@@ -2,6 +2,7 @@ import { Loader2 } from "lucide-react";
 import { CustomFieldsEditor } from "@/components/entries/custom-fields-editor";
 import { FieldGroup } from "@/components/ui/field";
 import {
+  EntryExpiryField,
   EntryFormActions,
   EntryGroupField,
   EntryNotesField,
@@ -138,6 +139,7 @@ export function EntryEditForm({
           watchedPassword={watchedPassword}
           onUseGeneratedPassword={setGeneratedPassword}
         />
+        <EntryExpiryField control={form.control} isPending={isPending} />
         <EntryUrlField control={form.control} isPending={isPending} />
         <EntryTagsField
           control={form.control}

--- a/src/components/entries/EntryEditForm.tsx
+++ b/src/components/entries/EntryEditForm.tsx
@@ -38,7 +38,7 @@ export function EntryEditForm({
   onSave,
   onCancel,
   onDirtyChange,
-}: EntryEditFormProps) {
+}: Readonly<EntryEditFormProps>) {
   const {
     form,
     isEditMode,

--- a/src/components/entries/__tests__/EntryEditForm.test.tsx
+++ b/src/components/entries/__tests__/EntryEditForm.test.tsx
@@ -185,7 +185,7 @@ function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  function TestWrapper({ children }: { children: React.ReactNode }) {
+  function TestWrapper({ children }: Readonly<{ children: React.ReactNode }>) {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );

--- a/src/components/entries/__tests__/EntryEditForm.test.tsx
+++ b/src/components/entries/__tests__/EntryEditForm.test.tsx
@@ -943,4 +943,147 @@ describe("EntryEditForm", () => {
       expect(mockFetchFavicon).toHaveBeenCalledWith("db-1", "entry-1", false);
     });
   });
+
+  describe("expiry", () => {
+    const mockEntryWithExpiry: Entry = {
+      ...mockEntry,
+      id: "entry-expiry",
+      expires: true,
+      expiryTime: "2027-06-15T10:30:00.000Z",
+    };
+
+    it("renders the expiry checkbox after the password field, off by default", () => {
+      render(
+        <EntryEditForm
+          dbId="db-1"
+          groupId="group-1"
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: "entries.form.expiry.label",
+      });
+      expect(checkbox).toBeInTheDocument();
+      expect(checkbox).toHaveAttribute("data-state", "unchecked");
+
+      const password = screen.getByPlaceholderText(
+        "entries.form.passwordPlaceholder"
+      );
+      expect(
+        password.compareDocumentPosition(checkbox) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy();
+    });
+
+    it("hides the preset dropdown and picker until the checkbox is ticked", () => {
+      const { container } = render(
+        <EntryEditForm
+          dbId="db-1"
+          groupId="group-1"
+          onSave={vi.fn()}
+          onCancel={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      expect(
+        container.querySelector('[data-slot="date-time-picker-trigger"]')
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(
+        screen.getByRole("checkbox", { name: "entries.form.expiry.label" })
+      );
+
+      const trigger = container.querySelector(
+        '[data-slot="date-time-picker-trigger"]'
+      );
+      expect(trigger).toBeInTheDocument();
+      // First tick pre-selects "1 year", so the picker shows a value rather
+      // than its empty placeholder.
+      expect(trigger).not.toHaveTextContent(
+        "entries.form.expiry.pickPlaceholder"
+      );
+    });
+
+    it("does not send expiry on create when the checkbox is off", async () => {
+      const onSave = vi.fn();
+      mockCreateEntry.mockResolvedValueOnce({ ...mockEntry, id: "new-1" });
+
+      render(
+        <EntryEditForm
+          dbId="db-1"
+          groupId="group-1"
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      await act(async () => {
+        fireEvent.change(
+          screen.getByPlaceholderText("entries.form.titlePlaceholder"),
+          { target: { value: "No Expiry" } }
+        );
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByText("entries.form.createEntry"));
+      });
+
+      await waitFor(() => {
+        expect(mockCreateEntry).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              expires: false,
+              expiryTime: undefined,
+            }),
+          })
+        );
+      });
+    });
+
+    it("loads an existing entry's expiry and persists it on update", async () => {
+      const onSave = vi.fn();
+      mockUpdateEntry.mockResolvedValueOnce(mockEntryWithExpiry);
+
+      render(
+        <EntryEditForm
+          entry={mockEntryWithExpiry}
+          dbId="db-1"
+          groupId="group-1"
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />,
+        { wrapper: createWrapper() }
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText("entries.form.titlePlaceholder")
+        ).toHaveValue("Test Entry");
+      });
+
+      expect(
+        screen.getByRole("checkbox", { name: "entries.form.expiry.label" })
+      ).toHaveAttribute("data-state", "checked");
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("entries.form.saveChanges"));
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateEntry).toHaveBeenCalledWith(
+          expect.objectContaining({
+            id: "entry-expiry",
+            data: expect.objectContaining({
+              expires: true,
+              expiryTime: "2027-06-15T10:30:00.000Z",
+            }),
+          })
+        );
+      });
+    });
+  });
 });

--- a/src/components/entries/__tests__/EntryEditFormFields.test.tsx
+++ b/src/components/entries/__tests__/EntryEditFormFields.test.tsx
@@ -46,6 +46,8 @@ const defaultValues: EntryFormValues = {
   customIconUuid: null,
   tags: [],
   customFields: [],
+  expires: false,
+  expiryTime: null,
 };
 
 function renderWithForm(

--- a/src/components/entries/entry-edit-form/EntryExpiryField.tsx
+++ b/src/components/entries/entry-edit-form/EntryExpiryField.tsx
@@ -25,7 +25,7 @@ interface EntryExpiryFieldProps {
 export function EntryExpiryField({
   control,
   isPending,
-}: EntryExpiryFieldProps) {
+}: Readonly<EntryExpiryFieldProps>) {
   const { t } = useTranslation();
   const { field: expiresField } = useController({ name: "expires", control });
   const { field: expiryTimeField, fieldState } = useController({

--- a/src/components/entries/entry-edit-form/EntryExpiryField.tsx
+++ b/src/components/entries/entry-edit-form/EntryExpiryField.tsx
@@ -1,0 +1,98 @@
+import { useTranslation } from "react-i18next";
+import { type Control, useController } from "react-hook-form";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DateTimePicker } from "@/components/ui/date-time-picker";
+import { Field, FieldError, FieldLabel } from "@/components/ui/field";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  EXPIRY_PRESETS,
+  type ExpiryPreset,
+  resolveExpiryPreset,
+} from "@/lib/entry-expiry";
+import type { EntryFormValues } from "@/lib/formTypes";
+
+interface EntryExpiryFieldProps {
+  control: Control<EntryFormValues>;
+  isPending: boolean;
+}
+
+export function EntryExpiryField({
+  control,
+  isPending,
+}: EntryExpiryFieldProps) {
+  const { t } = useTranslation();
+  const { field: expiresField } = useController({ name: "expires", control });
+  const { field: expiryTimeField, fieldState } = useController({
+    name: "expiryTime",
+    control,
+  });
+
+  function handleToggle(checked: boolean) {
+    expiresField.onChange(checked);
+    // First time expiry is enabled, seed a sensible starting value (1 year).
+    // This is a transient field value, not a persisted preference.
+    if (checked && expiryTimeField.value === null) {
+      expiryTimeField.onChange(resolveExpiryPreset("1y", new Date()));
+    }
+  }
+
+  function handlePresetChange(preset: string) {
+    expiryTimeField.onChange(
+      resolveExpiryPreset(preset as ExpiryPreset, new Date())
+    );
+  }
+
+  return (
+    <Field>
+      <div className="flex items-center gap-2">
+        <Checkbox
+          id="expires"
+          checked={expiresField.value}
+          onCheckedChange={(checked) => handleToggle(checked === true)}
+          disabled={isPending}
+          aria-label={t("entries.form.expiry.label")}
+        />
+        <FieldLabel htmlFor="expires">
+          {t("entries.form.expiry.label")}
+        </FieldLabel>
+      </div>
+      {expiresField.value && (
+        <div className="flex flex-col gap-2">
+          <Select onValueChange={handlePresetChange} disabled={isPending}>
+            <SelectTrigger
+              className="w-full"
+              aria-label={t("entries.form.expiry.presetLabel")}
+            >
+              <SelectValue
+                placeholder={t("entries.form.expiry.presetPlaceholder")}
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {EXPIRY_PRESETS.map((preset) => (
+                <SelectItem key={preset} value={preset}>
+                  {t(`entries.form.expiry.presets.${preset}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <DateTimePicker
+            id="expiryTime"
+            value={expiryTimeField.value ?? undefined}
+            onChange={(date) => expiryTimeField.onChange(date ?? null)}
+            placeholder={t("entries.form.expiry.pickPlaceholder")}
+            disabled={isPending}
+          />
+          {fieldState.error && (
+            <FieldError>{fieldState.error.message}</FieldError>
+          )}
+        </div>
+      )}
+    </Field>
+  );
+}

--- a/src/components/entries/entry-edit-form/index.ts
+++ b/src/components/entries/entry-edit-form/index.ts
@@ -2,6 +2,7 @@ export { EntryGroupField } from "./EntryGroupField";
 export { EntryTitleField } from "./EntryTitleField";
 export { EntryUsernameField } from "./EntryUsernameField";
 export { EntryPasswordField } from "./EntryPasswordField";
+export { EntryExpiryField } from "./EntryExpiryField";
 export { EntryUrlField } from "./EntryUrlField";
 export { EntryTagsField } from "./EntryTagsField";
 export { EntryNotesField } from "./EntryNotesField";

--- a/src/hooks/use-entry-edit-form.ts
+++ b/src/hooks/use-entry-edit-form.ts
@@ -38,6 +38,8 @@ function getEntryFormDefaults(
       tags: [],
       customFields: [],
       groupId: defaultGroupId,
+      expires: false,
+      expiryTime: null,
     };
   }
 
@@ -56,6 +58,15 @@ function getEntryFormDefaults(
       isProtected: meta.isProtected,
     })),
     groupId: entry.groupId,
+    expires: entry.expires,
+    expiryTime: entry.expiryTime ? new Date(entry.expiryTime) : null,
+  };
+}
+
+function toExpiryPayload(values: EntryFormValues) {
+  return {
+    expires: values.expires,
+    expiryTime: values.expiryTime ? values.expiryTime.toISOString() : undefined,
   };
 }
 
@@ -166,6 +177,7 @@ export function useEntryEditForm({
             tags: values.tags,
             customFields,
             protectedCustomFields,
+            ...toExpiryPayload(values),
           },
         });
 
@@ -200,6 +212,7 @@ export function useEntryEditForm({
           tags: values.tags,
           customFields,
           protectedCustomFields,
+          ...toExpiryPayload(values),
         },
       });
       if (values.customIconUuid) {
@@ -265,6 +278,7 @@ export function useEntryEditForm({
           tags: values.tags,
           customFields,
           protectedCustomFields,
+          ...toExpiryPayload(values),
         },
       });
       if (values.customIconUuid) {

--- a/src/lib/__tests__/formTypes.test.ts
+++ b/src/lib/__tests__/formTypes.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { entryFormSchema, type EntryFormValues } from "@/lib/formTypes";
+
+function baseValues(overrides: Partial<EntryFormValues> = {}): EntryFormValues {
+  return {
+    title: "Example",
+    username: "",
+    password: "",
+    url: "",
+    notes: "",
+    iconId: 0,
+    customIconUuid: null,
+    tags: [],
+    customFields: [],
+    groupId: undefined,
+    expires: false,
+    expiryTime: null,
+    ...overrides,
+  };
+}
+
+describe("entryFormSchema expiry refinement", () => {
+  it("fails when expires is on but no expiry time is chosen", () => {
+    const result = entryFormSchema.safeParse(
+      baseValues({ expires: true, expiryTime: null })
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path[0] === "expiryTime")).toBe(
+        true
+      );
+    }
+  });
+
+  it("passes when expires is on with a future expiry time", () => {
+    const result = entryFormSchema.safeParse(
+      baseValues({ expires: true, expiryTime: new Date(2099, 0, 1) })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("passes when expires is on with a past expiry time", () => {
+    const result = entryFormSchema.safeParse(
+      baseValues({ expires: true, expiryTime: new Date(2000, 0, 1) })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("passes when expires is off regardless of expiry time", () => {
+    expect(
+      entryFormSchema.safeParse(
+        baseValues({ expires: false, expiryTime: null })
+      ).success
+    ).toBe(true);
+    expect(
+      entryFormSchema.safeParse(
+        baseValues({ expires: false, expiryTime: new Date(2000, 0, 1) })
+      ).success
+    ).toBe(true);
+  });
+});

--- a/src/lib/entry-expiry.test.ts
+++ b/src/lib/entry-expiry.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import dayjs from "dayjs";
+import {
+  EXPIRY_PRESETS,
+  type ExpiryPreset,
+  resolveExpiryPreset,
+} from "@/lib/entry-expiry";
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// Fixed reference instant, built in local time so calendar assertions are
+// timezone-independent.
+const NOW = new Date(2026, 0, 15, 10, 30, 0, 0);
+
+describe("resolveExpiryPreset", () => {
+  it("exposes all twelve presets in order", () => {
+    expect(EXPIRY_PRESETS).toEqual([
+      "12h",
+      "24h",
+      "1w",
+      "2w",
+      "3w",
+      "1mo",
+      "2mo",
+      "3mo",
+      "6mo",
+      "1y",
+      "2y",
+      "3y",
+    ]);
+  });
+
+  it.each<[ExpiryPreset, number]>([
+    ["12h", 12 * HOUR_MS],
+    ["24h", 24 * HOUR_MS],
+    ["1w", 7 * DAY_MS],
+    ["2w", 14 * DAY_MS],
+    ["3w", 21 * DAY_MS],
+  ])("resolves %s as a fixed duration from now", (preset, deltaMs) => {
+    const result = resolveExpiryPreset(preset, NOW);
+    expect(result.getTime() - NOW.getTime()).toBe(deltaMs);
+  });
+
+  it.each<[ExpiryPreset, number, number]>([
+    // preset, expected calendar year, expected calendar month (0-based)
+    ["1mo", 2026, 1],
+    ["2mo", 2026, 2],
+    ["3mo", 2026, 3],
+    ["6mo", 2026, 6],
+    ["1y", 2027, 0],
+    ["2y", 2028, 0],
+    ["3y", 2029, 0],
+  ])(
+    "resolves %s by advancing the local calendar, keeping time-of-day",
+    (preset, year, month) => {
+      const result = dayjs(resolveExpiryPreset(preset, NOW));
+      expect(result.year()).toBe(year);
+      expect(result.month()).toBe(month);
+      expect(result.date()).toBe(15);
+      expect(result.hour()).toBe(10);
+      expect(result.minute()).toBe(30);
+    }
+  );
+
+  it("is pure: same now produces the same instant", () => {
+    const a = resolveExpiryPreset("1y", NOW);
+    const b = resolveExpiryPreset("1y", NOW);
+    expect(a.getTime()).toBe(b.getTime());
+  });
+
+  it("does not mutate the provided now", () => {
+    const before = NOW.getTime();
+    resolveExpiryPreset("6mo", NOW);
+    expect(NOW.getTime()).toBe(before);
+  });
+});

--- a/src/lib/entry-expiry.ts
+++ b/src/lib/entry-expiry.ts
@@ -1,0 +1,62 @@
+import dayjs, { type ManipulateType } from "dayjs";
+
+/**
+ * Duration presets a user can pick to set an Entry's expiry. Each resolves to
+ * an absolute instant computed from "now" at the moment it is picked.
+ */
+export type ExpiryPreset =
+  | "12h"
+  | "24h"
+  | "1w"
+  | "2w"
+  | "3w"
+  | "1mo"
+  | "2mo"
+  | "3mo"
+  | "6mo"
+  | "1y"
+  | "2y"
+  | "3y";
+
+/** Ordered list of presets for the editor dropdown. */
+export const EXPIRY_PRESETS: ExpiryPreset[] = [
+  "12h",
+  "24h",
+  "1w",
+  "2w",
+  "3w",
+  "1mo",
+  "2mo",
+  "3mo",
+  "6mo",
+  "1y",
+  "2y",
+  "3y",
+];
+
+const PRESET_DURATIONS: Record<
+  ExpiryPreset,
+  { amount: number; unit: ManipulateType }
+> = {
+  "12h": { amount: 12, unit: "hour" },
+  "24h": { amount: 24, unit: "hour" },
+  "1w": { amount: 1, unit: "week" },
+  "2w": { amount: 2, unit: "week" },
+  "3w": { amount: 3, unit: "week" },
+  "1mo": { amount: 1, unit: "month" },
+  "2mo": { amount: 2, unit: "month" },
+  "3mo": { amount: 3, unit: "month" },
+  "6mo": { amount: 6, unit: "month" },
+  "1y": { amount: 1, unit: "year" },
+  "2y": { amount: 2, unit: "year" },
+  "3y": { amount: 3, unit: "year" },
+};
+
+/**
+ * Resolve a preset to an absolute instant `now + duration`. Pure: a given
+ * (preset, now) always yields the same instant and never mutates `now`.
+ */
+export function resolveExpiryPreset(preset: ExpiryPreset, now: Date): Date {
+  const { amount, unit } = PRESET_DURATIONS[preset];
+  return dayjs(now).add(amount, unit).toDate();
+}

--- a/src/lib/formTypes.ts
+++ b/src/lib/formTypes.ts
@@ -74,12 +74,21 @@ const entryFormBaseSchema = z.object({
   tags: z.array(z.string()),
   customFields: z.array(entryCustomFieldSchema),
   groupId: z.string().optional(),
+  expires: z.boolean(),
+  // Held as a Date in the form (matches DateTimePicker); converted to UTC ISO
+  // 8601 at the IPC boundary. Past dates are valid.
+  expiryTime: z.date().nullable(),
 });
 
-export const entryFormSchema = entryFormBaseSchema.refine(
-  (data) => data.url === "" || /^https?:\/\/.+/.test(data.url),
-  { message: "Must be a valid URL.", path: ["url"] }
-);
+export const entryFormSchema = entryFormBaseSchema
+  .refine((data) => data.url === "" || /^https?:\/\/.+/.test(data.url), {
+    message: "Must be a valid URL.",
+    path: ["url"],
+  })
+  .refine((data) => !data.expires || data.expiryTime !== null, {
+    message: "An expiry date is required when expiry is enabled.",
+    path: ["expiryTime"],
+  });
 
 // Use the base schema for type inference to avoid type mismatch with react-hook-form
 export type EntryFormValues = z.infer<typeof entryFormBaseSchema>;

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -284,7 +284,27 @@
       "removeField": "Benutzerdefiniertes Feld entfernen",
       "fetchFavicon": "Favicon von URL abrufen",
       "refreshFavicon": "Favicon von URL aktualisieren",
-      "clearCustomIcon": "Benutzerdefiniertes Symbol entfernen"
+      "clearCustomIcon": "Benutzerdefiniertes Symbol entfernen",
+      "expiry": {
+        "label": "Läuft ab",
+        "presetLabel": "Ablauf-Vorgabe",
+        "presetPlaceholder": "Vorgabe auswählen",
+        "pickPlaceholder": "Datum und Uhrzeit wählen",
+        "presets": {
+          "12h": "12 Stunden",
+          "24h": "24 Stunden",
+          "1w": "1 Woche",
+          "2w": "2 Wochen",
+          "3w": "3 Wochen",
+          "1mo": "1 Monat",
+          "2mo": "2 Monate",
+          "3mo": "3 Monate",
+          "6mo": "6 Monate",
+          "1y": "1 Jahr",
+          "2y": "2 Jahre",
+          "3y": "3 Jahre"
+        }
+      }
     },
     "toast": {
       "created": "Eintrag erstellt",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -307,7 +307,27 @@
       "removeField": "Remove custom field",
       "fetchFavicon": "Fetch favicon from URL",
       "refreshFavicon": "Refresh favicon from URL",
-      "clearCustomIcon": "Clear custom icon"
+      "clearCustomIcon": "Clear custom icon",
+      "expiry": {
+        "label": "Expires",
+        "presetLabel": "Expiry preset",
+        "presetPlaceholder": "Choose a preset",
+        "pickPlaceholder": "Pick a date and time",
+        "presets": {
+          "12h": "12 hours",
+          "24h": "24 hours",
+          "1w": "1 week",
+          "2w": "2 weeks",
+          "3w": "3 weeks",
+          "1mo": "1 month",
+          "2mo": "2 months",
+          "3mo": "3 months",
+          "6mo": "6 months",
+          "1y": "1 year",
+          "2y": "2 years",
+          "3y": "3 years"
+        }
+      }
     },
     "toast": {
       "created": "Entry created",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -284,7 +284,27 @@
       "removeField": "Eliminar campo personalizado",
       "fetchFavicon": "Obtener favicon desde la URL",
       "refreshFavicon": "Actualizar favicon desde la URL",
-      "clearCustomIcon": "Quitar icono personalizado"
+      "clearCustomIcon": "Quitar icono personalizado",
+      "expiry": {
+        "label": "Caduca",
+        "presetLabel": "Preajuste de caducidad",
+        "presetPlaceholder": "Elige un preajuste",
+        "pickPlaceholder": "Elige una fecha y hora",
+        "presets": {
+          "12h": "12 horas",
+          "24h": "24 horas",
+          "1w": "1 semana",
+          "2w": "2 semanas",
+          "3w": "3 semanas",
+          "1mo": "1 mes",
+          "2mo": "2 meses",
+          "3mo": "3 meses",
+          "6mo": "6 meses",
+          "1y": "1 año",
+          "2y": "2 años",
+          "3y": "3 años"
+        }
+      }
     },
     "toast": {
       "created": "Entrada creada",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -284,7 +284,27 @@
       "removeField": "Supprimer le champ personnalisé",
       "fetchFavicon": "Récupérer le favicon depuis l'URL",
       "refreshFavicon": "Actualiser le favicon depuis l'URL",
-      "clearCustomIcon": "Supprimer l'icône personnalisée"
+      "clearCustomIcon": "Supprimer l'icône personnalisée",
+      "expiry": {
+        "label": "Expire",
+        "presetLabel": "Préréglage d'expiration",
+        "presetPlaceholder": "Choisir un préréglage",
+        "pickPlaceholder": "Choisir une date et une heure",
+        "presets": {
+          "12h": "12 heures",
+          "24h": "24 heures",
+          "1w": "1 semaine",
+          "2w": "2 semaines",
+          "3w": "3 semaines",
+          "1mo": "1 mois",
+          "2mo": "2 mois",
+          "3mo": "3 mois",
+          "6mo": "6 mois",
+          "1y": "1 an",
+          "2y": "2 ans",
+          "3y": "3 ans"
+        }
+      }
     },
     "toast": {
       "created": "Entrée créée",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -284,7 +284,27 @@
       "removeField": "Ukloni prilagođeno polje",
       "fetchFavicon": "Preuzmi favikonu sa URL-a",
       "refreshFavicon": "Osveži favikonu sa URL-a",
-      "clearCustomIcon": "Ukloni prilagođenu ikonu"
+      "clearCustomIcon": "Ukloni prilagođenu ikonu",
+      "expiry": {
+        "label": "Ističe",
+        "presetLabel": "Unapred zadat rok isteka",
+        "presetPlaceholder": "Izaberite unapred zadatu vrednost",
+        "pickPlaceholder": "Izaberite datum i vreme",
+        "presets": {
+          "12h": "12 sati",
+          "24h": "24 sata",
+          "1w": "1 nedelja",
+          "2w": "2 nedelje",
+          "3w": "3 nedelje",
+          "1mo": "1 mesec",
+          "2mo": "2 meseca",
+          "3mo": "3 meseca",
+          "6mo": "6 meseci",
+          "1y": "1 godina",
+          "2y": "2 godine",
+          "3y": "3 godine"
+        }
+      }
     },
     "toast": {
       "created": "Unos kreiran",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,21 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
+// jsdom lacks ResizeObserver, which Radix primitives (e.g. Checkbox) rely on.
+if (!globalThis.ResizeObserver) {
+  globalThis.ResizeObserver = class {
+    observe() {
+      /* noop for tests */
+    }
+    unobserve() {
+      /* noop for tests */
+    }
+    disconnect() {
+      /* noop for tests */
+    }
+  };
+}
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => {


### PR DESCRIPTION
## What

Implements the entry-expiry **editor experience** (#266, parent #263). Builds on the now-merged persistence (#264) and `DateTimePicker` primitive (#265).

A new `EntryExpiryField` sits immediately after the password field:
- **"Expires" checkbox**, off by default on a new entry
- when on, reveals a **preset dropdown** + the `DateTimePicker`
- first tick pre-selects **"1 year"** (transient field value, not a persisted preference)
- unchecking keeps the previously chosen date hidden (per #264 semantics)

## How

- **`resolveExpiryPreset(preset, now)`** (`src/lib/entry-expiry.ts`) — pure dayjs mapping of all twelve presets (12h, 24h, 1/2/3w, 1/2/3/6mo, 1/2/3y) to an absolute instant `now + duration`.
- **Schema refinement** (`formTypes.ts`) — `expires` + `expiryTime` added to the base schema; refinement requires `expiryTime` when `expires=true`. Past dates are valid.
- **`use-entry-edit-form`** — loads an existing entry's expiry into form defaults and carries `expires`/`expiryTime` (UTC ISO 8601) through both create and update mutations.
- New i18n keys under `entries.form.expiry.*` across `en`, `de`, `es`, `fr`, `sr`.
- `ResizeObserver` polyfill added to the test setup (jsdom gap that Radix `Checkbox` relies on).

## Testing

Built with TDD (vertical slices). New coverage:
- `resolveExpiryPreset` — all twelve presets vs a fixed `now`, purity, no-mutation (timezone-independent assertions)
- schema refinement — `expires=true` no date fails; with date (incl. past) passes; `expires=false` passes regardless
- editor integration — checkbox off-by-default after password field; reveal + 1-year pre-select on tick; no expiry sent when off; edit-load → update round-trip

`bun run check` (lint + format), `tsc --noEmit`, and the full suite (462 tests) all pass.

## Acceptance criteria

All met, with two deliberately scoped out of #266:
- the validation-block path is covered by the schema unit test (the 1-year pre-select means the UI never reaches `expires=true` + no-date)
- the expired strikethrough/badge **indicator** belongs to a separate #263 slice

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)