### PR TITLE
feat(ui): expired entry indicator (strikethrough title + badge)

### DIFF
--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import dayjs from "dayjs";
+
+import EntryItemDetails from "./EntryItemDetails";
+import type { Entry } from "@/lib/types";
+
+const baseEntry: Entry = {
+  id: "entry-1",
+  groupId: "root",
+  title: "GitHub",
+  username: "octocat",
+  url: null,
+  notes: null,
+  iconId: 0,
+  customIconUuid: null,
+  tags: [],
+  customFields: {},
+  customFieldMeta: [],
+  createdAt: "2026-01-01T00:00:00Z",
+  modifiedAt: "2026-01-02T00:00:00Z",
+  accessedAt: "2026-01-02T00:00:00Z",
+  expires: false,
+  expiryTime: null,
+};
+
+// Mutable holder the mocked hook reads from. vi.hoisted runs before the
+// vi.mock factories so they can close over it safely.
+const state = vi.hoisted(() => ({ entry: null as Entry | null }));
+
+vi.mock("@/hooks/use-entry-detail", () => ({
+  useEntryDetail: () => ({
+    entry: state.entry,
+    isLoading: false,
+    isError: false,
+    password: null,
+    isPasswordVisible: false,
+    isPasswordLoading: false,
+    isTransitioning: false,
+    revealPassword: vi.fn(),
+    hidePassword: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-custom-icons", () => ({
+  useCustomIcons: () => ({ data: {} }),
+}));
+
+vi.mock("@/hooks/use-copy-to-clipboard", () => ({
+  useCopyToClipboard: () => ({ copy: vi.fn(), isCopied: false }),
+}));
+
+vi.mock("@/hooks/use-clipboard-countdown", () => ({
+  useClipboardCountdown: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/use-clipboard-timeout", () => ({
+  useClipboardTimeout: () => 30,
+}));
+
+vi.mock("@/lib/tauri", () => ({
+  clipboard: { copyPassword: vi.fn(), copyProtectedField: vi.fn() },
+  entries: { getProtectedCustomField: vi.fn() },
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
+
+function renderDetails(override: Partial<Entry>) {
+  state.entry = { ...baseEntry, ...override };
+  return render(<EntryItemDetails entryId="entry-1" dbId="db-1" />);
+}
+
+describe("EntryItemDetails expired indicator", () => {
+  beforeEach(() => {
+    state.entry = null;
+  });
+
+  it("strikes through the title and shows an Expired badge when expired", () => {
+    renderDetails({ expires: true, expiryTime: "2000-01-01T00:00:00Z" });
+
+    const title = screen.getByRole("heading", { name: "GitHub" });
+    expect(title.className).toContain("line-through");
+    expect(title.className).toContain("text-muted-foreground");
+    expect(screen.getByText("entries.detail.expired")).toBeInTheDocument();
+  });
+
+  it("shows the absolute expiry date in local time alongside the metadata", () => {
+    const expiryTime = "2000-06-15T12:00:00Z";
+    renderDetails({ expires: true, expiryTime });
+
+    expect(screen.getByText("entries.detail.expires")).toBeInTheDocument();
+    // Rendered in the viewer's local time via dayjs — assert the local
+    // calendar year appears so the row reflects the actual instant.
+    const localYear = String(dayjs(expiryTime).year());
+    expect(
+      screen.getByText((text) => text.includes(localYear))
+    ).toBeInTheDocument();
+  });
+
+  it("shows no badge or strikethrough for a non-expired Entry", () => {
+    renderDetails({ expires: false });
+
+    const title = screen.getByRole("heading", { name: "GitHub" });
+    expect(title.className).not.toContain("line-through");
+    expect(
+      screen.queryByText("entries.detail.expired")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("entries.detail.expires")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -1,5 +1,6 @@
 import { createElement, useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
+import dayjs from "dayjs";
 import { Separator } from "@/components/ui/separator.tsx";
 import {
   Check,
@@ -25,6 +26,8 @@ import { useClipboardCountdown } from "@/hooks/use-clipboard-countdown";
 import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
 import { clipboard, entries as entriesApi } from "@/lib/tauri";
 import { getKeepassIcon } from "@/lib/keepass-icons";
+import { isExpired } from "@/lib/entry-expiry";
+import { cn } from "@/lib/utils";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
 import type { CustomFieldMeta } from "@/lib/types";
@@ -64,6 +67,8 @@ export default function EntryItemDetails({
     ? `data:${customIcon.mimeType};base64,${customIcon.data}`
     : undefined;
 
+  const expired = isExpired(entry, new Date());
+
   return (
     <>
       {/* Title section */}
@@ -74,9 +79,17 @@ export default function EntryItemDetails({
             {createElement(iconComponent, { className: "h-4 w-4" })}
           </AvatarFallback>
         </Avatar>
-        <h4 className="scroll-m-20 text-xl font-semibold tracking-tight">
+        <h4
+          className={cn(
+            "scroll-m-20 text-xl font-semibold tracking-tight",
+            expired && "line-through text-muted-foreground"
+          )}
+        >
           {entry.title}
         </h4>
+        {expired && (
+          <Badge variant="destructive">{t("entries.detail.expired")}</Badge>
+        )}
       </div>
 
       {/* Main fields */}
@@ -177,6 +190,15 @@ export default function EntryItemDetails({
           label={t("entries.detail.modified")}
           value={formatDate(entry.modifiedAt)}
         />
+        {entry.expires && entry.expiryTime && (
+          <>
+            <Separator />
+            <EntryFieldBasic
+              label={t("entries.detail.expires")}
+              value={formatExpiry(entry.expiryTime)}
+            />
+          </>
+        )}
       </div>
     </>
   );
@@ -521,6 +543,12 @@ function EntryFieldBasic({ label, value }: { label: string; value: string }) {
       </small>
     </div>
   );
+}
+
+// The expiry instant is stored UTC; render it in the viewer's local time
+// via dayjs so the displayed date matches the date picker in the editor.
+function formatExpiry(isoString: string): string {
+  return dayjs(isoString).format("MMM D, YYYY h:mm:ss A");
 }
 
 function formatDate(isoString: string): string {

--- a/src/components/entries/EntryListItem.test.tsx
+++ b/src/components/entries/EntryListItem.test.tsx
@@ -89,3 +89,27 @@ describe("EntryListItem findings indicator", () => {
     );
   });
 });
+
+describe("EntryListItem expired indicator", () => {
+  // An Expired Entry's title is struck through and muted, driven purely
+  // from the Entry's own expires flag + past expiry — independent of the
+  // Password Health report.
+  it("strikes through and mutes the title when expired", () => {
+    renderItem({ expires: true, expiryTime: "2000-01-01T00:00:00Z" });
+    const title = screen.getByText("GitHub");
+    expect(title.className).toContain("line-through");
+    expect(title.className).toContain("text-muted-foreground");
+  });
+
+  it("does not strike through a non-expired Entry (future expiry)", () => {
+    renderItem({ expires: true, expiryTime: "2999-01-01T00:00:00Z" });
+    const title = screen.getByText("GitHub");
+    expect(title.className).not.toContain("line-through");
+  });
+
+  it("does not strike through when the expires flag is unset", () => {
+    renderItem({ expires: false, expiryTime: "2000-01-01T00:00:00Z" });
+    const title = screen.getByText("GitHub");
+    expect(title.className).not.toContain("line-through");
+  });
+});

--- a/src/components/entries/EntryListItem.tsx
+++ b/src/components/entries/EntryListItem.tsx
@@ -18,6 +18,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getKeepassIcon } from "@/lib/keepass-icons";
+import { isExpired } from "@/lib/entry-expiry";
 import { cn } from "@/lib/utils";
 
 interface EntryListItemProps extends Entry {
@@ -48,8 +49,11 @@ const EntryListItem = memo(function EntryListItem({
   onClick,
   findings,
   reusedGroupSize,
+  expires,
+  expiryTime,
 }: EntryListItemProps) {
   const iconComponent = getKeepassIcon(iconId ?? 0);
+  const expired = isExpired({ expires, expiryTime }, new Date());
   const customIcon = customIconUuid ? customIcons[customIconUuid] : null;
   const customIconSrc = customIcon
     ? `data:${customIcon.mimeType};base64,${customIcon.data}`
@@ -79,7 +83,14 @@ const EntryListItem = memo(function EntryListItem({
           </Avatar>
         </ItemMedia>
         <ItemContent className="min-w-0 flex-1 overflow-hidden">
-          <ItemTitle className="block truncate w-full">{title}</ItemTitle>
+          <ItemTitle
+            className={cn(
+              "block truncate w-full",
+              expired && "line-through text-muted-foreground"
+            )}
+          >
+            {title}
+          </ItemTitle>
           <ItemDescription className="line-clamp-none truncate w-full min-w-0">
             {username}
           </ItemDescription>

--- a/src/lib/entry-expiry.test.ts
+++ b/src/lib/entry-expiry.test.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs";
 import {
   EXPIRY_PRESETS,
   type ExpiryPreset,
+  isExpired,
   resolveExpiryPreset,
 } from "@/lib/entry-expiry";
 
@@ -73,5 +74,29 @@ describe("resolveExpiryPreset", () => {
     const before = NOW.getTime();
     resolveExpiryPreset("6mo", NOW);
     expect(NOW.getTime()).toBe(before);
+  });
+});
+
+describe("isExpired", () => {
+  const past = dayjs(NOW).subtract(1, "day").toISOString();
+  const future = dayjs(NOW).add(1, "day").toISOString();
+
+  it("is true when the flag is set and the expiry is in the past", () => {
+    expect(isExpired({ expires: true, expiryTime: past }, NOW)).toBe(true);
+  });
+
+  it("is false when the flag is set but the expiry is in the future", () => {
+    expect(isExpired({ expires: true, expiryTime: future }, NOW)).toBe(false);
+  });
+
+  it("is false when the flag is not set, even with a past expiry", () => {
+    expect(isExpired({ expires: false, expiryTime: past }, NOW)).toBe(false);
+  });
+
+  it("is false when the expiry timestamp is missing", () => {
+    expect(isExpired({ expires: true, expiryTime: null }, NOW)).toBe(false);
+    expect(isExpired({ expires: true, expiryTime: undefined }, NOW)).toBe(
+      false
+    );
   });
 });

--- a/src/lib/entry-expiry.ts
+++ b/src/lib/entry-expiry.ts
@@ -60,3 +60,19 @@ export function resolveExpiryPreset(preset: ExpiryPreset, now: Date): Date {
   const { amount, unit } = PRESET_DURATIONS[preset];
   return dayjs(now).add(amount, unit).toDate();
 }
+
+/**
+ * Whether an Entry is Expired at `now`: its `expires` flag is set and its
+ * `expiryTime` is strictly in the past. A cleared flag or a missing/future
+ * timestamp is never Expired. Binary — there is no "expires-soon" state.
+ *
+ * Driven purely from the Entry's own fields, so it holds even when the
+ * Password Health report has not been loaded.
+ */
+export function isExpired(
+  entry: { expires: boolean; expiryTime?: string | null },
+  now: Date
+): boolean {
+  if (!entry.expires || !entry.expiryTime) return false;
+  return new Date(entry.expiryTime).getTime() < now.getTime();
+}

--- a/src/lib/entry-expiry.ts
+++ b/src/lib/entry-expiry.ts
@@ -70,7 +70,7 @@ export function resolveExpiryPreset(preset: ExpiryPreset, now: Date): Date {
  * Password Health report has not been loaded.
  */
 export function isExpired(
-  entry: { expires: boolean; expiryTime?: string | null },
+  entry: { expires: boolean; expiryTime?: string | null | undefined },
   now: Date
 ): boolean {
   if (!entry.expires || !entry.expiryTime) return false;

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -333,6 +333,8 @@
       "tags": "Tags",
       "created": "Erstellt",
       "modified": "Geändert",
+      "expired": "Abgelaufen",
+      "expires": "Läuft ab",
       "revealPassword": "Passwort anzeigen",
       "hidePassword": "Passwort verbergen",
       "autoType": "Auto-Type",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -356,6 +356,8 @@
       "tags": "Tags",
       "created": "Created",
       "modified": "Modified",
+      "expired": "Expired",
+      "expires": "Expires",
       "revealPassword": "reveal password",
       "hidePassword": "hide password",
       "autoType": "auto-type",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -333,6 +333,8 @@
       "tags": "Etiquetas",
       "created": "Creado",
       "modified": "Modificado",
+      "expired": "Caducado",
+      "expires": "Caduca",
       "revealPassword": "revelar contraseña",
       "hidePassword": "ocultar contraseña",
       "autoType": "auto-escritura",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -333,6 +333,8 @@
       "tags": "Étiquettes",
       "created": "Créé",
       "modified": "Modifié",
+      "expired": "Expiré",
+      "expires": "Expire le",
       "revealPassword": "révéler le mot de passe",
       "hidePassword": "masquer le mot de passe",
       "autoType": "saisie automatique",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -333,6 +333,8 @@
       "tags": "Oznake",
       "created": "Kreirano",
       "modified": "Izmenjeno",
+      "expired": "Isteklo",
+      "expires": "Ističe",
       "revealPassword": "prikaži lozinku",
       "hidePassword": "sakrij lozinku",
       "autoType": "automatski unos",


### PR DESCRIPTION
## Summary

Adds the **Expired** visual indicator for entries, driven purely from an Entry's own `expires` flag + `expiryTime` so it shows even when the Password Health report has not been loaded.

- A pure `isExpired(entry, now)` predicate in `lib/entry-expiry.ts`: `expires && expiryTime < now`.
- **Entry list item**: an expired Entry's title is shown with `line-through` + `text-muted-foreground`.
- **Detail header**: same struck-through + muted title, plus an **"Expired" `Badge`** and an absolute **"Expires"** date row rendered in local time via dayjs (alongside Created/Modified).
- Binary expired/not — **no "expires-soon" / amber state**.
- Copy/reveal/open paths are untouched — expired Entries stay fully usable.
- New i18n keys `entries.detail.expired` / `entries.detail.expires` across all five locales (en/de/es/fr/sr).

Built test-first (red→green) one vertical slice at a time.

## Acceptance criteria

- [x] `isExpired` returns true only when `expires` is set and `expiryTime` is in the past; false when `expires=false` or `expiryTime` is missing
- [x] An expired Entry's title is struck through and muted in the entry list
- [x] An expired Entry's title is struck through and muted in the detail header
- [x] The detail view shows an "Expired" badge and the absolute expiry date in local time
- [x] A non-expired Entry shows no indicator; no "expires-soon" state exists
- [x] Copy/reveal/open are not blocked for expired Entries
- [x] Unit tests cover `isExpired` boundaries (false flag, past, future, missing date)
- [x] Any new i18n keys present in all five locales
- [x] `bun run check` passes

## Testing

- `bun run check` (eslint + prettier) → passes
- Full frontend suite → **472 tests passing** (54 files), including new coverage in `entry-expiry.test.ts`, `EntryListItem.test.tsx`, and the new `EntryItemDetails.test.tsx`

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)