### PR TITLE
feat(core): surface entry attachment metadata (read-only)

### DIFF
--- a/src-tauri/src/dto/entry.rs
+++ b/src-tauri/src/dto/entry.rs
@@ -18,6 +18,21 @@ pub struct CustomFieldValue {
     pub value: String,
 }
 
+/// Metadata for an Entry's Attachment — never its byte payload.
+///
+/// Attachments are presented as per-Entry and private (see `CONTEXT.md` →
+/// "Attachment"); the KDBX Vault-level binary pool and its dedup stay
+/// invisible. Bytes are fetched per-file on demand, so list/get responses
+/// carry only the filename, byte size, and a MIME hint derived from the
+/// filename extension.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentMeta {
+    pub filename: String,
+    pub size: u64,
+    pub mime_type: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Entry {
@@ -37,6 +52,7 @@ pub struct Entry {
     pub accessed_at: String,
     pub expires: bool,
     pub expiry_time: Option<String>,
+    pub attachments: Vec<AttachmentMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/services/kdbx/conversions.rs
+++ b/src-tauri/src/services/kdbx/conversions.rs
@@ -1,5 +1,5 @@
 use crate::domain::secure::SecureString;
-use crate::dto::entry::{CustomFieldMeta, Entry};
+use crate::dto::entry::{AttachmentMeta, CustomFieldMeta, Entry};
 use crate::dto::error::AppError;
 use crate::dto::group::Group;
 use chrono::DateTime;
@@ -19,6 +19,7 @@ pub(crate) fn convert_entry(entry: &EntryRef<'_>, group_id: &str) -> Entry {
         None => (None, None),
     };
     let (custom_fields, custom_field_meta) = collect_custom_fields(entry);
+    let attachments = collect_attachments(entry);
 
     Entry {
         id: entry.id().uuid().to_string(),
@@ -52,7 +53,56 @@ pub(crate) fn convert_entry(entry: &EntryRef<'_>, group_id: &str) -> Entry {
         // surface it as RFC 3339 so the frontend and Password Health agree,
         // consistent with `expiry.and_utc()` in the analyzer.
         expiry_time: entry.times.expiry.map(|t| t.and_utc().to_rfc3339()),
+        attachments,
     }
+}
+
+/// Collects an Entry's Attachment metadata — filename, byte size, and a MIME
+/// hint derived from the extension — from its native KDBX binary references.
+/// KDBX3 (XML) and KDBX4 (header) binaries are normalized to one model by the
+/// `keepass` crate, so both surface here identically. The byte payload is never
+/// read out; only its length is, keeping list/get responses lightweight per
+/// ADR-0003.
+fn collect_attachments(entry: &EntryRef<'_>) -> Vec<AttachmentMeta> {
+    entry
+        .attachments_named()
+        .map(|(filename, attachment)| AttachmentMeta {
+            filename: filename.to_string(),
+            size: attachment.data.get().len() as u64,
+            mime_type: derive_attachment_mime(filename),
+        })
+        .collect()
+}
+
+/// Derives a MIME hint from a filename's extension. Covers the formats the
+/// attachments feature cares about (previewable images and plain text per
+/// `CONTEXT.md`/ADR-0003) plus common document types; everything else falls
+/// back to `application/octet-stream`. Extension match is case-insensitive.
+fn derive_attachment_mime(filename: &str) -> String {
+    let ext = filename
+        .rsplit_once('.')
+        .map(|(_, ext)| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    let mime = match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        "svg" => "image/svg+xml",
+        "txt" | "log" | "conf" | "ini" => "text/plain",
+        "md" => "text/markdown",
+        "csv" => "text/csv",
+        "json" => "application/json",
+        "xml" => "application/xml",
+        "yaml" | "yml" => "application/yaml",
+        "pdf" => "application/pdf",
+        "zip" => "application/zip",
+        _ => "application/octet-stream",
+    };
+
+    mime.to_string()
 }
 
 pub(crate) fn convert_group(group: &GroupRef<'_>, parent_id: Option<&str>) -> Group {

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -480,7 +480,10 @@ fn dedupe_preserving_order(tags: &mut Vec<String>) {
 mod tests {
     use super::*;
     use crate::domain::secure::SecureString;
+    use crate::dto::entry::AttachmentMeta;
     use crate::services::kdbx::test_support::create_test_database;
+    use keepass::db::Value;
+    use std::collections::HashMap;
 
     fn create_entry_with_expiry(
         service: &KdbxService,
@@ -806,6 +809,50 @@ mod tests {
         assert_eq!(
             reloaded.title, "Entry A",
             "a rejected update must not apply the title change"
+        );
+    }
+
+    #[test]
+    fn get_entry_extracts_attachment_metadata_without_bytes() {
+        // Seed attachments the way another KeePass client would: native KDBX
+        // binaries keyed by filename, one unprotected and one protected. The
+        // DTO must surface filename + byte size + a MIME hint derived from the
+        // extension — and never the byte payload itself.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+
+        service
+            .with_vault_mut(&db_path, |vault| {
+                let mut entry = vault.entry_mut(&entry_a)?;
+                entry.add_attachment("Notes.txt", Value::unprotected(b"hello world".to_vec()));
+                entry.add_attachment("logo.png", Value::protected(vec![0u8; 2048]));
+                Ok(())
+            })
+            .expect("seed attachments");
+
+        let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
+
+        let by_name: HashMap<&str, &AttachmentMeta> = entry
+            .attachments
+            .iter()
+            .map(|a| (a.filename.as_str(), a))
+            .collect();
+
+        let notes = by_name.get("Notes.txt").expect("Notes.txt metadata");
+        assert_eq!(notes.size, 11, "size is the byte length of the binary");
+        assert_eq!(notes.mime_type, "text/plain");
+
+        let logo = by_name.get("logo.png").expect("logo.png metadata");
+        assert_eq!(logo.size, 2048);
+        assert_eq!(logo.mime_type, "image/png");
+    }
+
+    #[test]
+    fn entry_without_attachments_reports_an_empty_list() {
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
+        assert!(
+            entry.attachments.is_empty(),
+            "an entry with no binaries has no attachment metadata"
         );
     }
 

--- a/src/components/entries/EntryEditForm.tsx
+++ b/src/components/entries/EntryEditForm.tsx
@@ -157,7 +157,7 @@ export function EntryEditForm({
           secretLoadError={secretLoadError}
           onCancel={handleCancel}
           onRetrySecretLoad={retrySecretLoad}
-          onSaveAndNew={!isEditMode ? saveAndCreateAnother : undefined}
+          onSaveAndNew={isEditMode ? undefined : saveAndCreateAnother}
         />
       </FieldGroup>
     </form>

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -24,6 +24,7 @@ const baseEntry: Entry = {
   accessedAt: "2026-01-02T00:00:00Z",
   expires: false,
   expiryTime: null,
+  attachments: [],
 };
 
 // Mutable holder the mocked hook reads from. vi.hoisted runs before the
@@ -110,5 +111,51 @@ describe("EntryItemDetails expired indicator", () => {
     expect(
       screen.queryByText("entries.detail.expires")
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("EntryItemDetails attachments section", () => {
+  beforeEach(() => {
+    state.entry = null;
+  });
+
+  it("renders one row per attachment with its filename and human-readable size", () => {
+    renderDetails({
+      attachments: [
+        { filename: "report.pdf", size: 2048, mimeType: "application/pdf" },
+      ],
+    });
+
+    const row = screen.getByRole("listitem");
+    expect(row).toHaveTextContent("report.pdf");
+    // 2048 bytes formatted as decimal KB (2.048 → "2 KB").
+    expect(row).toHaveTextContent("2 KB");
+  });
+
+  it("shows an empty state and no rows when there are no attachments", () => {
+    renderDetails({ attachments: [] });
+
+    expect(
+      screen.getByText("entries.detail.noAttachments")
+    ).toBeInTheDocument();
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+  });
+
+  it("sorts attachment rows by filename, case-insensitively", () => {
+    renderDetails({
+      attachments: [
+        { filename: "Zebra.txt", size: 10, mimeType: "text/plain" },
+        { filename: "apple.png", size: 20, mimeType: "image/png" },
+        { filename: "Banana.gif", size: 30, mimeType: "image/gif" },
+      ],
+    });
+
+    const filenames = screen
+      .getAllByRole("listitem")
+      .map((li) => li.textContent ?? "");
+
+    expect(filenames[0]).toContain("apple.png");
+    expect(filenames[1]).toContain("Banana.gif");
+    expect(filenames[2]).toContain("Zebra.txt");
   });
 });

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -44,7 +44,7 @@ interface EntryItemDetailsProps {
 export default function EntryItemDetails({
   entryId,
   dbId,
-}: EntryItemDetailsProps) {
+}: Readonly<EntryItemDetailsProps>) {
   const { t } = useTranslation();
   const {
     entry,
@@ -247,7 +247,7 @@ function PasswordRow({
   isDisabled,
   onReveal,
   onHide,
-}: {
+}: Readonly<{
   dbId: string;
   entryId: string;
   password: string | null;
@@ -256,7 +256,7 @@ function PasswordRow({
   isDisabled: boolean;
   onReveal: () => void;
   onHide: () => void;
-}) {
+}>) {
   const { t } = useTranslation();
   const clipboardClearTimeout = useClipboardTimeout();
   const startCountdown = useClipboardCountdown();
@@ -333,7 +333,10 @@ function PasswordRow({
   );
 }
 
-function UrlRow({ url, isDisabled }: { url: string; isDisabled: boolean }) {
+function UrlRow({
+  url,
+  isDisabled,
+}: Readonly<{ url: string; isDisabled: boolean }>) {
   const { t } = useTranslation();
   const { copy, isCopied } = useCopyToClipboard();
 
@@ -391,12 +394,12 @@ function ProtectedCustomFieldRow({
   entryId,
   meta,
   isDisabled,
-}: {
+}: Readonly<{
   dbId: string;
   entryId: string;
   meta: CustomFieldMeta;
   isDisabled: boolean;
-}) {
+}>) {
   const { t } = useTranslation();
   const clipboardClearTimeout = useClipboardTimeout();
   const startCountdown = useClipboardCountdown();
@@ -492,11 +495,11 @@ function EntryFieldRow({
   label,
   value,
   isDisabled,
-}: {
+}: Readonly<{
   label: string;
   value: string;
   isDisabled: boolean;
-}) {
+}>) {
   const { t } = useTranslation();
   const { copy, isCopied } = useCopyToClipboard();
 
@@ -559,9 +562,9 @@ function attachmentIcon(mimeType: string) {
 
 function AttachmentsSection({
   attachments,
-}: {
+}: Readonly<{
   attachments: AttachmentMeta[];
-}) {
+}>) {
   const { t } = useTranslation();
 
   // Sorted by filename, case-insensitively, for a stable display order (the
@@ -607,7 +610,10 @@ function AttachmentsSection({
   );
 }
 
-function EntryFieldBasic({ label, value }: { label: string; value: string }) {
+function EntryFieldBasic({
+  label,
+  value,
+}: Readonly<{ label: string; value: string }>) {
   return (
     <div className="flex justify-between items-center px-4 py-2">
       <small className="text-sm font-medium">{label}</small>

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -8,6 +8,9 @@ import {
   ExternalLink,
   Eye,
   EyeOff,
+  File,
+  FileText,
+  Image,
   Keyboard,
   Loader2,
 } from "lucide-react";
@@ -27,10 +30,11 @@ import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
 import { clipboard, entries as entriesApi } from "@/lib/tauri";
 import { getKeepassIcon } from "@/lib/keepass-icons";
 import { isExpired } from "@/lib/entry-expiry";
+import { formatAttachmentSize } from "@/lib/entry-attachment";
 import { cn } from "@/lib/utils";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { toast } from "sonner";
-import type { CustomFieldMeta } from "@/lib/types";
+import type { AttachmentMeta, CustomFieldMeta } from "@/lib/types";
 
 interface EntryItemDetailsProps {
   entryId: string;
@@ -178,6 +182,9 @@ export default function EntryItemDetails({
           ))}
         </div>
       )}
+
+      {/* Attachments */}
+      <AttachmentsSection attachments={entry.attachments} />
 
       {/* Metadata */}
       <div className="border rounded-md">
@@ -530,6 +537,72 @@ function EntryFieldRow({
           <Keyboard className="h-3 w-3" />
         </Button>
       </div>
+    </div>
+  );
+}
+
+// Pick a file-type glyph from the MIME hint. Coarse on purpose: the read-only
+// slice only needs images vs. text vs. everything-else; richer mapping can
+// follow when preview/download land.
+function attachmentIcon(mimeType: string) {
+  if (mimeType.startsWith("image/")) return Image;
+  if (
+    mimeType.startsWith("text/") ||
+    mimeType === "application/json" ||
+    mimeType === "application/xml" ||
+    mimeType === "application/yaml"
+  ) {
+    return FileText;
+  }
+  return File;
+}
+
+function AttachmentsSection({
+  attachments,
+}: {
+  attachments: AttachmentMeta[];
+}) {
+  const { t } = useTranslation();
+
+  // Sorted by filename, case-insensitively, for a stable display order (the
+  // KDBX binary pool is unordered). Copy first so we never mutate props.
+  const sorted = [...attachments].sort((a, b) =>
+    a.filename.localeCompare(b.filename, undefined, { sensitivity: "base" })
+  );
+
+  return (
+    <div className="border rounded-md">
+      <div className="px-4 py-2">
+        <small className="text-sm font-medium">
+          {t("entries.detail.attachments")}
+        </small>
+      </div>
+      <Separator />
+      {sorted.length === 0 ? (
+        <p className="px-4 py-2 text-sm text-muted-foreground">
+          {t("entries.detail.noAttachments")}
+        </p>
+      ) : (
+        <ul>
+          {sorted.map((attachment, index) => {
+            const Icon = attachmentIcon(attachment.mimeType);
+            return (
+              <li key={attachment.filename}>
+                {index > 0 && <Separator />}
+                <div className="flex min-w-0 items-center gap-3 px-4 py-2">
+                  <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                    {attachment.filename}
+                  </span>
+                  <span className="shrink-0 text-sm text-muted-foreground">
+                    {formatAttachmentSize(attachment.size)}
+                  </span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/components/entries/EntryListItem.test.tsx
+++ b/src/components/entries/EntryListItem.test.tsx
@@ -47,6 +47,7 @@ const baseProps = {
   modifiedAt: "",
   accessedAt: "",
   expires: false,
+  attachments: [],
   customIcons: {},
 };
 

--- a/src/components/entries/__tests__/EntryEditForm.test.tsx
+++ b/src/components/entries/__tests__/EntryEditForm.test.tsx
@@ -155,6 +155,7 @@ const mockEntry: Entry = {
   modifiedAt: "2024-02-17T15:58:43Z",
   accessedAt: "2024-02-17T15:58:43Z",
   expires: false,
+  attachments: [],
 };
 
 const mockEntryTwo: Entry = {
@@ -173,6 +174,7 @@ const mockEntryTwo: Entry = {
   modifiedAt: "2024-02-17T15:58:43Z",
   accessedAt: "2024-02-17T15:58:43Z",
   expires: false,
+  attachments: [],
 };
 
 const mockEntryWithCustomIcon: Entry = {

--- a/src/components/entries/__tests__/EntryItemDetails.test.tsx
+++ b/src/components/entries/__tests__/EntryItemDetails.test.tsx
@@ -31,6 +31,7 @@ const mockEntry: Entry = {
   modifiedAt: "2024-02-17T15:58:43Z",
   accessedAt: "2024-02-17T15:58:43Z",
   expires: false,
+  attachments: [],
 };
 
 vi.mock("@/hooks/use-entry-detail", () => ({

--- a/src/components/search/__tests__/SearchResultItem.test.tsx
+++ b/src/components/search/__tests__/SearchResultItem.test.tsx
@@ -23,6 +23,7 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/components/search/__tests__/SearchResultsList.test.tsx
+++ b/src/components/search/__tests__/SearchResultsList.test.tsx
@@ -111,6 +111,7 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/components/security/ReusedGroupRow.test.tsx
+++ b/src/components/security/ReusedGroupRow.test.tsx
@@ -21,6 +21,7 @@ function entry(id: string, title: string): Entry {
     modifiedAt: "",
     accessedAt: "",
     expires: false,
+    attachments: [],
   };
 }
 

--- a/src/hooks/__tests__/use-entry-detail.test.ts
+++ b/src/hooks/__tests__/use-entry-detail.test.ts
@@ -23,6 +23,7 @@ function makeMockEntry(): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
   };
 }
 

--- a/src/hooks/__tests__/use-search-entries.test.ts
+++ b/src/hooks/__tests__/use-search-entries.test.ts
@@ -22,6 +22,7 @@ function makeMockEntry(overrides: Partial<Entry> = {}): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/hooks/use-sorted-entries.test.ts
+++ b/src/hooks/use-sorted-entries.test.ts
@@ -21,6 +21,7 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/lib/entry-attachment.test.ts
+++ b/src/lib/entry-attachment.test.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "vitest";
+import { formatAttachmentSize } from "@/lib/entry-attachment";
+
+describe("formatAttachmentSize", () => {
+  it("renders sub-kilobyte sizes as whole bytes", () => {
+    expect(formatAttachmentSize(0)).toBe("0 B");
+    expect(formatAttachmentSize(11)).toBe("11 B");
+    expect(formatAttachmentSize(999)).toBe("999 B");
+  });
+
+  it("switches to decimal kilobytes at 1000 bytes", () => {
+    // Decimal (1000) units, matching macOS Finder and native save dialogs.
+    expect(formatAttachmentSize(1000)).toBe("1 KB");
+    expect(formatAttachmentSize(1500)).toBe("1.5 KB");
+  });
+
+  it("keeps at most one decimal place and drops a trailing .0", () => {
+    expect(formatAttachmentSize(2048)).toBe("2 KB");
+  });
+
+  it("scales up through megabytes and gigabytes", () => {
+    expect(formatAttachmentSize(1_500_000)).toBe("1.5 MB");
+    expect(formatAttachmentSize(1_500_000_000)).toBe("1.5 GB");
+  });
+});

--- a/src/lib/entry-attachment.ts
+++ b/src/lib/entry-attachment.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+/** Decimal (1000-based) unit ladder, matching macOS Finder and save dialogs. */
+const SIZE_UNITS = ["B", "KB", "MB", "GB", "TB"] as const;
+
+/**
+ * Format an Attachment's byte size for display. Pure: a given byte count always
+ * yields the same string.
+ *
+ * Uses decimal units (1 KB = 1000 B) so sizes line up with what the OS file
+ * dialog reports. Bytes render as whole numbers; larger units keep at most one
+ * decimal place with a trailing `.0` trimmed (e.g. `2 KB`, not `2.0 KB`).
+ */
+export function formatAttachmentSize(bytes: number): string {
+  let size = bytes;
+  let unit = 0;
+  while (size >= 1000 && unit < SIZE_UNITS.length - 1) {
+    size /= 1000;
+    unit += 1;
+  }
+
+  // Bytes are always whole; scaled units round to a single decimal.
+  const value =
+    unit === 0
+      ? size
+      : Number.parseFloat((Math.round(size * 10) / 10).toFixed(1));
+
+  return `${value} ${SIZE_UNITS[unit]}`;
+}

--- a/src/lib/search-utils.test.ts
+++ b/src/lib/search-utils.test.ts
@@ -25,6 +25,7 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/lib/tag-utils.test.ts
+++ b/src/lib/tag-utils.test.ts
@@ -25,6 +25,7 @@ function makeEntry(overrides: Partial<Entry> = {}): Entry {
     modifiedAt: "2024-01-01T00:00:00Z",
     accessedAt: "2024-01-01T00:00:00Z",
     expires: false,
+    attachments: [],
     ...overrides,
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,13 @@ export const CustomFieldMetaSchema = z.object({
 });
 export type CustomFieldMeta = z.infer<typeof CustomFieldMetaSchema>;
 
+export const AttachmentMetaSchema = z.object({
+  filename: z.string(),
+  size: z.number().int().nonnegative(),
+  mimeType: z.string(),
+});
+export type AttachmentMeta = z.infer<typeof AttachmentMetaSchema>;
+
 export const EntrySchema = z.object({
   id: z.string(),
   groupId: z.string(),
@@ -35,6 +42,7 @@ export const EntrySchema = z.object({
   accessedAt: z.string(),
   expires: z.boolean(),
   expiryTime: z.string().nullable().optional(),
+  attachments: z.array(AttachmentMetaSchema),
 });
 export type Entry = z.infer<typeof EntrySchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -340,7 +340,9 @@
       "autoType": "Auto-Type",
       "openUrl": "URL öffnen",
       "revealField": "{{field}} anzeigen",
-      "hideField": "{{field}} verbergen"
+      "hideField": "{{field}} verbergen",
+      "attachments": "Anhänge",
+      "noAttachments": "Keine Anhänge"
     },
     "sort": {
       "sortBy": "Sortieren nach",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -363,7 +363,9 @@
       "autoType": "auto-type",
       "openUrl": "open url",
       "revealField": "reveal {{field}}",
-      "hideField": "hide {{field}}"
+      "hideField": "hide {{field}}",
+      "attachments": "Attachments",
+      "noAttachments": "No attachments"
     },
     "sort": {
       "sortBy": "Sort by",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -340,7 +340,9 @@
       "autoType": "auto-escritura",
       "openUrl": "abrir URL",
       "revealField": "revelar {{field}}",
-      "hideField": "ocultar {{field}}"
+      "hideField": "ocultar {{field}}",
+      "attachments": "Adjuntos",
+      "noAttachments": "Sin adjuntos"
     },
     "sort": {
       "sortBy": "Ordenar por",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -340,7 +340,9 @@
       "autoType": "saisie automatique",
       "openUrl": "ouvrir l'URL",
       "revealField": "révéler {{field}}",
-      "hideField": "masquer {{field}}"
+      "hideField": "masquer {{field}}",
+      "attachments": "Pièces jointes",
+      "noAttachments": "Aucune pièce jointe"
     },
     "sort": {
       "sortBy": "Trier par",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -340,7 +340,9 @@
       "autoType": "automatski unos",
       "openUrl": "otvori URL",
       "revealField": "prikaži {{field}}",
-      "hideField": "sakrij {{field}}"
+      "hideField": "sakrij {{field}}",
+      "attachments": "Prilozi",
+      "noAttachments": "Nema priloga"
     },
     "sort": {
       "sortBy": "Sortiraj po",


### PR DESCRIPTION
## Summary

Foundational vertical slice of #280: surface each Entry's attachments as **metadata** through every layer and display them read-only in the Entry detail view. No byte payloads, no add/delete/download yet — just proving the pipe end-to-end against attachments created by other KeePass clients.

Closes #281.

## What changed

**Backend (Rust)**
- New `AttachmentMeta { filename, size, mimeType }` DTO; `Entry.attachments: Vec<AttachmentMeta>`.
- `convert_entry` populates it from the entry's native KDBX binary refs via `attachments_named()`. The `keepass` crate normalizes KDBX3 XML and KDBX4 header binaries into one model, so both formats surface identically. Only the byte **length** is read — never the payload — so `get_entry`/`list_entries` stay lightweight per ADR-0003.
- `derive_attachment_mime` maps the filename extension to a MIME hint (covers previewable images + plain text per CONTEXT.md, plus common doc types; falls back to `application/octet-stream`).

**Frontend**
- `lib/entry-attachment.ts`: `formatAttachmentSize` pure fn — decimal KB/MB (matches macOS Finder / native save dialogs); bytes whole, larger units ≤1 decimal with trailing `.0` trimmed.
- `AttachmentMeta` wired into `EntrySchema`.
- `EntryItemDetails` renders an attachments section: one row per attachment (file-type glyph + filename + human-readable size), sorted by filename case-insensitively, with a clear empty state.
- i18n keys (`entries.detail.attachments` / `noAttachments`) in all five locales.

## Acceptance criteria

- [x] Entry DTO + frontend Entry type carry an `attachments` metadata array (filename, size, derived type); no byte content
- [x] `convert_entry` populates metadata from KDBX binary refs (KDBX3 XML + KDBX4 header binaries both parse via the crate's unified model)
- [x] `get_entry` and `list_entries` return attachment metadata without byte payloads
- [x] Opening an Entry with attachments shows a row per attachment with type icon, filename, and human-readable size, sorted by filename
- [x] An Entry with no attachments shows an empty state
- [x] Backend test (via `test_support`) asserts metadata is extracted from a Vault containing attachments
- [x] Frontend pure-function test for size formatting
- [x] Component test asserts `EntryItemDetails` renders attachment rows and the empty state

## Testing

- `cargo test --lib`: 323 passed · `cargo clippy` clean · `cargo fmt --check` clean
- `bun run test`: 479 passed · `tsc --noEmit`: 0 errors · `bun run check`: 0 errors

Built test-first (red → green) in vertical slices: backend metadata extraction → size formatter → component rendering + empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)