### PR TITLE
feat(core): add entry attachments via drag-and-drop (desktop) (#286)

### DIFF
--- a/src-tauri/src/commands/entries.rs
+++ b/src-tauri/src/commands/entries.rs
@@ -4,6 +4,7 @@ use crate::dto::entry::{
 };
 use crate::dto::error::AppError;
 use crate::services::audit::AuditService;
+use crate::services::drag_drop::DropPathsBuffer;
 use crate::services::kdbx::favicons::FaviconFetchOutcome;
 use crate::services::kdbx::KdbxService;
 use crate::services::settings::SettingsService;
@@ -209,6 +210,29 @@ pub async fn add_entry_attachments<R: Runtime>(
         .into_iter()
         .filter_map(|file_path| file_path.into_path().ok())
         .collect();
+    state.add_entry_attachments(&db_id, &id, &paths)
+}
+
+/// Adds the files from the most recent native `tauri://drag-drop` event to an
+/// Entry. The paths were captured *in Rust* from the window event (buffered in
+/// `DropPathsBuffer`) — the frontend passes only the target db/entry ids, so a
+/// renderer-supplied path can never reach the read. This is the same trust
+/// boundary as the picker (ADR-0004): the renderer decides *whether* to commit
+/// (the drop must land on the selected Entry's panel) but never names a file.
+/// Draining the buffer here means a stale drop cannot be replayed against a
+/// later entry, and a commit with no preceding drop reads nothing (empty
+/// outcome). The dropped files go through the same feeder as the picker — hard
+/// size cap, auto-rename on collision, one bad file never aborting the rest —
+/// and the frontend persists via `database.save` and refreshes when anything
+/// landed.
+#[tauri::command]
+pub async fn commit_dropped_attachments(
+    db_id: String,
+    id: String,
+    drops: State<'_, Arc<DropPathsBuffer>>,
+    state: State<'_, Arc<KdbxService>>,
+) -> Result<AddAttachmentsOutcome, AppError> {
+    let paths = drops.take();
     state.add_entry_attachments(&db_id, &id, &paths)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,12 +10,12 @@ use crate::dto::error::AppError;
 use commands::{
     add_entry_attachments, add_recent_database, clear_audit_log, clear_clipboard,
     clear_entry_custom_icon, clear_recent_databases, clear_session_key, close_database,
-    copy_password_to_clipboard, copy_protected_field_to_clipboard, copy_text_to_clipboard,
-    create_database, create_entry, create_group, create_manual_backup, delete_backup, delete_entry,
-    delete_entry_attachment, delete_group, delete_tag, export_entry_attachment,
-    fetch_entry_favicon, generate_keyfile, generate_passphrase, generate_password,
-    get_app_preferences, get_audit_events, get_audit_status, get_custom_icons, get_database_config,
-    get_database_info, get_entry, get_entry_attachment, get_entry_password,
+    commit_dropped_attachments, copy_password_to_clipboard, copy_protected_field_to_clipboard,
+    copy_text_to_clipboard, create_database, create_entry, create_group, create_manual_backup,
+    delete_backup, delete_entry, delete_entry_attachment, delete_group, delete_tag,
+    export_entry_attachment, fetch_entry_favicon, generate_keyfile, generate_passphrase,
+    generate_password, get_app_preferences, get_audit_events, get_audit_status, get_custom_icons,
+    get_database_config, get_database_info, get_entry, get_entry_attachment, get_entry_password,
     get_entry_protected_custom_field, get_group, get_group_entry_counts, get_keyfile_for_database,
     get_password_health_report, get_recent_databases, get_recycle_bin_id,
     get_window_content_protection_supported, has_session_key, inspect_database, list_backups,
@@ -30,6 +30,7 @@ use services::audit::key::FileBackedAuditKey;
 use services::audit::AuditService;
 use services::auto_lock::AutoLockService;
 use services::clipboard::ClipboardService;
+use services::drag_drop::DropPathsBuffer;
 use services::kdbx::KdbxService;
 use services::password_health::service::PasswordHealthService;
 use services::secure_storage::SecureStorageService;
@@ -43,6 +44,18 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
     builder
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
+        // Capture dropped file paths from the native window event *in Rust* so
+        // the renderer never names a file for the add (#286, ADR-0004). The
+        // paths are buffered here; the renderer decides whether to commit them
+        // (the drop must land on the selected Entry's panel) via
+        // `commit_dropped_attachments`, which drains the buffer.
+        .on_window_event(|window, event| {
+            if let tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) = event {
+                if let Some(buffer) = window.try_state::<Arc<DropPathsBuffer>>() {
+                    buffer.replace(paths.clone());
+                }
+            }
+        })
         .setup(|app| {
             let handle = app.handle();
             register_services(handle)?;
@@ -73,6 +86,7 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             get_entry,
             get_entry_attachment,
             add_entry_attachments,
+            commit_dropped_attachments,
             export_entry_attachment,
             delete_entry_attachment,
             get_entry_password,
@@ -142,6 +156,12 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     let kdbx_service = KdbxService::new();
     let kdbx_arc = Arc::new(kdbx_service);
     app.manage(Arc::clone(&kdbx_arc));
+
+    // Holds the paths from the most recent native drag-drop event so the
+    // trusted add path can read them without the renderer naming a file (#286,
+    // ADR-0004). Filled by the `on_window_event` handler, drained by
+    // `commit_dropped_attachments`.
+    app.manage(Arc::new(DropPathsBuffer::default()));
 
     let clipboard_service = ClipboardService::new();
     app.manage(Arc::new(clipboard_service));

--- a/src-tauri/src/services/drag_drop.rs
+++ b/src-tauri/src/services/drag_drop.rs
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// Holds the file paths from the most recent native `tauri://drag-drop` window
+/// event so the trusted add path can read them without the renderer ever naming
+/// a file. Paths are captured *in Rust* from the OS event (see ADR-0004) and
+/// stashed here; the `commit_dropped_attachments` command drains them with
+/// [`take`](DropPathsBuffer::take) and feeds them to
+/// `KdbxService::add_entry_attachments`. The renderer decides *whether* to
+/// commit (the drop must land on the selected Entry's panel) but never supplies
+/// the paths — there is no command parameter through which one could be passed.
+///
+/// A drop that the renderer chooses not to commit leaves its paths buffered
+/// until the next drop overwrites them or a commit drains them; staleness is
+/// bounded to a single drop because the renderer commits synchronously in the
+/// same drop handler.
+#[derive(Default)]
+pub struct DropPathsBuffer {
+    paths: Mutex<Vec<PathBuf>>,
+}
+
+impl DropPathsBuffer {
+    /// Overwrites the buffer with the paths from a fresh drop event.
+    pub fn replace(&self, paths: Vec<PathBuf>) {
+        if let Ok(mut guard) = self.paths.lock() {
+            *guard = paths;
+        }
+    }
+
+    /// Removes and returns the buffered paths, leaving the buffer empty so a
+    /// second commit (or a commit with no preceding drop) reads nothing.
+    pub fn take(&self) -> Vec<PathBuf> {
+        match self.paths.lock() {
+            Ok(mut guard) => std::mem::take(&mut *guard),
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn take_drains_the_buffered_paths_and_empties_it() {
+        let buffer = DropPathsBuffer::default();
+        buffer.replace(vec![
+            PathBuf::from("/tmp/a.txt"),
+            PathBuf::from("/tmp/b.txt"),
+        ]);
+
+        let drained = buffer.take();
+        assert_eq!(
+            drained,
+            vec![PathBuf::from("/tmp/a.txt"), PathBuf::from("/tmp/b.txt")],
+            "take returns exactly what the drop captured, in order"
+        );
+
+        assert!(
+            buffer.take().is_empty(),
+            "a second commit with no fresh drop reads nothing"
+        );
+    }
+
+    #[test]
+    fn take_on_an_untouched_buffer_returns_nothing() {
+        let buffer = DropPathsBuffer::default();
+        assert!(
+            buffer.take().is_empty(),
+            "a commit with no preceding drop is a no-op"
+        );
+    }
+}

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -1497,6 +1497,40 @@ mod tests {
         );
     }
 
+    /// Asserts that feeding `paths` to the add feeder is a no-op: nothing is
+    /// added or fails, the Entry stays empty, and the Vault is unmodified.
+    /// Shared by the picker trust-boundary test (an empty pick while a secret
+    /// sits on disk) and the drop-commit no-op test (an empty buffer), since
+    /// both make the same "a path never handed in is never read" guarantee.
+    fn assert_empty_add_is_inert(service: &KdbxService, db_path: &str, entry_id: &str) {
+        let generation_before = service
+            .with_vault(db_path, |vault| Ok(vault.generation()))
+            .expect("generation before");
+
+        let outcome = service
+            .add_entry_attachments(db_path, entry_id, &[])
+            .expect("empty add");
+
+        assert!(outcome.added.is_empty(), "nothing is added");
+        assert!(outcome.failed.is_empty(), "and nothing fails");
+
+        let entry = service.get_entry(db_path, entry_id).expect("get entry");
+        assert!(
+            entry.attachments.is_empty(),
+            "a file never handed to the add path must not be readable through it"
+        );
+        service
+            .with_vault(db_path, |vault| {
+                assert_eq!(
+                    vault.generation(),
+                    generation_before,
+                    "no read means no modification"
+                );
+                Ok(())
+            })
+            .expect("vault scope");
+    }
+
     #[test]
     fn add_entry_attachments_reads_only_paths_handed_to_it() {
         // The trust boundary (issue #296): a file the user never selected
@@ -1511,35 +1545,7 @@ mod tests {
         let secret = dir.path().join("id_rsa");
         std::fs::write(&secret, b"-----BEGIN PRIVATE KEY-----").expect("seed secret");
 
-        let generation_before = service
-            .with_vault(&db_path, |vault| Ok(vault.generation()))
-            .expect("generation before");
-
-        let outcome = service
-            .add_entry_attachments(&db_path, &entry_a, &[])
-            .expect("empty batch");
-
-        assert!(
-            outcome.added.is_empty(),
-            "nothing is added from an empty pick"
-        );
-        assert!(outcome.failed.is_empty(), "and nothing fails either");
-
-        let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
-        assert!(
-            entry.attachments.is_empty(),
-            "a file never handed to the add path must not be readable through it"
-        );
-        service
-            .with_vault(&db_path, |vault| {
-                assert_eq!(
-                    vault.generation(),
-                    generation_before,
-                    "no read means no modification"
-                );
-                Ok(())
-            })
-            .expect("vault scope");
+        assert_empty_add_is_inert(&service, &db_path, &entry_a);
     }
 
     #[test]
@@ -1587,38 +1593,14 @@ mod tests {
     fn commit_with_no_preceding_drop_is_a_noop() {
         // The drop event is window-global, so a commit can fire with nothing
         // buffered (e.g. a stale render). Draining an empty buffer hands the
-        // feeder no paths: nothing is read, nothing is stored, the Vault is
+        // feeder no paths, so nothing is read or stored and the Vault is
         // untouched — the same guarantee as a cancelled picker dialog.
         let (service, _dir, db_path, entry_a, _b) = create_test_database();
 
-        let generation_before = service
-            .with_vault(&db_path, |vault| Ok(vault.generation()))
-            .expect("generation before");
-
         let buffer = crate::services::drag_drop::DropPathsBuffer::default();
-        let paths = buffer.take();
-        let outcome = service
-            .add_entry_attachments(&db_path, &entry_a, &paths)
-            .expect("empty commit");
+        assert!(buffer.take().is_empty(), "no drop means no buffered paths");
 
-        assert!(outcome.added.is_empty(), "an empty drop adds nothing");
-        assert!(outcome.failed.is_empty(), "and fails nothing");
-
-        let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
-        assert!(
-            entry.attachments.is_empty(),
-            "a commit with no buffered drop leaves the Entry untouched"
-        );
-        service
-            .with_vault(&db_path, |vault| {
-                assert_eq!(
-                    vault.generation(),
-                    generation_before,
-                    "no paths means no read and no modification"
-                );
-                Ok(())
-            })
-            .expect("vault scope");
+        assert_empty_add_is_inert(&service, &db_path, &entry_a);
     }
 
     #[test]

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -1543,6 +1543,85 @@ mod tests {
     }
 
     #[test]
+    fn commit_drains_the_drop_buffer_into_the_add_feeder() {
+        // Drag-and-drop (#286) reuses the same trusted feeder as the picker: a
+        // native drop buffers its OS-provided paths, and the commit drains them
+        // into `add_entry_attachments`. This proves the drain+feed seam end to
+        // end — what the drop captured lands on the Entry, and the buffer is
+        // emptied so the same drop can't be replayed against a later entry.
+        let (service, dir, db_path, entry_a, _b) = create_test_database();
+        let dropped = dir.path().join("dropped.txt");
+        std::fs::write(&dropped, b"from a drag-drop").expect("seed dropped file");
+
+        let buffer = crate::services::drag_drop::DropPathsBuffer::default();
+        buffer.replace(vec![dropped.clone()]);
+
+        // The commit drains the buffer and hands only those paths to the feeder.
+        let paths = buffer.take();
+        let outcome = service
+            .add_entry_attachments(&db_path, &entry_a, &paths)
+            .expect("commit drained drop");
+
+        assert_eq!(
+            outcome.added,
+            vec!["dropped.txt".to_string()],
+            "the dropped file lands on the Entry through the shared feeder"
+        );
+
+        let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
+        assert!(
+            entry
+                .attachments
+                .iter()
+                .any(|a| a.filename == "dropped.txt"),
+            "the attachment is persisted on the Entry"
+        );
+
+        assert!(
+            buffer.take().is_empty(),
+            "the buffer is drained, so a second commit reads nothing"
+        );
+    }
+
+    #[test]
+    fn commit_with_no_preceding_drop_is_a_noop() {
+        // The drop event is window-global, so a commit can fire with nothing
+        // buffered (e.g. a stale render). Draining an empty buffer hands the
+        // feeder no paths: nothing is read, nothing is stored, the Vault is
+        // untouched — the same guarantee as a cancelled picker dialog.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+
+        let generation_before = service
+            .with_vault(&db_path, |vault| Ok(vault.generation()))
+            .expect("generation before");
+
+        let buffer = crate::services::drag_drop::DropPathsBuffer::default();
+        let paths = buffer.take();
+        let outcome = service
+            .add_entry_attachments(&db_path, &entry_a, &paths)
+            .expect("empty commit");
+
+        assert!(outcome.added.is_empty(), "an empty drop adds nothing");
+        assert!(outcome.failed.is_empty(), "and fails nothing");
+
+        let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
+        assert!(
+            entry.attachments.is_empty(),
+            "a commit with no buffered drop leaves the Entry untouched"
+        );
+        service
+            .with_vault(&db_path, |vault| {
+                assert_eq!(
+                    vault.generation(),
+                    generation_before,
+                    "no paths means no read and no modification"
+                );
+                Ok(())
+            })
+            .expect("vault scope");
+    }
+
+    #[test]
     fn list_entries_without_group_filter_hides_recycle_bin_entries() {
         // Regression: deleting an entry moves it to the recycle bin, but the
         // unfiltered list view used to keep returning it (since

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod audit;
 pub mod auto_lock;
 pub mod clipboard;
 pub mod crypto;
+pub mod drag_drop;
 pub mod generator;
 pub mod kdbx;
 pub mod password_health;

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -688,4 +688,35 @@ describe("EntryItemDetails attachment drop zone", () => {
 
     expect(dragDrop.handler).toBeNull();
   });
+
+  it("highlights the drop zone while a file is dragged over it", () => {
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    act(() => {
+      dragDrop.handler?.({
+        payload: { type: "over", position: { x: 50, y: 50 } },
+      });
+    });
+
+    expect(screen.getByText("entries.detail.dropToAttach").className).toContain(
+      "border-primary"
+    );
+    rect.mockRestore();
+  });
+
+  it("surfaces a batch error toast when a dropped commit rejects", async () => {
+    commitDroppedAttachments.mockRejectedValue(new Error("vault locked"));
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    await fireDrop({ x: 50, y: 50 });
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled();
+    });
+    expect(databaseSave).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    rect.mockRestore();
+  });
 });

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -596,7 +596,7 @@ describe("EntryItemDetails attachment drop zone", () => {
         x: 0,
         y: 0,
         toJSON: () => ({}),
-      } as DOMRect);
+      });
   }
 
   async function fireDrop(position: { x: number; y: number }) {

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -1,7 +1,13 @@
 // SPDX-License-Identifier: MIT
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import dayjs from "dayjs";
 
@@ -68,6 +74,7 @@ vi.mock("@/hooks/use-clipboard-timeout", () => ({
 const exportAttachment = vi.hoisted(() => vi.fn());
 const deleteAttachment = vi.hoisted(() => vi.fn());
 const addAttachments = vi.hoisted(() => vi.fn());
+const commitDroppedAttachments = vi.hoisted(() => vi.fn());
 const databaseSave = vi.hoisted(() => vi.fn());
 const save = vi.hoisted(() => vi.fn());
 const ask = vi.hoisted(() => vi.fn());
@@ -81,8 +88,32 @@ vi.mock("@/lib/tauri", () => ({
     exportAttachment,
     deleteAttachment,
     addAttachments,
+    commitDroppedAttachments,
   },
   database: { save: databaseSave },
+}));
+
+// Mutable holder for the responsive breakpoint so each test can render the
+// desktop (drop zone present) or mobile (drop zone hidden) layout.
+const mobile = vi.hoisted(() => ({ isMobile: false }));
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mobile.isMobile,
+}));
+
+// Captures the handler the detail panel registers for the native
+// `tauri://drag-drop` event so tests can fire synthetic drop events at it.
+const dragDrop = vi.hoisted(() => ({
+  handler: null as ((event: { payload: unknown }) => void) | null,
+}));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: (handler: (event: { payload: unknown }) => void) => {
+      dragDrop.handler = handler;
+      return Promise.resolve(() => {
+        dragDrop.handler = null;
+      });
+    },
+  }),
 }));
 
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl: vi.fn() }));
@@ -510,5 +541,151 @@ describe("EntryItemDetails attachment add", () => {
     });
     expect(toastError).toHaveBeenCalledTimes(1);
     expect(toastSuccess).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("EntryItemDetails attachment drop zone", () => {
+  beforeEach(() => {
+    state.entry = null;
+    state.isTransitioning = false;
+    mobile.isMobile = false;
+    dragDrop.handler = null;
+    commitDroppedAttachments.mockReset();
+    databaseSave.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  it("shows the drop-zone affordance on desktop alongside the picker button", () => {
+    mobile.isMobile = false;
+    renderDetails({ attachments: [] });
+
+    expect(screen.getByText("entries.detail.dropToAttach")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "entries.detail.addAttachment" })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the drop zone on mobile but keeps the picker button", () => {
+    // Mobile has no OS file-drop, so the affordance is gone; the picker button
+    // remains the only way to add an attachment there.
+    mobile.isMobile = true;
+    renderDetails({ attachments: [] });
+
+    expect(
+      screen.queryByText("entries.detail.dropToAttach")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "entries.detail.addAttachment" })
+    ).toBeInTheDocument();
+  });
+
+  // The native event reports a physical position; the panel is mocked to a
+  // 100x100 box at the origin so a position inside (50,50) vs. outside (500,500)
+  // exercises the scoping hit-test (devicePixelRatio defaults to 1 in jsdom).
+  function mockPanelRect() {
+    return vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        left: 0,
+        top: 0,
+        right: 100,
+        bottom: 100,
+        width: 100,
+        height: 100,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect);
+  }
+
+  async function fireDrop(position: { x: number; y: number }) {
+    await act(async () => {
+      dragDrop.handler?.({ payload: { type: "drop", position } });
+    });
+  }
+
+  it("commits a drop that lands inside the panel via the shared add path", async () => {
+    // A drop on the selected Entry's panel drains the Rust-side buffer (the
+    // command takes only ids — no path) and then goes through the exact same
+    // tail as the picker: persist once, refresh, success toast.
+    commitDroppedAttachments.mockResolvedValue({
+      added: ["dropped.txt"],
+      failed: [],
+    });
+    databaseSave.mockResolvedValue(undefined);
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    expect(dragDrop.handler).toBeTypeOf("function");
+
+    await fireDrop({ x: 50, y: 50 });
+
+    await waitFor(() => {
+      expect(commitDroppedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+    });
+    expect(databaseSave).toHaveBeenCalledWith("db-1");
+    expect(toastSuccess).toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+    rect.mockRestore();
+  });
+
+  it("does not persist when a dropped batch wholly fails", async () => {
+    // Same no-phantom-save guard as the picker: a fully-failed drop reports its
+    // per-file failures but never persists or reports success.
+    commitDroppedAttachments.mockResolvedValue({
+      added: [],
+      failed: [{ sourceName: "huge.bin", reason: "too large" }],
+    });
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    await fireDrop({ x: 50, y: 50 });
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledTimes(1);
+    });
+    expect(databaseSave).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    rect.mockRestore();
+  });
+
+  it("ignores a drop that lands outside the panel", async () => {
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    await fireDrop({ x: 500, y: 500 });
+
+    expect(commitDroppedAttachments).not.toHaveBeenCalled();
+    expect(databaseSave).not.toHaveBeenCalled();
+    rect.mockRestore();
+  });
+
+  it("ignores a drop while the entry is transitioning", async () => {
+    // A drop landing mid-transition could target a stale entry, so it no-ops.
+    state.isTransitioning = true;
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    await fireDrop({ x: 50, y: 50 });
+
+    expect(commitDroppedAttachments).not.toHaveBeenCalled();
+    rect.mockRestore();
+  });
+
+  it("registers no drop handler when no entry is selected", () => {
+    // With no entry the detail panel renders a skeleton, so nothing subscribes
+    // to the window-global drop event — drops are ignored structurally.
+    state.entry = null;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EntryItemDetails entryId="entry-1" dbId="db-1" />
+      </QueryClientProvider>
+    );
+
+    expect(dragDrop.handler).toBeNull();
   });
 });

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -1,4 +1,4 @@
-import { createElement, useCallback, useState } from "react";
+import { createElement, useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import dayjs from "dayjs";
 import { Separator } from "@/components/ui/separator.tsx";
@@ -30,6 +30,8 @@ import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useCustomIcons } from "@/hooks/use-custom-icons";
 import { useClipboardCountdown } from "@/hooks/use-clipboard-countdown";
 import { useClipboardTimeout } from "@/hooks/use-clipboard-timeout";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { useAttachmentDrop } from "@/hooks/use-attachment-drop";
 import { useQueryClient } from "@tanstack/react-query";
 import { clipboard, entries as entriesApi } from "@/lib/tauri";
 import { queryKeys } from "@/lib/query-keys";
@@ -585,6 +587,8 @@ function AttachmentsSection({
 }>) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  const isMobile = useIsMobile();
+  const panelRef = useRef<HTMLDivElement>(null);
 
   // Sorted by filename, case-insensitively, for a stable display order (the
   // KDBX binary pool is unordered). Copy first so we never mutate props.
@@ -627,15 +631,39 @@ function AttachmentsSection({
       }),
     ]);
 
+  // Shared tail for both add paths (picker and drag-drop): the backend has
+  // already read, size-capped, and auto-renamed each file, returning a batch
+  // outcome. We surface one toast per failure naming the file and the backend's
+  // reason (e.g. "exceeds the 25 MiB limit") so the user knows which file and
+  // whether retrying could ever work, then persist once and refresh only when
+  // at least one file actually landed in the in-memory Vault — so a
+  // wholly-failed, cancelled, or empty batch leaves no phantom unsaved state.
+  const applyAddOutcome = async (
+    outcome: Awaited<ReturnType<typeof entriesApi.addAttachments>>
+  ) => {
+    for (const failure of outcome.failed) {
+      toast.error(
+        t("entries.detail.attachmentAddFailed", {
+          filename: failure.sourceName,
+          reason: failure.reason,
+        })
+      );
+    }
+
+    if (outcome.added.length > 0) {
+      await saveWithErrorToast(dbId, t);
+      await invalidateEntryQueries();
+      toast.success(
+        t("entries.detail.attachmentsAdded", { count: outcome.added.length })
+      );
+    }
+  };
+
   // Add is the primary write path. The multi-select file dialog is opened in
   // Rust by the add command — the frontend passes no path, so a fabricated
   // path can never reach the backend read (the trust boundary in ADR-0004).
-  // The backend reads, size-caps, and auto-renames each picked file; a failure
-  // on one (e.g. over the hard cap) doesn't abort the rest. We surface one
-  // toast per failure naming the file and the backend's reason (e.g. "exceeds
-  // the 25 MiB limit") so the user knows which file and whether retrying could
-  // ever work, then persist once and refresh only when something actually
-  // landed. A cancelled dialog comes back as an empty outcome — a no-op.
+  // A failure on one file doesn't abort the rest; a cancelled dialog comes back
+  // as an empty outcome — a no-op handled by the shared tail below.
   const handleAdd = async () => {
     if (isDisabled) return;
 
@@ -648,26 +676,38 @@ function AttachmentsSection({
       return;
     }
 
-    for (const failure of outcome.failed) {
-      toast.error(
-        t("entries.detail.attachmentAddFailed", {
-          filename: failure.sourceName,
-          reason: failure.reason,
-        })
-      );
-    }
-
-    // Persist and refresh only when at least one file actually landed in the
-    // in-memory Vault, so a wholly-failed or cancelled batch leaves no phantom
-    // unsaved state.
-    if (outcome.added.length > 0) {
-      await saveWithErrorToast(dbId, t);
-      await invalidateEntryQueries();
-      toast.success(
-        t("entries.detail.attachmentsAdded", { count: outcome.added.length })
-      );
-    }
+    await applyAddOutcome(outcome);
   };
+
+  // Drag-and-drop is the second write path (desktop only). The dropped paths
+  // were captured in Rust from the native window event (ADR-0004) — this only
+  // tells the backend to drain that buffer onto the selected Entry. The drop
+  // hook has already scoped the drop to this panel; from here it's identical to
+  // the picker (same feeder, same outcome handling).
+  const handleDrop = () => {
+    if (isDisabled) return;
+    void (async () => {
+      let outcome: Awaited<
+        ReturnType<typeof entriesApi.commitDroppedAttachments>
+      >;
+      try {
+        outcome = await entriesApi.commitDroppedAttachments(dbId, entryId);
+      } catch (error) {
+        console.error("Failed to add dropped attachments:", error);
+        toast.error(t("entries.detail.attachmentAddBatchFailed"));
+        return;
+      }
+      await applyAddOutcome(outcome);
+    })();
+  };
+
+  // The native drag-drop event is window-global; the hook acts only on desktop
+  // and only when a drop lands inside this panel (and not mid-transition).
+  const { isDragOver } = useAttachmentDrop({
+    enabled: !isMobile && !isDisabled,
+    panelRef,
+    onDrop: handleDrop,
+  });
 
   // Deleting an attachment is destructive and has no undo, so we confirm
   // first. On confirm the backend drops the Entry's reference (and the
@@ -704,7 +744,7 @@ function AttachmentsSection({
   };
 
   return (
-    <div className="border rounded-md">
+    <div ref={panelRef} className="border rounded-md">
       <div className="flex items-center justify-between px-4 py-2">
         <small className="text-sm font-medium">
           {t("entries.detail.attachments")}
@@ -766,6 +806,24 @@ function AttachmentsSection({
             );
           })}
         </ul>
+      )}
+      {/* Drop zone is desktop-only: mobile has no OS file-drop, so only the
+          picker button above is offered there (hidden via useIsMobile). */}
+      {!isMobile && (
+        <>
+          <Separator />
+          <div className="px-4 py-2">
+            <div
+              className={cn(
+                "flex items-center justify-center gap-2 rounded-md border border-dashed px-4 py-6 text-sm text-muted-foreground transition-colors",
+                isDragOver && "border-primary bg-primary/5 text-foreground"
+              )}
+            >
+              <Paperclip className="h-4 w-4" />
+              {t("entries.detail.dropToAttach")}
+            </div>
+          </div>
+        </>
       )}
     </div>
   );

--- a/src/hooks/__tests__/use-attachment-drop.test.tsx
+++ b/src/hooks/__tests__/use-attachment-drop.test.tsx
@@ -37,7 +37,7 @@ function makePanelRef(): RefObject<HTMLElement | null> {
     x: 0,
     y: 0,
     toJSON: () => ({}),
-  } as DOMRect);
+  });
   return { current: el };
 }
 

--- a/src/hooks/__tests__/use-attachment-drop.test.tsx
+++ b/src/hooks/__tests__/use-attachment-drop.test.tsx
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { type RefObject } from "react";
+
+import { useAttachmentDrop } from "../use-attachment-drop";
+
+// Capture the handler the hook registers for the native drag-drop event so the
+// tests can fire synthetic enter/over/leave/drop events at it. This overrides
+// the inert default mock in the global test setup.
+const dragDrop = vi.hoisted(() => ({
+  handler: null as ((event: { payload: unknown }) => void) | null,
+}));
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: (handler: (event: { payload: unknown }) => void) => {
+      dragDrop.handler = handler;
+      return Promise.resolve(() => {
+        dragDrop.handler = null;
+      });
+    },
+  }),
+}));
+
+// A 100x100 panel anchored at the origin: a position at (50,50) lands inside,
+// (500,500) outside.
+function makePanelRef(): RefObject<HTMLElement | null> {
+  const el = document.createElement("div");
+  vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+    left: 0,
+    top: 0,
+    right: 100,
+    bottom: 100,
+    width: 100,
+    height: 100,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return { current: el };
+}
+
+function fire(payload: unknown) {
+  act(() => {
+    dragDrop.handler?.({ payload });
+  });
+}
+
+const INSIDE = { x: 50, y: 50 };
+const OUTSIDE = { x: 500, y: 500 };
+
+describe("useAttachmentDrop", () => {
+  beforeEach(() => {
+    dragDrop.handler = null;
+    window.devicePixelRatio = 1;
+  });
+
+  it("highlights while a drag hovers inside the panel and clears on leave", () => {
+    const panelRef = makePanelRef();
+    const { result } = renderHook(() =>
+      useAttachmentDrop({ enabled: true, panelRef, onDrop: vi.fn() })
+    );
+
+    fire({ type: "over", position: INSIDE });
+    expect(result.current.isDragOver).toBe(true);
+
+    fire({ type: "leave" });
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it("does not highlight when the drag hovers outside the panel", () => {
+    const panelRef = makePanelRef();
+    const { result } = renderHook(() =>
+      useAttachmentDrop({ enabled: true, panelRef, onDrop: vi.fn() })
+    );
+
+    fire({ type: "enter", position: OUTSIDE });
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it("invokes onDrop for a drop inside the panel and clears the highlight", () => {
+    const panelRef = makePanelRef();
+    const onDrop = vi.fn();
+    const { result } = renderHook(() =>
+      useAttachmentDrop({ enabled: true, panelRef, onDrop })
+    );
+
+    fire({ type: "over", position: INSIDE });
+    fire({ type: "drop", position: INSIDE });
+
+    expect(onDrop).toHaveBeenCalledTimes(1);
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it("ignores a drop that lands outside the panel", () => {
+    const panelRef = makePanelRef();
+    const onDrop = vi.fn();
+    renderHook(() => useAttachmentDrop({ enabled: true, panelRef, onDrop }));
+
+    fire({ type: "drop", position: OUTSIDE });
+
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("no-ops entirely while disabled", () => {
+    const panelRef = makePanelRef();
+    const onDrop = vi.fn();
+    const { result } = renderHook(() =>
+      useAttachmentDrop({ enabled: false, panelRef, onDrop })
+    );
+
+    fire({ type: "over", position: INSIDE });
+    fire({ type: "drop", position: INSIDE });
+
+    expect(result.current.isDragOver).toBe(false);
+    expect(onDrop).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing panel element as outside", () => {
+    const onDrop = vi.fn();
+    const panelRef: RefObject<HTMLElement | null> = { current: null };
+    const { result } = renderHook(() =>
+      useAttachmentDrop({ enabled: true, panelRef, onDrop })
+    );
+
+    fire({ type: "drop", position: INSIDE });
+
+    expect(onDrop).not.toHaveBeenCalled();
+    expect(result.current.isDragOver).toBe(false);
+  });
+
+  it("scales the physical drop position by the device pixel ratio", () => {
+    // On a 2x display the native event reports physical pixels: a CSS-(50,50)
+    // hit inside the 100x100 panel arrives as physical (100,100).
+    window.devicePixelRatio = 2;
+    const panelRef = makePanelRef();
+    const onDrop = vi.fn();
+    renderHook(() => useAttachmentDrop({ enabled: true, panelRef, onDrop }));
+
+    fire({ type: "drop", position: { x: 100, y: 100 } });
+    expect(onDrop).toHaveBeenCalledTimes(1);
+
+    // The same physical point would fall outside without the scaling.
+    fire({ type: "drop", position: { x: 300, y: 300 } });
+    expect(onDrop).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/use-attachment-drop.ts
+++ b/src/hooks/use-attachment-drop.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useRef, useState, type RefObject } from "react";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+interface PhysicalPosition {
+  x: number;
+  y: number;
+}
+
+interface UseAttachmentDropArgs {
+  /**
+   * Whether drops should be acted on. The native drag-drop event is
+   * window-global, so the listener is always registered, but it no-ops unless
+   * enabled — desktop only, an Entry selected, and not mid-transition.
+   */
+  enabled: boolean;
+  /** The Entry detail region a drop must land on to count (scoping). */
+  panelRef: RefObject<HTMLElement | null>;
+  /** Invoked once per drop that lands inside the panel while enabled. */
+  onDrop: () => void;
+}
+
+/**
+ * Wires the native `tauri://drag-drop` window event to a single Entry's detail
+ * panel. The event is window-global, so this hook scopes it two ways: it acts
+ * only while `enabled` (desktop, an Entry selected, not transitioning) and only
+ * when the drop position falls inside `panelRef`. It never reads the dropped
+ * paths — those are captured in Rust (ADR-0004); `onDrop` triggers the commit
+ * command that drains the backend buffer. The returned `isDragOver` flag drives
+ * the drop-zone highlight while a drag hovers the panel.
+ */
+export function useAttachmentDrop({
+  enabled,
+  panelRef,
+  onDrop,
+}: UseAttachmentDropArgs): { isDragOver: boolean } {
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  // Keep the latest enabled/onDrop in refs so the listener is registered once
+  // (on mount) yet always reads current values — re-registering the native
+  // listener on every render would drop in-flight drag state.
+  const enabledRef = useRef(enabled);
+  const onDropRef = useRef(onDrop);
+  useEffect(() => {
+    enabledRef.current = enabled;
+    onDropRef.current = onDrop;
+  }, [enabled, onDrop]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined;
+    let disposed = false;
+
+    const register = getCurrentWebview().onDragDropEvent((event) => {
+      const payload = event.payload as
+        | { type: "enter" | "over"; position: PhysicalPosition }
+        | { type: "drop"; position: PhysicalPosition }
+        | { type: "leave" };
+
+      if (!enabledRef.current) {
+        setIsDragOver(false);
+        return;
+      }
+
+      if (payload.type === "leave") {
+        setIsDragOver(false);
+        return;
+      }
+
+      const inside = isInsidePanel(panelRef.current, payload.position);
+
+      if (payload.type === "drop") {
+        setIsDragOver(false);
+        if (inside) onDropRef.current();
+        return;
+      }
+
+      // enter / over: highlight only while hovering the panel.
+      setIsDragOver(inside);
+    });
+
+    void register.then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, [panelRef]);
+
+  return { isDragOver };
+}
+
+/**
+ * Hit-tests a physical drop position against an element's box. The native event
+ * reports physical pixels (window-relative); `getBoundingClientRect` is in CSS
+ * pixels (viewport-relative), so we scale by the device pixel ratio. On the
+ * frameless desktop window the webview fills the viewport, so the two origins
+ * align.
+ */
+function isInsidePanel(
+  el: HTMLElement | null,
+  position: PhysicalPosition
+): boolean {
+  if (!el) return false;
+  const rect = el.getBoundingClientRect();
+  const dpr = window.devicePixelRatio || 1;
+  const x = position.x / dpr;
+  const y = position.y / dpr;
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -328,6 +328,28 @@ export const entries = {
   },
 
   /**
+   * Adds the files from the most recent native drag-drop event to an Entry.
+   * The paths were captured *in Rust* from the `tauri://drag-drop` window event
+   * and buffered backend-side — this call passes only the target ids, so a
+   * renderer-supplied path can never reach the read (the same trust boundary as
+   * the picker, ADR-0004). The caller is responsible for only invoking this
+   * when a drop lands on the selected Entry's panel; the backend drains the
+   * buffer, so a commit with no preceding drop returns an empty outcome. Files
+   * go through the same feeder as the picker (hard cap, auto-rename, per-file
+   * failures); the caller persists via `database.save` and refreshes when
+   * anything landed.
+   */
+  async commitDroppedAttachments(
+    dbId: string,
+    id: string
+  ): Promise<AddAttachmentsOutcome> {
+    DbIdSchema.parse({ dbId });
+    IdSchema.parse({ id });
+    const result = await invoke("commit_dropped_attachments", { dbId, id });
+    return AddAttachmentsOutcomeSchema.parse(result);
+  },
+
+  /**
    * Exports (downloads) a single Attachment by writing its bytes to a
    * user-chosen path. The save dialog runs in the UI; the resolved
    * `destPath` is handed to the backend, which fetches the bytes and writes

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -345,6 +345,7 @@
       "attachments": "Anhänge",
       "noAttachments": "Keine Anhänge",
       "addAttachment": "Anhang hinzufügen",
+      "dropToAttach": "Dateien hier ablegen, um sie anzuhängen",
       "attachmentsAdded_one": "{{count}} Anhang hinzugefügt",
       "attachmentsAdded_other": "{{count}} Anhänge hinzugefügt",
       "attachmentAddFailed": "{{filename}} konnte nicht hinzugefügt werden: {{reason}}",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -368,6 +368,7 @@
       "attachments": "Attachments",
       "noAttachments": "No attachments",
       "addAttachment": "Add attachment",
+      "dropToAttach": "Drop files here to attach",
       "attachmentsAdded_one": "Added {{count}} attachment",
       "attachmentsAdded_other": "Added {{count}} attachments",
       "attachmentAddFailed": "Failed to add {{filename}}: {{reason}}",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -345,6 +345,7 @@
       "attachments": "Adjuntos",
       "noAttachments": "Sin adjuntos",
       "addAttachment": "Añadir adjunto",
+      "dropToAttach": "Suelta archivos aquí para adjuntarlos",
       "attachmentsAdded_one": "{{count}} adjunto añadido",
       "attachmentsAdded_other": "{{count}} adjuntos añadidos",
       "attachmentAddFailed": "No se pudo añadir {{filename}}: {{reason}}",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -345,6 +345,7 @@
       "attachments": "Pièces jointes",
       "noAttachments": "Aucune pièce jointe",
       "addAttachment": "Ajouter une pièce jointe",
+      "dropToAttach": "Déposez des fichiers ici pour les joindre",
       "attachmentsAdded_one": "{{count}} pièce jointe ajoutée",
       "attachmentsAdded_other": "{{count}} pièces jointes ajoutées",
       "attachmentAddFailed": "Échec de l'ajout de {{filename}} : {{reason}}",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -345,6 +345,7 @@
       "attachments": "Prilozi",
       "noAttachments": "Nema priloga",
       "addAttachment": "Dodaj prilog",
+      "dropToAttach": "Prevucite datoteke ovde da biste ih priložili",
       "attachmentsAdded_one": "Dodat {{count}} prilog",
       "attachmentsAdded_other": "Dodato {{count}} priloga",
       "attachmentAddFailed": "Dodavanje priloga {{filename}} nije uspelo: {{reason}}",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -17,6 +17,44 @@ if (!globalThis.ResizeObserver) {
   };
 }
 
+// jsdom lacks matchMedia, which `useIsMobile` and the theme provider rely on.
+// Default to the desktop breakpoint (no match); tests that care about the
+// mobile layout mock `@/hooks/use-mobile` directly.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {
+        /* noop for tests */
+      },
+      removeEventListener: () => {
+        /* noop for tests */
+      },
+      addListener: () => {
+        /* noop for tests */
+      },
+      removeListener: () => {
+        /* noop for tests */
+      },
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+
+// The native drag-drop listener (`useAttachmentDrop`) subscribes through the
+// webview API, which has no Tauri runtime under jsdom. Default to an inert
+// subscription; tests that exercise drops mock this module to capture the
+// handler.
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: () =>
+      Promise.resolve(() => {
+        /* noop unlisten for tests */
+      }),
+  }),
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -20,26 +20,25 @@ if (!globalThis.ResizeObserver) {
 // jsdom lacks matchMedia, which `useIsMobile` and the theme provider rely on.
 // Default to the desktop breakpoint (no match); tests that care about the
 // mobile layout mock `@/hooks/use-mobile` directly.
-if (!window.matchMedia) {
-  window.matchMedia = (query: string) =>
-    ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: () => {
-        /* noop for tests */
-      },
-      removeEventListener: () => {
-        /* noop for tests */
-      },
-      addListener: () => {
-        /* noop for tests */
-      },
-      removeListener: () => {
-        /* noop for tests */
-      },
-      dispatchEvent: () => false,
-    }) as unknown as MediaQueryList;
+if (!globalThis.matchMedia) {
+  globalThis.matchMedia = (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {
+      /* noop for tests */
+    },
+    removeEventListener: () => {
+      /* noop for tests */
+    },
+    addListener: () => {
+      /* noop for tests */
+    },
+    removeListener: () => {
+      /* noop for tests */
+    },
+    dispatchEvent: () => false,
+  });
 }
 
 // The native drag-drop listener (`useAttachmentDrop`) subscribes through the


### PR DESCRIPTION
## Summary

Closes #286. Desktop users can now add attachments by dropping files from the OS file manager onto the selected Entry's detail panel.

Dropped paths are captured **in Rust** from the native `tauri://drag-drop` window event into a `DropPathsBuffer`, never routed through JS — preserving the **ADR-0004** trust boundary (the renderer cannot name a file to import). The new `commit_dropped_attachments(db_id, id)` command drains the buffer into the **existing** `add_entry_attachments` feeder, so the drop path inherits the hard size cap, auto-rename on collision, per-file failures, and immediate persist for free.

The renderer owns affordance + scoping only: `useAttachmentDrop` drives the drop-zone highlight and commits a drop only when it lands inside the selected Entry's panel and not mid-transition. The drop zone is desktop-only — hidden on mobile via `useIsMobile()`, where the picker button remains the sole add path.

## Acceptance criteria

- [x] Dropping files onto the selected Entry's panel adds them via the same path as the file picker (cap + auto-rename + immediate persist)
- [x] Drops outside the Entry panel, or when no Entry is selected, are ignored
- [x] A drop-zone affordance is visible on desktop
- [x] The drop zone is hidden on mobile; the picker button remains available there
- [x] Component-level test covers the mobile/desktop gating of the drop zone

## Changes

**Backend**
- `services/drag_drop.rs` — `DropPathsBuffer` (`replace`/`take`)
- `lib.rs` — `on_window_event` captures `DragDropEvent::Drop` paths; buffer managed as state
- `commands/entries.rs` — `commit_dropped_attachments` drains the buffer into `add_entry_attachments`

**Frontend**
- `lib/tauri.ts` — `commitDroppedAttachments` wrapper
- `hooks/use-attachment-drop.ts` — native drop listener, panel hit-test scoping, `isDragOver` highlight
- `components/entries/EntryItemDetails.tsx` — extracted shared add-outcome tail, desktop-only drop zone gated by `useIsMobile()`
- `dropToAttach` added to all five locales
- `test/setup.ts` — global `matchMedia` polyfill + default inert webview mock (jsdom/Tauri gaps)

## Testing

Test-driven (red→green per slice).

- **Backend**: `commit_drains_the_drop_buffer_into_the_add_feeder`, `commit_with_no_preceding_drop_is_a_noop` (mirrors the existing trust-boundary test), plus `DropPathsBuffer` unit tests. `cargo test` all pass; clippy/fmt clean.
- **Frontend**: drop-zone desktop/mobile gating, valid drop → commit + persist + toast, wholly-failed batch doesn't persist, drop outside panel ignored, drop while transitioning ignored, no handler registered when no entry selected. 504 tests pass; lint/format/tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)