### PR TITLE
feat(ui): in-app preview for image and text attachments (#287)

### DIFF
--- a/src/components/entries/AttachmentPreviewModal.test.tsx
+++ b/src/components/entries/AttachmentPreviewModal.test.tsx
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { AttachmentPreviewModal } from "./AttachmentPreviewModal";
+
+const noop = () => undefined;
+
+// Three bytes that, base64-encoded, produce a predictable suffix we can match
+// on. UTF-8 they decode to "abc".
+const SAMPLE_BYTES = new Uint8Array([0x61, 0x62, 0x63]);
+
+function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+// Match the literal textContent against a <pre>, bypassing the library's
+// default whitespace normalization so we can assert on multi-line input.
+function findPreWithText(text: string) {
+  return screen.findByText((_, el) => {
+    return el?.tagName === "PRE" && el.textContent === text;
+  });
+}
+
+describe("AttachmentPreviewModal — text", () => {
+  it("renders the fetched bytes as decoded UTF-8 text in a <pre>", async () => {
+    const contents = "line one\nline two — π";
+    const fetchBytes = vi.fn().mockResolvedValue(utf8(contents));
+
+    render(
+      <AttachmentPreviewModal
+        open={true}
+        onOpenChange={noop}
+        attachment={{
+          filename: "notes.txt",
+          mimeType: "application/octet-stream",
+          size: utf8(contents).length,
+        }}
+        fetchBytes={fetchBytes}
+      />
+    );
+
+    const pre = await findPreWithText(contents);
+    expect(pre).toBeInTheDocument();
+    expect(fetchBytes).toHaveBeenCalledWith("notes.txt");
+  });
+
+  it("preserves the literal text without rendering markdown or syntax", async () => {
+    // Spec calls this out explicitly: raw monospace text, no markdown.
+    const md = "# Heading\n**not bold**";
+    const fetchBytes = vi.fn().mockResolvedValue(utf8(md));
+
+    render(
+      <AttachmentPreviewModal
+        open={true}
+        onOpenChange={noop}
+        attachment={{
+          filename: "README.md",
+          mimeType: "application/octet-stream",
+          size: utf8(md).length,
+        }}
+        fetchBytes={fetchBytes}
+      />
+    );
+
+    // Render preserves literal characters verbatim — no <h1>, no <strong>.
+    const pre = await findPreWithText(md);
+    expect(pre.querySelector("h1")).toBeNull();
+    expect(pre.querySelector("strong")).toBeNull();
+  });
+});
+
+describe("AttachmentPreviewModal — too-large", () => {
+  it("shows the too-large message and never fetches bytes", async () => {
+    const fetchBytes = vi.fn();
+    const TWO_MB_PLUS_ONE = 2 * 1024 * 1024 + 1;
+
+    render(
+      <AttachmentPreviewModal
+        open={true}
+        onOpenChange={noop}
+        attachment={{
+          filename: "huge.png",
+          mimeType: "image/png",
+          size: TWO_MB_PLUS_ONE,
+        }}
+        fetchBytes={fetchBytes}
+      />
+    );
+
+    expect(
+      await screen.findByText("entries.detail.attachmentPreviewTooLarge")
+    ).toBeInTheDocument();
+    // Avoid paying for the byte fetch we are about to refuse to render.
+    expect(fetchBytes).not.toHaveBeenCalled();
+  });
+});
+
+describe("AttachmentPreviewModal — image", () => {
+  it("renders the fetched bytes as a base64 data URL using the attachment MIME type", async () => {
+    const fetchBytes = vi.fn().mockResolvedValue(SAMPLE_BYTES);
+
+    render(
+      <AttachmentPreviewModal
+        open={true}
+        onOpenChange={noop}
+        attachment={{ filename: "logo.png", mimeType: "image/png", size: 3 }}
+        fetchBytes={fetchBytes}
+      />
+    );
+
+    const img = await screen.findByRole("img", { name: "logo.png" });
+    expect(img.getAttribute("src")).toBe("data:image/png;base64,YWJj");
+    expect(fetchBytes).toHaveBeenCalledWith("logo.png");
+  });
+});

--- a/src/components/entries/AttachmentPreviewModal.tsx
+++ b/src/components/entries/AttachmentPreviewModal.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import type { AttachmentMeta } from "@/lib/types";
+import { classifyAttachment } from "@/lib/attachment-preview";
+
+interface AttachmentPreviewModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  attachment: AttachmentMeta;
+  fetchBytes: (filename: string) => Promise<Uint8Array>;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  // chunked binary string → btoa, the standard browser path. Chunked to keep
+  // String.fromCharCode under its argument-limit on multi-MB payloads.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(
+      ...bytes.subarray(i, Math.min(i + CHUNK, bytes.length))
+    );
+  }
+  return btoa(binary);
+}
+
+export function AttachmentPreviewModal({
+  open,
+  onOpenChange,
+  attachment,
+  fetchBytes,
+}: Readonly<AttachmentPreviewModalProps>) {
+  const { t } = useTranslation();
+  const kind = classifyAttachment(attachment).kind;
+  const [bytes, setBytes] = useState<Uint8Array | null>(null);
+
+  useEffect(() => {
+    // Skip the byte fetch for kinds the modal will not render (too-large
+    // shows a message; none is rendered as nothing). Saves an IPC round-trip
+    // and keeps the in-memory copy of the bytes small.
+    if (!open || kind === "too-large" || kind === "none") return;
+    let cancelled = false;
+    void fetchBytes(attachment.filename).then((result) => {
+      if (!cancelled) setBytes(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, kind, attachment.filename, fetchBytes]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[80vh] overflow-auto">
+        <DialogHeader>
+          <DialogTitle>{attachment.filename}</DialogTitle>
+        </DialogHeader>
+        {kind === "too-large" ? (
+          <p className="text-sm text-muted-foreground">
+            {t("entries.detail.attachmentPreviewTooLarge")}
+          </p>
+        ) : kind === "image" && bytes ? (
+          <img
+            alt={attachment.filename}
+            src={`data:${attachment.mimeType};base64,${bytesToBase64(bytes)}`}
+          />
+        ) : kind === "text" && bytes ? (
+          <pre className="whitespace-pre-wrap break-words font-mono text-sm">
+            {new TextDecoder("utf-8").decode(bytes)}
+          </pre>
+        ) : (
+          <p>{t("entries.detail.attachmentPreviewLoading")}</p>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/entries/AttachmentPreviewModal.tsx
+++ b/src/components/entries/AttachmentPreviewModal.tsx
@@ -25,7 +25,7 @@ function bytesToBase64(bytes: Uint8Array): string {
   const CHUNK = 0x8000;
   let binary = "";
   for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(
+    binary += String.fromCodePoint(
       ...bytes.subarray(i, Math.min(i + CHUNK, bytes.length))
     );
   }
@@ -56,28 +56,42 @@ export function AttachmentPreviewModal({
     };
   }, [open, kind, attachment.filename, fetchBytes]);
 
+  const previewContent = (() => {
+    if (kind === "too-large") {
+      return (
+        <p className="text-sm text-muted-foreground">
+          {t("entries.detail.attachmentPreviewTooLarge")}
+        </p>
+      );
+    }
+
+    if (kind === "image" && bytes) {
+      return (
+        <img
+          alt={attachment.filename}
+          src={`data:${attachment.mimeType};base64,${bytesToBase64(bytes)}`}
+        />
+      );
+    }
+
+    if (kind === "text" && bytes) {
+      return (
+        <pre className="whitespace-pre-wrap break-words font-mono text-sm">
+          {new TextDecoder("utf-8").decode(bytes)}
+        </pre>
+      );
+    }
+
+    return <p>{t("entries.detail.attachmentPreviewLoading")}</p>;
+  })();
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl max-h-[80vh] overflow-auto">
         <DialogHeader>
           <DialogTitle>{attachment.filename}</DialogTitle>
         </DialogHeader>
-        {kind === "too-large" ? (
-          <p className="text-sm text-muted-foreground">
-            {t("entries.detail.attachmentPreviewTooLarge")}
-          </p>
-        ) : kind === "image" && bytes ? (
-          <img
-            alt={attachment.filename}
-            src={`data:${attachment.mimeType};base64,${bytesToBase64(bytes)}`}
-          />
-        ) : kind === "text" && bytes ? (
-          <pre className="whitespace-pre-wrap break-words font-mono text-sm">
-            {new TextDecoder("utf-8").decode(bytes)}
-          </pre>
-        ) : (
-          <p>{t("entries.detail.attachmentPreviewLoading")}</p>
-        )}
+        {previewContent}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -670,6 +670,31 @@ describe("EntryItemDetails attachment add", () => {
   });
 });
 
+// The native event reports a physical position; the panel is mocked to a
+// 100x100 box at the origin so a position inside (50,50) vs. outside (500,500)
+// exercises the scoping hit-test (devicePixelRatio defaults to 1 in jsdom).
+function mockPanelRect() {
+  return vi
+    .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+    .mockReturnValue({
+      left: 0,
+      top: 0,
+      right: 100,
+      bottom: 100,
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+}
+
+async function fireDrop(position: { x: number; y: number }) {
+  await act(async () => {
+    dragDrop.handler?.({ payload: { type: "drop", position } });
+  });
+}
+
 describe("EntryItemDetails attachment drop zone", () => {
   beforeEach(() => {
     state.entry = null;
@@ -705,31 +730,6 @@ describe("EntryItemDetails attachment drop zone", () => {
       screen.getByRole("button", { name: "entries.detail.addAttachment" })
     ).toBeInTheDocument();
   });
-
-  // The native event reports a physical position; the panel is mocked to a
-  // 100x100 box at the origin so a position inside (50,50) vs. outside (500,500)
-  // exercises the scoping hit-test (devicePixelRatio defaults to 1 in jsdom).
-  function mockPanelRect() {
-    return vi
-      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
-      .mockReturnValue({
-        left: 0,
-        top: 0,
-        right: 100,
-        bottom: 100,
-        width: 100,
-        height: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      });
-  }
-
-  async function fireDrop(position: { x: number; y: number }) {
-    await act(async () => {
-      dragDrop.handler?.({ payload: { type: "drop", position } });
-    });
-  }
 
   it("commits a drop that lands inside the panel via the shared add path", async () => {
     // A drop on the selected Entry's panel drains the Rust-side buffer (the

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -68,6 +68,7 @@ vi.mock("@/hooks/use-clipboard-timeout", () => ({
 const exportAttachment = vi.hoisted(() => vi.fn());
 const deleteAttachment = vi.hoisted(() => vi.fn());
 const addAttachments = vi.hoisted(() => vi.fn());
+const getAttachmentBytes = vi.hoisted(() => vi.fn());
 const databaseSave = vi.hoisted(() => vi.fn());
 const save = vi.hoisted(() => vi.fn());
 const ask = vi.hoisted(() => vi.fn());
@@ -81,6 +82,7 @@ vi.mock("@/lib/tauri", () => ({
     exportAttachment,
     deleteAttachment,
     addAttachments,
+    getAttachmentBytes,
   },
   database: { save: databaseSave },
 }));
@@ -281,6 +283,130 @@ describe("EntryItemDetails attachments section", () => {
     expect(filenames[0]).toContain("apple.png");
     expect(filenames[1]).toContain("Banana.gif");
     expect(filenames[2]).toContain("Zebra.txt");
+  });
+});
+
+describe("EntryItemDetails attachment preview", () => {
+  beforeEach(() => {
+    state.entry = null;
+    state.isTransitioning = false;
+    getAttachmentBytes.mockReset();
+  });
+
+  it("renders a Preview button for an image attachment", () => {
+    renderDetails({
+      attachments: [{ filename: "logo.png", size: 100, mimeType: "image/png" }],
+    });
+
+    expect(
+      screen.getByRole("button", { name: "entries.detail.previewAttachment" })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Preview button for non-previewable types (PDF)", () => {
+    renderWithPdf();
+
+    expect(
+      screen.queryByRole("button", { name: "entries.detail.previewAttachment" })
+    ).not.toBeInTheDocument();
+    // Download remains available for non-previewable types — that's the
+    // whole point of the gating.
+    expect(
+      screen.getByRole("button", { name: "entries.detail.downloadAttachment" })
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Preview button for SVG (browser-renderable but not previewable per spec)", () => {
+    renderDetails({
+      attachments: [
+        { filename: "icon.svg", size: 200, mimeType: "image/svg+xml" },
+      ],
+    });
+
+    expect(
+      screen.queryByRole("button", { name: "entries.detail.previewAttachment" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Preview button for a text attachment (.txt)", () => {
+    renderDetails({
+      attachments: [
+        {
+          filename: "notes.txt",
+          size: 50,
+          mimeType: "application/octet-stream",
+        },
+      ],
+    });
+
+    expect(
+      screen.getByRole("button", { name: "entries.detail.previewAttachment" })
+    ).toBeInTheDocument();
+  });
+
+  it("opens the modal and fetches bytes when Preview is clicked on an image", async () => {
+    getAttachmentBytes.mockResolvedValue(
+      new Uint8Array([0x61, 0x62, 0x63]) // "abc" → base64 "YWJj"
+    );
+
+    renderDetails({
+      attachments: [{ filename: "logo.png", size: 3, mimeType: "image/png" }],
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "entries.detail.previewAttachment" })
+    );
+
+    const img = await screen.findByRole("img", { name: "logo.png" });
+    expect(img.getAttribute("src")).toBe("data:image/png;base64,YWJj");
+    expect(getAttachmentBytes).toHaveBeenCalledWith(
+      "db-1",
+      "entry-1",
+      "logo.png"
+    );
+  });
+
+  it("opens the modal and fetches bytes when Preview is clicked on a text file", async () => {
+    const contents = "hello world";
+    getAttachmentBytes.mockResolvedValue(new TextEncoder().encode(contents));
+
+    renderDetails({
+      attachments: [
+        {
+          filename: "notes.txt",
+          size: contents.length,
+          mimeType: "application/octet-stream",
+        },
+      ],
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "entries.detail.previewAttachment" })
+    );
+
+    await waitFor(() => {
+      expect(getAttachmentBytes).toHaveBeenCalledWith(
+        "db-1",
+        "entry-1",
+        "notes.txt"
+      );
+    });
+    expect(await screen.findByText(contents)).toBeInTheDocument();
+  });
+
+  it("shows the Preview button for a previewable file above the size cap (modal explains it)", () => {
+    // Per the answered spec question: Preview button is still offered; the
+    // modal carries the "too large to preview — download to view" message.
+    const TWO_MB_PLUS_ONE = 2 * 1024 * 1024 + 1;
+    renderDetails({
+      attachments: [
+        { filename: "huge.png", size: TWO_MB_PLUS_ONE, mimeType: "image/png" },
+      ],
+    });
+
+    expect(
+      screen.getByRole("button", { name: "entries.detail.previewAttachment" })
+    ).toBeInTheDocument();
   });
 });
 

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -37,6 +37,8 @@ import { saveWithErrorToast } from "@/lib/save-with-error-toast";
 import { getKeepassIcon } from "@/lib/keepass-icons";
 import { isExpired } from "@/lib/entry-expiry";
 import { formatAttachmentSize } from "@/lib/entry-attachment";
+import { classifyAttachment } from "@/lib/attachment-preview";
+import { AttachmentPreviewModal } from "@/components/entries/AttachmentPreviewModal";
 import { cn } from "@/lib/utils";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { ask, save } from "@tauri-apps/plugin-dialog";
@@ -585,11 +587,24 @@ function AttachmentsSection({
 }>) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
+  // The Attachment the user opened the Preview modal on, or null when the
+  // modal is closed. Kept at the section level so the modal sits outside the
+  // row mapping (one modal, not one per row).
+  const [previewing, setPreviewing] = useState<AttachmentMeta | null>(null);
 
   // Sorted by filename, case-insensitively, for a stable display order (the
   // KDBX binary pool is unordered). Copy first so we never mutate props.
   const sorted = [...attachments].sort((a, b) =>
     a.filename.localeCompare(b.filename, undefined, { sensitivity: "base" })
+  );
+
+  // Preview fetches the bytes on demand via the same lazy byte-fetch the
+  // download path uses (no audit event — Preview is a read inside the Vault,
+  // not an export to the host filesystem).
+  const fetchPreviewBytes = useCallback(
+    (filename: string) =>
+      entriesApi.getAttachmentBytes(dbId, entryId, filename),
+    [dbId, entryId]
   );
 
   // Download is the only export path (ADR-0003): pick a destination with the
@@ -730,6 +745,11 @@ function AttachmentsSection({
         <ul>
           {sorted.map((attachment, index) => {
             const Icon = attachmentIcon(attachment.mimeType);
+            // Non-previewable types (PDF, SVG, archives, opaque binaries)
+            // don't get a Preview affordance at all — the spec says no
+            // broken preview button.
+            const isPreviewable =
+              classifyAttachment(attachment).kind !== "none";
             return (
               <li key={attachment.filename}>
                 {index > 0 && <Separator />}
@@ -741,6 +761,18 @@ function AttachmentsSection({
                   <span className="shrink-0 text-sm text-muted-foreground">
                     {formatAttachmentSize(attachment.size)}
                   </span>
+                  {isPreviewable && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0"
+                      aria-label={t("entries.detail.previewAttachment")}
+                      disabled={isDisabled}
+                      onClick={() => setPreviewing(attachment)}
+                    >
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                  )}
                   <Button
                     variant="ghost"
                     size="icon"
@@ -766,6 +798,16 @@ function AttachmentsSection({
             );
           })}
         </ul>
+      )}
+      {previewing && (
+        <AttachmentPreviewModal
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) setPreviewing(null);
+          }}
+          attachment={previewing}
+          fetchBytes={fetchPreviewBytes}
+        />
       )}
     </div>
   );

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -291,13 +291,14 @@ function PasswordRow({
     }
   };
 
-  const displayValue = isLoading ? (
-    <Loader2 className="inline h-3 w-3 animate-spin" />
-  ) : isVisible ? (
-    password
-  ) : (
-    "••••••••"
-  );
+  let displayValue: React.ReactNode;
+  if (isLoading) {
+    displayValue = <Loader2 className="inline h-3 w-3 animate-spin" />;
+  } else if (isVisible) {
+    displayValue = password;
+  } else {
+    displayValue = "••••••••";
+  }
 
   return (
     <div className="flex min-w-0 justify-between items-center px-4 py-2 gap-2">
@@ -459,13 +460,14 @@ function ProtectedCustomFieldRow({
     }
   };
 
-  const displayValue = isLoading ? (
-    <Loader2 className="inline h-3 w-3 animate-spin" />
-  ) : isVisible ? (
-    value
-  ) : (
-    "••••••••"
-  );
+  let displayValue: React.ReactNode;
+  if (isLoading) {
+    displayValue = <Loader2 className="inline h-3 w-3 animate-spin" />;
+  } else if (isVisible) {
+    displayValue = value;
+  } else {
+    displayValue = "••••••••";
+  }
 
   return (
     <div className="flex min-w-0 justify-between items-center px-4 py-2 gap-2">

--- a/src/lib/attachment-preview.test.ts
+++ b/src/lib/attachment-preview.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from "vitest";
+import {
+  classifyAttachment,
+  PREVIEW_MAX_BYTES,
+} from "@/lib/attachment-preview";
+
+const KB = 1024;
+
+describe("classifyAttachment", () => {
+  it("classifies a small PNG as a previewable image", () => {
+    expect(
+      classifyAttachment({
+        filename: "logo.png",
+        mimeType: "image/png",
+        size: 10 * KB,
+      })
+    ).toEqual({ kind: "image" });
+  });
+});
+
+describe("classifyAttachment — images", () => {
+  it.each<string>([
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+  ])("treats %s under the cap as a previewable image", (mimeType) => {
+    expect(
+      classifyAttachment({
+        filename: "pic",
+        mimeType,
+        size: 1 * KB,
+      })
+    ).toEqual({ kind: "image" });
+  });
+});
+
+describe("classifyAttachment — explicitly non-previewable types", () => {
+  it.each<[string, string]>([
+    // SVG is browser-renderable but executes script in its own context, so
+    // it is treated as Download-only by the issue spec.
+    ["icon.svg", "image/svg+xml"],
+    ["report.pdf", "application/pdf"],
+    ["archive.zip", "application/zip"],
+    ["doc.docx", "application/octet-stream"],
+    ["blob.bin", "application/octet-stream"],
+  ])(
+    "classifies %s with %s as none (no preview button)",
+    (filename, mimeType) => {
+      expect(classifyAttachment({ filename, mimeType, size: 1 * KB })).toEqual({
+        kind: "none",
+      });
+    }
+  );
+});
+
+describe("classifyAttachment — text", () => {
+  it("classifies a small .txt file as previewable text", () => {
+    expect(
+      classifyAttachment({
+        filename: "notes.txt",
+        mimeType: "application/octet-stream",
+        size: 50,
+      })
+    ).toEqual({ kind: "text" });
+  });
+
+  it.each<string>([
+    "txt",
+    "md",
+    "csv",
+    "json",
+    "xml",
+    "yaml",
+    "yml",
+    "ini",
+    "log",
+    "conf",
+  ])("treats .%s under the cap as previewable text", (ext) => {
+    expect(
+      classifyAttachment({
+        filename: `file.${ext}`,
+        mimeType: "application/octet-stream",
+        size: 1 * KB,
+      })
+    ).toEqual({ kind: "text" });
+  });
+
+  it("matches the extension case-insensitively", () => {
+    // Real-world filenames carry mixed case (e.g. README.MD on Windows).
+    expect(
+      classifyAttachment({
+        filename: "README.MD",
+        mimeType: "application/octet-stream",
+        size: 1 * KB,
+      })
+    ).toEqual({ kind: "text" });
+  });
+
+  it("falls back to none when there is no extension at all", () => {
+    expect(
+      classifyAttachment({
+        filename: "Makefile",
+        mimeType: "application/octet-stream",
+        size: 1 * KB,
+      })
+    ).toEqual({ kind: "none" });
+  });
+
+  it("falls back to none for an unknown text-ish extension", () => {
+    // The allowlist is exhaustive by design — adding new extensions is a
+    // conscious decision, not a heuristic that lights up on rs/py/sh.
+    expect(
+      classifyAttachment({
+        filename: "main.rs",
+        mimeType: "text/plain",
+        size: 1 * KB,
+      })
+    ).toEqual({ kind: "none" });
+  });
+});
+
+describe("classifyAttachment — size cap", () => {
+  it("classifies a previewable image above 2 MB as too-large", () => {
+    expect(
+      classifyAttachment({
+        filename: "huge.png",
+        mimeType: "image/png",
+        size: PREVIEW_MAX_BYTES + 1,
+      })
+    ).toEqual({ kind: "too-large" });
+  });
+
+  it("classifies a previewable text file above 2 MB as too-large", () => {
+    expect(
+      classifyAttachment({
+        filename: "huge.log",
+        mimeType: "application/octet-stream",
+        size: PREVIEW_MAX_BYTES + 1,
+      })
+    ).toEqual({ kind: "too-large" });
+  });
+
+  it("treats a file exactly at the cap as previewable, not too-large", () => {
+    expect(
+      classifyAttachment({
+        filename: "edge.png",
+        mimeType: "image/png",
+        size: PREVIEW_MAX_BYTES,
+      })
+    ).toEqual({ kind: "image" });
+  });
+
+  it("does not flag non-previewable types as too-large even when huge", () => {
+    // A 5 MB PDF would skip preview anyway; the size cap is a refinement of
+    // the previewable kinds, not a separate gate.
+    expect(
+      classifyAttachment({
+        filename: "scan.pdf",
+        mimeType: "application/pdf",
+        size: 5 * 1024 * 1024,
+      })
+    ).toEqual({ kind: "none" });
+  });
+});
+
+describe("PREVIEW_MAX_BYTES", () => {
+  it("caps preview at ~2 MB", () => {
+    expect(PREVIEW_MAX_BYTES).toBe(2 * 1024 * 1024);
+  });
+});

--- a/src/lib/attachment-preview.ts
+++ b/src/lib/attachment-preview.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Largest Attachment, in bytes, that the in-app preview will render. Files
+ * above this skip rendering and show a "too large to preview — download to
+ * view" message instead. Chosen so that base64-encoding a payload over the
+ * IPC boundary and holding the resulting `data:` URL in a single DOM node
+ * stays comfortably cheap on every supported desktop platform.
+ */
+export const PREVIEW_MAX_BYTES = 2 * 1024 * 1024;
+
+/**
+ * MIME types the preview renders as inline images via a `data:` URL. SVG is
+ * deliberately excluded — it is technically previewable in a browser but
+ * executes script in its own context, so it is treated as Download-only.
+ */
+const IMAGE_MIME_TYPES = new Set<string>([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+]);
+
+/**
+ * Filename extensions (lower-case, no leading dot) the preview renders as
+ * raw monospace text. Matched on extension rather than MIME because real
+ * KDBX attachments often arrive with `application/octet-stream` even when
+ * the file is plainly textual.
+ */
+const TEXT_EXTENSIONS = new Set<string>([
+  "txt",
+  "md",
+  "csv",
+  "json",
+  "xml",
+  "yaml",
+  "yml",
+  "ini",
+  "log",
+  "conf",
+]);
+
+function extensionOf(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot < 0 || dot === filename.length - 1) return "";
+  return filename.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * Result of classifying an Attachment for preview. A discriminated union so
+ * the caller can pattern-match without checking flags:
+ *
+ * - `image` / `text`: previewable and within the size cap — open the modal
+ *   and render via the matching path.
+ * - `too-large`: the type would be previewable, but the bytes exceed
+ *   [`PREVIEW_MAX_BYTES`]. The Preview button is still offered, but the
+ *   modal shows a "too large to preview — download to view" message.
+ * - `none`: the Attachment is not previewable (SVG, PDF, archives, office
+ *   docs, opaque binaries). The Preview button is hidden entirely.
+ */
+export type AttachmentPreviewKind =
+  | { kind: "image" }
+  | { kind: "text" }
+  | { kind: "too-large" }
+  | { kind: "none" };
+
+/**
+ * Classify an Attachment for in-app preview from its metadata. Pure: a given
+ * `(filename, mimeType, size)` always yields the same kind.
+ */
+export function classifyAttachment(meta: {
+  filename: string;
+  mimeType: string;
+  size: number;
+}): AttachmentPreviewKind {
+  const previewable: "image" | "text" | null = IMAGE_MIME_TYPES.has(
+    meta.mimeType
+  )
+    ? "image"
+    : TEXT_EXTENSIONS.has(extensionOf(meta.filename))
+      ? "text"
+      : null;
+  if (previewable === null) return { kind: "none" };
+  if (meta.size > PREVIEW_MAX_BYTES) return { kind: "too-large" };
+  return { kind: previewable };
+}

--- a/src/lib/attachment-preview.ts
+++ b/src/lib/attachment-preview.ts
@@ -74,13 +74,13 @@ export function classifyAttachment(meta: {
   mimeType: string;
   size: number;
 }): AttachmentPreviewKind {
-  const previewable: "image" | "text" | null = IMAGE_MIME_TYPES.has(
-    meta.mimeType
-  )
-    ? "image"
-    : TEXT_EXTENSIONS.has(extensionOf(meta.filename))
-      ? "text"
-      : null;
+  let previewable: "image" | "text" | null = null;
+  if (IMAGE_MIME_TYPES.has(meta.mimeType)) {
+    previewable = "image";
+  } else if (TEXT_EXTENSIONS.has(extensionOf(meta.filename))) {
+    previewable = "text";
+  }
+
   if (previewable === null) return { kind: "none" };
   if (meta.size > PREVIEW_MAX_BYTES) return { kind: "too-large" };
   return { kind: previewable };

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -346,6 +346,30 @@ export const entries = {
   },
 
   /**
+   * Fetches a single Attachment's bytes on demand, keyed by filename. Used by
+   * the in-app Preview modal to render image/text payloads inline without
+   * exporting to disk. Records no audit event — Preview is a read inside the
+   * Vault, not an export to the host filesystem. Returns the raw bytes as a
+   * `Uint8Array`; the backend serializes its `SecureBytes` as a JSON number
+   * array over IPC, which we widen to `Uint8Array` at the boundary so
+   * callers can construct `data:` URLs or decode UTF-8 directly.
+   */
+  async getAttachmentBytes(
+    dbId: string,
+    id: string,
+    filename: string
+  ): Promise<Uint8Array> {
+    DbIdSchema.parse({ dbId });
+    IdSchema.parse({ id });
+    const result = await invoke<number[]>("get_entry_attachment", {
+      dbId,
+      id,
+      filename,
+    });
+    return Uint8Array.from(result);
+  },
+
+  /**
    * Removes a single Attachment from an Entry, keyed by filename. The backend
    * drops the Entry's reference and (when it was the last reference) the
    * orphaned blob from the Vault-level pool, then marks the Vault modified.

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -356,7 +356,10 @@
       "deleteAttachmentConfirmTitle": "Anhang löschen",
       "deleteAttachmentConfirm": "{{filename}} aus diesem Eintrag entfernen?",
       "attachmentDeleted": "{{filename}} gelöscht",
-      "attachmentDeleteFailed": "{{filename}} konnte nicht gelöscht werden"
+      "attachmentDeleteFailed": "{{filename}} konnte nicht gelöscht werden",
+      "previewAttachment": "Anhang anzeigen",
+      "attachmentPreviewLoading": "Vorschau wird geladen…",
+      "attachmentPreviewTooLarge": "Zu groß für die Vorschau – zum Anzeigen herunterladen"
     },
     "sort": {
       "sortBy": "Sortieren nach",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -379,7 +379,10 @@
       "deleteAttachmentConfirmTitle": "Delete attachment",
       "deleteAttachmentConfirm": "Remove {{filename}} from this entry?",
       "attachmentDeleted": "Deleted {{filename}}",
-      "attachmentDeleteFailed": "Failed to delete {{filename}}"
+      "attachmentDeleteFailed": "Failed to delete {{filename}}",
+      "previewAttachment": "Preview attachment",
+      "attachmentPreviewLoading": "Loading preview…",
+      "attachmentPreviewTooLarge": "Too large to preview — download to view"
     },
     "sort": {
       "sortBy": "Sort by",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -356,7 +356,10 @@
       "deleteAttachmentConfirmTitle": "Eliminar adjunto",
       "deleteAttachmentConfirm": "¿Quitar {{filename}} de esta entrada?",
       "attachmentDeleted": "{{filename}} eliminado",
-      "attachmentDeleteFailed": "No se pudo eliminar {{filename}}"
+      "attachmentDeleteFailed": "No se pudo eliminar {{filename}}",
+      "previewAttachment": "Previsualizar adjunto",
+      "attachmentPreviewLoading": "Cargando vista previa…",
+      "attachmentPreviewTooLarge": "Demasiado grande para previsualizar — descarga para verlo"
     },
     "sort": {
       "sortBy": "Ordenar por",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -356,7 +356,10 @@
       "deleteAttachmentConfirmTitle": "Supprimer la pièce jointe",
       "deleteAttachmentConfirm": "Retirer {{filename}} de cette entrée ?",
       "attachmentDeleted": "{{filename}} supprimé",
-      "attachmentDeleteFailed": "Échec de la suppression de {{filename}}"
+      "attachmentDeleteFailed": "Échec de la suppression de {{filename}}",
+      "previewAttachment": "Prévisualiser la pièce jointe",
+      "attachmentPreviewLoading": "Chargement de l'aperçu…",
+      "attachmentPreviewTooLarge": "Trop volumineux pour la prévisualisation — téléchargez pour consulter"
     },
     "sort": {
       "sortBy": "Trier par",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -356,7 +356,10 @@
       "deleteAttachmentConfirmTitle": "Obriši prilog",
       "deleteAttachmentConfirm": "Ukloniti {{filename}} iz ovog unosa?",
       "attachmentDeleted": "Obrisano: {{filename}}",
-      "attachmentDeleteFailed": "Brisanje nije uspelo: {{filename}}"
+      "attachmentDeleteFailed": "Brisanje nije uspelo: {{filename}}",
+      "previewAttachment": "Pregled priloga",
+      "attachmentPreviewLoading": "Učitavanje pregleda…",
+      "attachmentPreviewTooLarge": "Previše veliko za pregled — preuzmi da bi se videlo"
     },
     "sort": {
       "sortBy": "Sortiraj po",


### PR DESCRIPTION
Closes #287.

## Summary

- Adds a Preview action on Attachment rows for raster images (`png/jpeg/gif/webp/bmp`) and plain-text files (`txt/md/csv/json/xml/yaml/yml/ini/log/conf`) under a 2 MB cap, opened in a modal. Images render via a `data:` URL; text renders as raw monospace UTF-8 (no markdown/syntax rendering).
- Previewable files above the 2 MB cap still offer Preview, but the modal carries a "too large to preview — download to view" message and skips the byte fetch.
- Non-previewable types (SVG, PDF, archives, opaque binaries) get Download only — no broken preview button.
- Preview reuses the on-demand byte fetch from #282 (no audit event — Preview is a read inside the Vault, not an export to the host filesystem).

Built TDD: pure classification module → Tauri wrapper → modal component → wired into `AttachmentsSection`.

## Test plan

- [x] `bun run test src/lib/attachment-preview.test.ts` — 30 tests covering image MIME allowlist, 10 text extensions, 2 MB cap edges, SVG/PDF exclusion
- [x] `bun run test src/components/entries/AttachmentPreviewModal.test.tsx` — 4 tests (image data-URL render, text `<pre>` render, no markdown rendering, too-large skips fetch)
- [x] `bun run test src/components/entries/EntryItemDetails.test.tsx` — 7 new tests on Preview button visibility (image/text/too-large show; PDF/SVG hide) and click-to-preview against mocked bytes
- [x] `bun run lint` — clean (no new warnings)
- [x] `bun run format:check` — clean
- [ ] Manual: open an entry with a PNG, click Preview → image renders inline
- [ ] Manual: open an entry with a `.md` file, click Preview → raw text in monospace, markdown NOT rendered
- [ ] Manual: open an entry with a >2 MB PNG → Preview button still shows, modal explains too-large
- [ ] Manual: open an entry with a PDF → no Preview button, only Download

🤖 Generated with [Claude Code](https://claude.com/claude-code)