### PR TITLE
feat(core): configurable attachment size thresholds + soft-warning (#288)

### DIFF
--- a/src-tauri/src/commands/entries.rs
+++ b/src-tauri/src/commands/entries.rs
@@ -225,8 +225,13 @@ pub async fn prepare_picked_attachments<R: Runtime>(
         .into_iter()
         .filter_map(|file_path| file_path.into_path().ok())
         .collect();
-    pending.replace(paths.clone());
-    Ok(plan_attachment_adds(&paths, soft, hard))
+    // Buffering mints a fresh batch id; the frontend echoes it back at commit so
+    // a later pick/drop that supersedes this batch turns the stale commit into a
+    // no-op rather than a wrong-file attach.
+    let batch_id = pending.replace(paths.clone());
+    let mut plan = plan_attachment_adds(&paths, soft, hard);
+    plan.batch_id = batch_id;
+    Ok(plan)
 }
 
 /// Phase 1 (drag-drop): classifies the paths buffered from the most recent
@@ -241,29 +246,35 @@ pub async fn prepare_dropped_attachments(
     pending: State<'_, Arc<PendingAttachmentPaths>>,
 ) -> Result<AttachmentAddPlan, AppError> {
     let (soft, hard) = attachment_thresholds(&settings)?;
-    let paths = pending.peek();
-    Ok(plan_attachment_adds(&paths, soft, hard))
+    let (batch_id, paths) = pending.peek();
+    let mut plan = plan_attachment_adds(&paths, soft, hard);
+    plan.batch_id = batch_id;
+    Ok(plan)
 }
 
-/// Phase 2 (shared): drains the buffered paths and stores each as a native KDBX
-/// binary, enforcing the configured hard cap. Used by both the picker and the
-/// drop after the frontend has resolved any soft-warning confirmation. Draining
-/// means a stale batch cannot be replayed against a later entry, and a commit
-/// with no preceding prepare reads nothing (empty outcome). Each file is read,
-/// hard-size-capped, and auto-renamed on a filename collision; one bad file
-/// never aborts the rest. Returns the batch outcome (stored names + per-file
-/// failures); the frontend persists via `database.save` and refreshes when
-/// anything landed.
+/// Phase 2 (shared): drains the buffered paths for `batch_id` and stores each as
+/// a native KDBX binary, enforcing the configured hard cap. Used by both the
+/// picker and the drop after the frontend has resolved any soft-warning
+/// confirmation. The buffer drains *only* when `batch_id` still matches the
+/// current generation, so a later pick/drop that superseded the prepared batch
+/// (e.g. a stray drop while the confirmation prompt was open) makes this commit a
+/// no-op (empty outcome) instead of attaching the wrong file. Draining also means
+/// a stale batch cannot be replayed against a later entry, and a commit with no
+/// preceding prepare reads nothing. Each file is read, hard-size-capped, and
+/// auto-renamed on a filename collision; one bad file never aborts the rest.
+/// Returns the batch outcome (stored names + per-file failures); the frontend
+/// persists via `database.save` and refreshes when anything landed.
 #[tauri::command]
 pub async fn commit_prepared_attachments(
     db_id: String,
     id: String,
+    batch_id: u64,
     state: State<'_, Arc<KdbxService>>,
     settings: State<'_, Arc<SettingsService>>,
     pending: State<'_, Arc<PendingAttachmentPaths>>,
 ) -> Result<AddAttachmentsOutcome, AppError> {
     let (_soft, hard) = attachment_thresholds(&settings)?;
-    let paths = pending.take();
+    let paths = pending.take(batch_id);
     state.add_entry_attachments(&db_id, &id, &paths, hard)
 }
 

--- a/src-tauri/src/commands/entries.rs
+++ b/src-tauri/src/commands/entries.rs
@@ -1,10 +1,12 @@
 use crate::domain::secure::SecureBytes;
 use crate::dto::entry::{
-    AddAttachmentsOutcome, CreateEntryData, CustomFieldValue, Entry, UpdateEntryData,
+    AddAttachmentsOutcome, AttachmentAddPlan, CreateEntryData, CustomFieldValue, Entry,
+    UpdateEntryData,
 };
 use crate::dto::error::AppError;
 use crate::services::audit::AuditService;
-use crate::services::drag_drop::DropPathsBuffer;
+use crate::services::drag_drop::PendingAttachmentPaths;
+use crate::services::kdbx::entries::plan_attachment_adds;
 use crate::services::kdbx::favicons::FaviconFetchOutcome;
 use crate::services::kdbx::KdbxService;
 use crate::services::settings::SettingsService;
@@ -181,23 +183,36 @@ pub async fn delete_entry_attachment(
     state.delete_entry_attachment(&db_id, &id, &filename)
 }
 
-/// Adds files on disk to an Entry as native KDBX binaries. The file paths are
-/// acquired *here in Rust* from the native multi-select dialog — the frontend
-/// passes no path, so a renderer-supplied (or fabricated) path can never reach
-/// the read. This is the trust boundary recorded in ADR-0004: only an
-/// OS-provided source (this dialog today; the `tauri://drag-drop` event for
-/// #286) can name a file to import. A cancelled dialog yields no paths and is a
-/// no-op. Each picked file is read, hard-size-capped, and auto-renamed on a
-/// filename collision; one bad pick never aborts the rest. Returns the batch
-/// outcome (stored names + per-file failures); the frontend persists via
-/// `database.save` and refreshes the entry when anything landed.
+/// Reads the configured attachment size guardrails from App Preferences as a
+/// `(soft_warn_bytes, hard_cap_bytes)` pair. Both prepare commands and the
+/// commit command resolve the thresholds through here so the user-configured
+/// values — not a hard-coded constant — govern every add.
+fn attachment_thresholds(settings: &SettingsService) -> Result<(u64, u64), AppError> {
+    let prefs = settings.get_app_preferences()?;
+    Ok((
+        prefs.attachments.soft_warn_bytes,
+        prefs.attachments.hard_cap_bytes,
+    ))
+}
+
+/// Phase 1 (picker): opens the native multi-select dialog *in Rust*, buffers the
+/// picked paths, and returns the size-classification plan against the configured
+/// thresholds — without reading any bytes or mutating the Vault. The frontend
+/// inspects the plan: if it requires confirmation (a file over the soft
+/// threshold) it shows the warning prompt before calling
+/// `commit_prepared_attachments`; otherwise it commits directly. A cancelled
+/// dialog buffers nothing and returns an empty plan (a no-op).
+///
+/// The paths are acquired here, never supplied by the renderer — the trust
+/// boundary in ADR-0004. They stay buffered until the commit drains them (or the
+/// next pick/drop overwrites them).
 #[tauri::command]
-pub async fn add_entry_attachments<R: Runtime>(
-    db_id: String,
-    id: String,
+pub async fn prepare_picked_attachments<R: Runtime>(
     app: AppHandle<R>,
-    state: State<'_, Arc<KdbxService>>,
-) -> Result<AddAttachmentsOutcome, AppError> {
+    settings: State<'_, Arc<SettingsService>>,
+    pending: State<'_, Arc<PendingAttachmentPaths>>,
+) -> Result<AttachmentAddPlan, AppError> {
+    let (soft, hard) = attachment_thresholds(&settings)?;
     // `blocking_pick_files` runs off the main thread (this command runs on the
     // async runtime), dispatching the dialog to the UI thread internally. It
     // returns `None` on cancel. Each `FilePath` is converted to a real
@@ -210,30 +225,46 @@ pub async fn add_entry_attachments<R: Runtime>(
         .into_iter()
         .filter_map(|file_path| file_path.into_path().ok())
         .collect();
-    state.add_entry_attachments(&db_id, &id, &paths)
+    pending.replace(paths.clone());
+    Ok(plan_attachment_adds(&paths, soft, hard))
 }
 
-/// Adds the files from the most recent native `tauri://drag-drop` event to an
-/// Entry. The paths were captured *in Rust* from the window event (buffered in
-/// `DropPathsBuffer`) — the frontend passes only the target db/entry ids, so a
-/// renderer-supplied path can never reach the read. This is the same trust
-/// boundary as the picker (ADR-0004): the renderer decides *whether* to commit
-/// (the drop must land on the selected Entry's panel) but never names a file.
-/// Draining the buffer here means a stale drop cannot be replayed against a
-/// later entry, and a commit with no preceding drop reads nothing (empty
-/// outcome). The dropped files go through the same feeder as the picker — hard
-/// size cap, auto-rename on collision, one bad file never aborting the rest —
-/// and the frontend persists via `database.save` and refreshes when anything
-/// landed.
+/// Phase 1 (drag-drop): classifies the paths buffered from the most recent
+/// native `tauri://drag-drop` event against the configured thresholds, without
+/// draining them — a peek, so the buffer survives for the commit that follows a
+/// confirmation. The paths were captured *in Rust* from the window event
+/// (ADR-0004); the renderer supplies none. A peek with no preceding drop returns
+/// an empty plan.
 #[tauri::command]
-pub async fn commit_dropped_attachments(
+pub async fn prepare_dropped_attachments(
+    settings: State<'_, Arc<SettingsService>>,
+    pending: State<'_, Arc<PendingAttachmentPaths>>,
+) -> Result<AttachmentAddPlan, AppError> {
+    let (soft, hard) = attachment_thresholds(&settings)?;
+    let paths = pending.peek();
+    Ok(plan_attachment_adds(&paths, soft, hard))
+}
+
+/// Phase 2 (shared): drains the buffered paths and stores each as a native KDBX
+/// binary, enforcing the configured hard cap. Used by both the picker and the
+/// drop after the frontend has resolved any soft-warning confirmation. Draining
+/// means a stale batch cannot be replayed against a later entry, and a commit
+/// with no preceding prepare reads nothing (empty outcome). Each file is read,
+/// hard-size-capped, and auto-renamed on a filename collision; one bad file
+/// never aborts the rest. Returns the batch outcome (stored names + per-file
+/// failures); the frontend persists via `database.save` and refreshes when
+/// anything landed.
+#[tauri::command]
+pub async fn commit_prepared_attachments(
     db_id: String,
     id: String,
-    drops: State<'_, Arc<DropPathsBuffer>>,
     state: State<'_, Arc<KdbxService>>,
+    settings: State<'_, Arc<SettingsService>>,
+    pending: State<'_, Arc<PendingAttachmentPaths>>,
 ) -> Result<AddAttachmentsOutcome, AppError> {
-    let paths = drops.take();
-    state.add_entry_attachments(&db_id, &id, &paths)
+    let (_soft, hard) = attachment_thresholds(&settings)?;
+    let paths = pending.take();
+    state.add_entry_attachments(&db_id, &id, &paths, hard)
 }
 
 /// Creates a new entry in a group.

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -366,6 +366,87 @@ mod audit_settings_tests {
     }
 }
 
+/// Per-file size guardrails for Entry attachments. `soft_warn_bytes` is the
+/// threshold above which the add flow prompts for confirmation ("large
+/// attachments grow the Vault and slow saving — add anyway?"); `hard_cap_bytes`
+/// is the threshold above which a file is rejected outright. Both are stored as
+/// raw bytes; the Settings UI surfaces them in decimal MB. Validated at the
+/// settings boundary (`hard_cap_bytes >= 1`, `soft_warn_bytes <= hard_cap_bytes`,
+/// `hard_cap_bytes <= MAX`) so a hand-edited file can't push a nonsensical pair
+/// (e.g. soft above hard) into the add flow. There is no aggregate Vault cap.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct AttachmentSettings {
+    #[serde(default = "default_attachment_soft_warn_bytes")]
+    pub soft_warn_bytes: u64,
+    #[serde(default = "default_attachment_hard_cap_bytes")]
+    pub hard_cap_bytes: u64,
+}
+
+/// Default per-file soft-warning threshold: 5 MB (decimal).
+pub(crate) const DEFAULT_ATTACHMENT_SOFT_WARN_BYTES: u64 = 5_000_000;
+/// Default per-file hard cap: 25 MB (decimal).
+pub(crate) const DEFAULT_ATTACHMENT_HARD_CAP_BYTES: u64 = 25_000_000;
+
+fn default_attachment_soft_warn_bytes() -> u64 {
+    DEFAULT_ATTACHMENT_SOFT_WARN_BYTES
+}
+
+fn default_attachment_hard_cap_bytes() -> u64 {
+    DEFAULT_ATTACHMENT_HARD_CAP_BYTES
+}
+
+impl Default for AttachmentSettings {
+    fn default() -> Self {
+        Self {
+            soft_warn_bytes: DEFAULT_ATTACHMENT_SOFT_WARN_BYTES,
+            hard_cap_bytes: DEFAULT_ATTACHMENT_HARD_CAP_BYTES,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod attachment_settings_tests {
+    use super::AttachmentSettings;
+
+    #[test]
+    fn defaults_are_five_and_twenty_five_megabytes() {
+        // PRD AC: soft-warn defaults to ~5 MB and the hard cap to ~25 MB
+        // (decimal). Pinning the documented user contract here means changing
+        // a default is a deliberate behavior change, not a silent edit.
+        let s = AttachmentSettings::default();
+        assert_eq!(s.soft_warn_bytes, 5_000_000);
+        assert_eq!(s.hard_cap_bytes, 25_000_000);
+    }
+
+    #[test]
+    fn absent_attachments_section_deserializes_to_defaults() {
+        // Users whose settings.json predates this slice have no attachments
+        // section. serde defaults must fill it in (no migration required) so
+        // the add flow has thresholds immediately.
+        let from_empty: AttachmentSettings = serde_json::from_str("{}").expect("parse {}");
+        assert_eq!(from_empty.soft_warn_bytes, 5_000_000);
+        assert_eq!(from_empty.hard_cap_bytes, 25_000_000);
+    }
+
+    #[test]
+    fn explicit_values_round_trip_in_camel_case() {
+        let json = r#"{"softWarnBytes": 1000000, "hardCapBytes": 2000000}"#;
+        let parsed: AttachmentSettings = serde_json::from_str(json).expect("parse explicit");
+        assert_eq!(parsed.soft_warn_bytes, 1_000_000);
+        assert_eq!(parsed.hard_cap_bytes, 2_000_000);
+
+        let serialized = serde_json::to_string(&parsed).expect("serialize");
+        assert!(
+            serialized.contains(r#""softWarnBytes":1000000"#)
+                && serialized.contains(r#""hardCapBytes":2000000"#),
+            "serialized json should carry camelCase byte fields: {serialized}"
+        );
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[serde(default)]
@@ -377,6 +458,7 @@ pub struct AppPreferences {
     pub advanced: AdvancedSettings,
     pub backups: BackupSettings,
     pub audit: AuditSettings,
+    pub attachments: AttachmentSettings,
 }
 
 /// Persisted shape written to `settings.json`. Combines the editable

--- a/src-tauri/src/dto/entry.rs
+++ b/src-tauri/src/dto/entry.rs
@@ -64,11 +64,18 @@ pub struct AttachmentPlanItem {
 /// decide whether to show the soft-warning prompt before committing. Files over
 /// the hard cap do not gate the prompt; they surface as per-file failures at
 /// commit time instead.
+///
+/// `batch_id` is the generation of the buffered batch this plan describes. The
+/// frontend echoes it back to `commit_prepared_attachments`, which only stores
+/// the batch when the id still matches — so a later pick/drop that supersedes the
+/// buffer turns a stale (e.g. post-confirmation) commit into a no-op rather than
+/// attaching the wrong file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttachmentAddPlan {
     pub items: Vec<AttachmentPlanItem>,
     pub requires_confirmation: bool,
+    pub batch_id: u64,
 }
 
 /// One file that failed to add in a batch, paired with the basename it was

--- a/src-tauri/src/dto/entry.rs
+++ b/src-tauri/src/dto/entry.rs
@@ -33,6 +33,44 @@ pub struct AttachmentMeta {
     pub mime_type: String,
 }
 
+/// Where a candidate attachment's size falls relative to the configured
+/// guardrails. `Ok` is under (or at) the soft threshold — add silently.
+/// `OverSoft` is above the soft threshold but within the hard cap — the add
+/// flow prompts for confirmation. `OverHard` is above the hard cap — rejected
+/// outright. Serialized in camelCase for the IPC plan the frontend reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AttachmentSizeStatus {
+    Ok,
+    OverSoft,
+    OverHard,
+}
+
+/// One candidate file in an attachment-add plan: the basename it was picked
+/// under, its on-disk size, and where that size falls relative to the
+/// thresholds. Returned by the prepare step so the frontend can decide whether
+/// to prompt before committing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentPlanItem {
+    pub source_name: String,
+    pub size: u64,
+    pub status: AttachmentSizeStatus,
+}
+
+/// The classification of a batch of candidate files against the configured
+/// guardrails, returned by the prepare step. `requires_confirmation` is `true`
+/// iff at least one item is `OverSoft` — the single signal the frontend uses to
+/// decide whether to show the soft-warning prompt before committing. Files over
+/// the hard cap do not gate the prompt; they surface as per-file failures at
+/// commit time instead.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachmentAddPlan {
+    pub items: Vec<AttachmentPlanItem>,
+    pub requires_confirmation: bool,
+}
+
 /// One file that failed to add in a batch, paired with the basename it was
 /// picked under and the backend's reason (the `AppError` display string, e.g.
 /// "…exceeds the 25-byte limit"). The frontend raises one toast per failure so

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,29 +8,30 @@ pub mod utils;
 
 use crate::dto::error::AppError;
 use commands::{
-    add_entry_attachments, add_recent_database, clear_audit_log, clear_clipboard,
-    clear_entry_custom_icon, clear_recent_databases, clear_session_key, close_database,
-    commit_dropped_attachments, copy_password_to_clipboard, copy_protected_field_to_clipboard,
-    copy_text_to_clipboard, create_database, create_entry, create_group, create_manual_backup,
-    delete_backup, delete_entry, delete_entry_attachment, delete_group, delete_tag,
-    export_entry_attachment, fetch_entry_favicon, generate_keyfile, generate_passphrase,
-    generate_password, get_app_preferences, get_audit_events, get_audit_status, get_custom_icons,
-    get_database_config, get_database_info, get_entry, get_entry_attachment, get_entry_password,
+    add_recent_database, clear_audit_log, clear_clipboard, clear_entry_custom_icon,
+    clear_recent_databases, clear_session_key, close_database, commit_prepared_attachments,
+    copy_password_to_clipboard, copy_protected_field_to_clipboard, copy_text_to_clipboard,
+    create_database, create_entry, create_group, create_manual_backup, delete_backup, delete_entry,
+    delete_entry_attachment, delete_group, delete_tag, export_entry_attachment,
+    fetch_entry_favicon, generate_keyfile, generate_passphrase, generate_password,
+    get_app_preferences, get_audit_events, get_audit_status, get_custom_icons, get_database_config,
+    get_database_info, get_entry, get_entry_attachment, get_entry_password,
     get_entry_protected_custom_field, get_group, get_group_entry_counts, get_keyfile_for_database,
     get_password_health_report, get_recent_databases, get_recycle_bin_id,
     get_window_content_protection_supported, has_session_key, inspect_database, list_backups,
     list_entries, list_groups, list_open_databases, lock_database, move_entry, move_group,
     open_database, open_database_with_keyfile, open_database_with_keyfile_only,
-    remove_recent_database, rename_group, rename_tag, report_activity, reset_app_preferences,
-    restore_backup, save_database, set_entry_custom_icon, set_window_content_protected,
-    store_session_key, unlock_database, update_app_preferences, update_entry, update_group,
+    prepare_dropped_attachments, prepare_picked_attachments, remove_recent_database, rename_group,
+    rename_tag, report_activity, reset_app_preferences, restore_backup, save_database,
+    set_entry_custom_icon, set_window_content_protected, store_session_key, unlock_database,
+    update_app_preferences, update_entry, update_group,
 };
 use services::audit::format::Reason;
 use services::audit::key::FileBackedAuditKey;
 use services::audit::AuditService;
 use services::auto_lock::AutoLockService;
 use services::clipboard::ClipboardService;
-use services::drag_drop::DropPathsBuffer;
+use services::drag_drop::PendingAttachmentPaths;
 use services::kdbx::KdbxService;
 use services::password_health::service::PasswordHealthService;
 use services::secure_storage::SecureStorageService;
@@ -46,12 +47,13 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
         .plugin(tauri_plugin_dialog::init())
         // Capture dropped file paths from the native window event *in Rust* so
         // the renderer never names a file for the add (#286, ADR-0004). The
-        // paths are buffered here; the renderer decides whether to commit them
-        // (the drop must land on the selected Entry's panel) via
-        // `commit_dropped_attachments`, which drains the buffer.
+        // paths are buffered here; the renderer inspects their sizes via
+        // `prepare_dropped_attachments` (a peek) and, after resolving any
+        // soft-warning confirmation, commits them via
+        // `commit_prepared_attachments`, which drains the buffer.
         .on_window_event(|window, event| {
             if let tauri::WindowEvent::DragDrop(tauri::DragDropEvent::Drop { paths, .. }) = event {
-                if let Some(buffer) = window.try_state::<Arc<DropPathsBuffer>>() {
+                if let Some(buffer) = window.try_state::<Arc<PendingAttachmentPaths>>() {
                     buffer.replace(paths.clone());
                 }
             }
@@ -85,8 +87,9 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             list_entries,
             get_entry,
             get_entry_attachment,
-            add_entry_attachments,
-            commit_dropped_attachments,
+            prepare_picked_attachments,
+            prepare_dropped_attachments,
+            commit_prepared_attachments,
             export_entry_attachment,
             delete_entry_attachment,
             get_entry_password,
@@ -157,11 +160,12 @@ pub fn register_services<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<(), Ap
     let kdbx_arc = Arc::new(kdbx_service);
     app.manage(Arc::clone(&kdbx_arc));
 
-    // Holds the paths from the most recent native drag-drop event so the
-    // trusted add path can read them without the renderer naming a file (#286,
-    // ADR-0004). Filled by the `on_window_event` handler, drained by
-    // `commit_dropped_attachments`.
-    app.manage(Arc::new(DropPathsBuffer::default()));
+    // Holds the paths of an in-flight attachment-add gesture (a native
+    // drag-drop or a file-picker pick) so the trusted add path can read them
+    // without the renderer naming a file (#286, ADR-0004). Filled by the
+    // `on_window_event` handler or `prepare_picked_attachments`, peeked by the
+    // prepare step, drained by `commit_prepared_attachments`.
+    app.manage(Arc::new(PendingAttachmentPaths::default()));
 
     let clipboard_service = ClipboardService::new();
     app.manage(Arc::new(clipboard_service));

--- a/src-tauri/src/services/drag_drop.rs
+++ b/src-tauri/src/services/drag_drop.rs
@@ -13,39 +13,68 @@ use std::sync::Mutex;
 /// The add flow is two-phase so the soft-warning prompt can fit between picking
 /// and storing: the prepare step buffers paths here and inspects their sizes via
 /// [`peek`](PendingAttachmentPaths::peek) (a non-draining clone), and the commit
-/// step drains them with [`take`](PendingAttachmentPaths::take) and feeds them to
-/// `KdbxService::add_entry_attachments`. Because the renderer commits
-/// synchronously within a single gesture, only one batch is ever buffered at a
-/// time; a fresh pick or drop overwrites the previous buffer.
+/// step drains them with [`take`](PendingAttachmentPaths::take).
+///
+/// # Batch identity
+///
+/// Every buffered batch carries a monotonic **generation**, returned from
+/// [`replace`](PendingAttachmentPaths::replace) and captured by the prepare step
+/// as a batch id. [`take`](PendingAttachmentPaths::take) drains the batch *only*
+/// when the caller's batch id still matches the current generation. This closes
+/// a window-global race: the `tauri://drag-drop` handler can `replace` the buffer
+/// at any time, so after the user has picked an over-soft file and is staring at
+/// the confirmation prompt, an unrelated drop anywhere in the window would
+/// otherwise replace the pending paths and the confirmed commit would attach the
+/// dropped file instead. Tying commit to the prepared generation makes such a
+/// superseded commit a no-op rather than a wrong-file attach.
 #[derive(Default)]
 pub struct PendingAttachmentPaths {
-    paths: Mutex<Vec<PathBuf>>,
+    inner: Mutex<PendingState>,
+}
+
+#[derive(Default)]
+struct PendingState {
+    /// Monotonic id of the currently buffered batch. Starts at 0 (pristine, no
+    /// real batch); every `replace` bumps it, so a legitimate batch id is >= 1.
+    generation: u64,
+    paths: Vec<PathBuf>,
 }
 
 impl PendingAttachmentPaths {
-    /// Overwrites the buffer with the paths from a fresh pick or drop.
-    pub fn replace(&self, paths: Vec<PathBuf>) {
-        if let Ok(mut guard) = self.paths.lock() {
-            *guard = paths;
+    /// Overwrites the buffer with a fresh batch, bumping the generation and
+    /// returning the new id. Any prepared-but-not-yet-committed batch is thereby
+    /// superseded: its captured id no longer matches, so its commit drains
+    /// nothing.
+    pub fn replace(&self, paths: Vec<PathBuf>) -> u64 {
+        match self.inner.lock() {
+            Ok(mut guard) => {
+                guard.generation = guard.generation.wrapping_add(1);
+                guard.paths = paths;
+                guard.generation
+            }
+            Err(_) => 0,
         }
     }
 
-    /// Returns a clone of the buffered paths without draining them, so the
-    /// prepare step can classify their sizes while leaving them in place for the
-    /// commit step that follows a confirmation.
-    pub fn peek(&self) -> Vec<PathBuf> {
-        match self.paths.lock() {
-            Ok(guard) => guard.clone(),
-            Err(_) => Vec::new(),
+    /// Returns the current batch id and a clone of its paths without draining,
+    /// so the prepare step can classify their sizes while leaving the batch in
+    /// place for the commit that follows a confirmation.
+    pub fn peek(&self) -> (u64, Vec<PathBuf>) {
+        match self.inner.lock() {
+            Ok(guard) => (guard.generation, guard.paths.clone()),
+            Err(_) => (0, Vec::new()),
         }
     }
 
-    /// Removes and returns the buffered paths, leaving the buffer empty so a
-    /// second commit (or a commit with no preceding pick/drop) reads nothing.
-    pub fn take(&self) -> Vec<PathBuf> {
-        match self.paths.lock() {
-            Ok(mut guard) => std::mem::take(&mut *guard),
-            Err(_) => Vec::new(),
+    /// Drains and returns the buffered paths only when `batch_id` still matches
+    /// the current generation — i.e. no later pick/drop has superseded the
+    /// batch. A superseded (or absent) batch yields nothing, so a confirmed
+    /// commit can never attach a file from a different, later gesture, and a
+    /// second commit of the same batch reads nothing.
+    pub fn take(&self, batch_id: u64) -> Vec<PathBuf> {
+        match self.inner.lock() {
+            Ok(mut guard) if guard.generation == batch_id => std::mem::take(&mut guard.paths),
+            _ => Vec::new(),
         }
     }
 }
@@ -55,14 +84,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn take_drains_the_buffered_paths_and_empties_it() {
+    fn take_drains_the_buffered_paths_for_a_matching_batch_id() {
         let buffer = PendingAttachmentPaths::default();
-        buffer.replace(vec![
+        let batch = buffer.replace(vec![
             PathBuf::from("/tmp/a.txt"),
             PathBuf::from("/tmp/b.txt"),
         ]);
 
-        let drained = buffer.take();
+        let drained = buffer.take(batch);
         assert_eq!(
             drained,
             vec![PathBuf::from("/tmp/a.txt"), PathBuf::from("/tmp/b.txt")],
@@ -70,8 +99,8 @@ mod tests {
         );
 
         assert!(
-            buffer.take().is_empty(),
-            "a second commit with no fresh pick/drop reads nothing"
+            buffer.take(batch).is_empty(),
+            "a second commit of the same batch reads nothing"
         );
     }
 
@@ -79,29 +108,50 @@ mod tests {
     fn take_on_an_untouched_buffer_returns_nothing() {
         let buffer = PendingAttachmentPaths::default();
         assert!(
-            buffer.take().is_empty(),
+            buffer.take(0).is_empty(),
             "a commit with no preceding pick/drop is a no-op"
         );
     }
 
     #[test]
-    fn peek_returns_paths_without_draining() {
-        // The prepare step peeks to classify sizes; the paths must survive for
-        // the commit step that follows a confirmation. Two peeks in a row see
-        // the same batch, and a subsequent take still drains it.
+    fn peek_returns_the_batch_id_and_paths_without_draining() {
         let buffer = PendingAttachmentPaths::default();
-        buffer.replace(vec![PathBuf::from("/tmp/a.txt")]);
+        let batch = buffer.replace(vec![PathBuf::from("/tmp/a.txt")]);
 
-        assert_eq!(buffer.peek(), vec![PathBuf::from("/tmp/a.txt")]);
+        let (peeked_id, peeked) = buffer.peek();
+        assert_eq!(peeked_id, batch, "peek reports the current batch id");
+        assert_eq!(peeked, vec![PathBuf::from("/tmp/a.txt")]);
         assert_eq!(
-            buffer.peek(),
+            buffer.peek().1,
             vec![PathBuf::from("/tmp/a.txt")],
             "peek must not drain — a second peek sees the same batch"
         );
         assert_eq!(
-            buffer.take(),
+            buffer.take(batch),
             vec![PathBuf::from("/tmp/a.txt")],
-            "take after peek still drains the buffer"
+            "take after peek still drains the batch"
+        );
+    }
+
+    #[test]
+    fn a_superseding_replace_makes_the_earlier_commit_a_noop() {
+        // The race the batch id closes: a first gesture prepares (capturing its
+        // id), then a window-global drop replaces the buffer before the first
+        // gesture commits. The first commit must drain nothing rather than
+        // attach the second gesture's files.
+        let buffer = PendingAttachmentPaths::default();
+        let first = buffer.replace(vec![PathBuf::from("/tmp/picked.txt")]);
+        let second = buffer.replace(vec![PathBuf::from("/tmp/dropped.txt")]);
+        assert_ne!(first, second, "each replace mints a fresh batch id");
+
+        assert!(
+            buffer.take(first).is_empty(),
+            "the superseded batch's commit must attach nothing"
+        );
+        assert_eq!(
+            buffer.take(second),
+            vec![PathBuf::from("/tmp/dropped.txt")],
+            "the current batch still commits normally"
         );
     }
 }

--- a/src-tauri/src/services/drag_drop.rs
+++ b/src-tauri/src/services/drag_drop.rs
@@ -3,34 +3,45 @@
 use std::path::PathBuf;
 use std::sync::Mutex;
 
-/// Holds the file paths from the most recent native `tauri://drag-drop` window
-/// event so the trusted add path can read them without the renderer ever naming
-/// a file. Paths are captured *in Rust* from the OS event (see ADR-0004) and
-/// stashed here; the `commit_dropped_attachments` command drains them with
-/// [`take`](DropPathsBuffer::take) and feeds them to
-/// `KdbxService::add_entry_attachments`. The renderer decides *whether* to
-/// commit (the drop must land on the selected Entry's panel) but never supplies
-/// the paths — there is no command parameter through which one could be passed.
+/// Holds the file paths of an in-flight attachment-add gesture so the trusted
+/// add path can read them without the renderer ever naming a file. Paths are
+/// captured *in Rust* from a trusted OS origin (the native `tauri://drag-drop`
+/// window event, or the file-picker dialog) and stashed here (see ADR-0004);
+/// the renderer never supplies a path — there is no command parameter through
+/// which one could be passed.
 ///
-/// A drop that the renderer chooses not to commit leaves its paths buffered
-/// until the next drop overwrites them or a commit drains them; staleness is
-/// bounded to a single drop because the renderer commits synchronously in the
-/// same drop handler.
+/// The add flow is two-phase so the soft-warning prompt can fit between picking
+/// and storing: the prepare step buffers paths here and inspects their sizes via
+/// [`peek`](PendingAttachmentPaths::peek) (a non-draining clone), and the commit
+/// step drains them with [`take`](PendingAttachmentPaths::take) and feeds them to
+/// `KdbxService::add_entry_attachments`. Because the renderer commits
+/// synchronously within a single gesture, only one batch is ever buffered at a
+/// time; a fresh pick or drop overwrites the previous buffer.
 #[derive(Default)]
-pub struct DropPathsBuffer {
+pub struct PendingAttachmentPaths {
     paths: Mutex<Vec<PathBuf>>,
 }
 
-impl DropPathsBuffer {
-    /// Overwrites the buffer with the paths from a fresh drop event.
+impl PendingAttachmentPaths {
+    /// Overwrites the buffer with the paths from a fresh pick or drop.
     pub fn replace(&self, paths: Vec<PathBuf>) {
         if let Ok(mut guard) = self.paths.lock() {
             *guard = paths;
         }
     }
 
+    /// Returns a clone of the buffered paths without draining them, so the
+    /// prepare step can classify their sizes while leaving them in place for the
+    /// commit step that follows a confirmation.
+    pub fn peek(&self) -> Vec<PathBuf> {
+        match self.paths.lock() {
+            Ok(guard) => guard.clone(),
+            Err(_) => Vec::new(),
+        }
+    }
+
     /// Removes and returns the buffered paths, leaving the buffer empty so a
-    /// second commit (or a commit with no preceding drop) reads nothing.
+    /// second commit (or a commit with no preceding pick/drop) reads nothing.
     pub fn take(&self) -> Vec<PathBuf> {
         match self.paths.lock() {
             Ok(mut guard) => std::mem::take(&mut *guard),
@@ -45,7 +56,7 @@ mod tests {
 
     #[test]
     fn take_drains_the_buffered_paths_and_empties_it() {
-        let buffer = DropPathsBuffer::default();
+        let buffer = PendingAttachmentPaths::default();
         buffer.replace(vec![
             PathBuf::from("/tmp/a.txt"),
             PathBuf::from("/tmp/b.txt"),
@@ -55,21 +66,42 @@ mod tests {
         assert_eq!(
             drained,
             vec![PathBuf::from("/tmp/a.txt"), PathBuf::from("/tmp/b.txt")],
-            "take returns exactly what the drop captured, in order"
+            "take returns exactly what the pick/drop captured, in order"
         );
 
         assert!(
             buffer.take().is_empty(),
-            "a second commit with no fresh drop reads nothing"
+            "a second commit with no fresh pick/drop reads nothing"
         );
     }
 
     #[test]
     fn take_on_an_untouched_buffer_returns_nothing() {
-        let buffer = DropPathsBuffer::default();
+        let buffer = PendingAttachmentPaths::default();
         assert!(
             buffer.take().is_empty(),
-            "a commit with no preceding drop is a no-op"
+            "a commit with no preceding pick/drop is a no-op"
+        );
+    }
+
+    #[test]
+    fn peek_returns_paths_without_draining() {
+        // The prepare step peeks to classify sizes; the paths must survive for
+        // the commit step that follows a confirmation. Two peeks in a row see
+        // the same batch, and a subsequent take still drains it.
+        let buffer = PendingAttachmentPaths::default();
+        buffer.replace(vec![PathBuf::from("/tmp/a.txt")]);
+
+        assert_eq!(buffer.peek(), vec![PathBuf::from("/tmp/a.txt")]);
+        assert_eq!(
+            buffer.peek(),
+            vec![PathBuf::from("/tmp/a.txt")],
+            "peek must not drain — a second peek sees the same batch"
+        );
+        assert_eq!(
+            buffer.take(),
+            vec![PathBuf::from("/tmp/a.txt")],
+            "take after peek still drains the buffer"
         );
     }
 }

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -1,7 +1,7 @@
 use crate::domain::secure::SecureBytes;
 use crate::dto::entry::{
-    AddAttachmentsOutcome, AttachmentAddFailure, CreateEntryData, CustomFieldValue, Entry,
-    UpdateEntryData,
+    AddAttachmentsOutcome, AttachmentAddFailure, AttachmentAddPlan, AttachmentPlanItem,
+    AttachmentSizeStatus, CreateEntryData, CustomFieldValue, Entry, UpdateEntryData,
 };
 use crate::dto::error::AppError;
 use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
@@ -15,11 +15,67 @@ use super::conversions::{
 use super::recycle::is_in_recycle_bin;
 use super::KdbxService;
 
-/// Hard per-file size cap for added attachments (25 MiB). A file larger than
-/// this is rejected outright to keep the Vault from bloating into something
-/// unusable. This is a fixed default for this slice; a later slice makes it a
-/// configurable App Preference (see issue #280 / ADR-0003).
-const HARD_CAP_BYTES: u64 = 25 * 1024 * 1024;
+/// Classifies a candidate attachment's size against the configured guardrails.
+/// At-threshold values are treated as within the lower band: a file exactly the
+/// size of the soft threshold is [`Ok`] (warning fires only *above* it), and a
+/// file exactly the size of the hard cap is [`OverSoft`] (rejection fires only
+/// *above* it — matching the `> hard_cap` check in the add path). Callers must
+/// pass a coherent pair (`soft <= hard`), which the settings boundary
+/// guarantees.
+///
+/// [`Ok`]: AttachmentSizeStatus::Ok
+/// [`OverSoft`]: AttachmentSizeStatus::OverSoft
+fn classify_attachment_size(size: u64, soft: u64, hard: u64) -> AttachmentSizeStatus {
+    if size > hard {
+        AttachmentSizeStatus::OverHard
+    } else if size > soft {
+        AttachmentSizeStatus::OverSoft
+    } else {
+        AttachmentSizeStatus::Ok
+    }
+}
+
+/// Builds the size-classification plan for a batch of candidate files without
+/// reading their bytes or touching the Vault. Each path is stat'd and
+/// classified against the configured `soft`/`hard` thresholds; the result drives
+/// the frontend's decision to prompt before committing. A path that cannot be
+/// stat'd (missing, permission-denied) is recorded with size `0` and status
+/// [`Ok`] — it is advisory only, and the authoritative read at commit time will
+/// surface the real I/O error as a per-file failure. `requires_confirmation` is
+/// `true` iff at least one file is [`OverSoft`]; files over the hard cap do not
+/// gate the prompt.
+///
+/// [`Ok`]: AttachmentSizeStatus::Ok
+/// [`OverSoft`]: AttachmentSizeStatus::OverSoft
+pub(crate) fn plan_attachment_adds(
+    paths: &[std::path::PathBuf],
+    soft: u64,
+    hard: u64,
+) -> AttachmentAddPlan {
+    let items: Vec<AttachmentPlanItem> = paths
+        .iter()
+        .map(|path| {
+            let source_name = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .unwrap_or("")
+                .to_string();
+            let size = std::fs::metadata(path).map_or(0, |m| m.len());
+            AttachmentPlanItem {
+                source_name,
+                size,
+                status: classify_attachment_size(size, soft, hard),
+            }
+        })
+        .collect();
+    let requires_confirmation = items
+        .iter()
+        .any(|item| item.status == AttachmentSizeStatus::OverSoft);
+    AttachmentAddPlan {
+        items,
+        requires_confirmation,
+    }
+}
 
 impl KdbxService {
     /// Lists entries, optionally filtered by group.
@@ -162,12 +218,16 @@ impl KdbxService {
     /// immediately, independent of the Entry edit-form save cycle (mirroring
     /// `set_entry_custom_icon`). Returns the filename the attachment was
     /// actually stored under, which may differ from the source basename when a
-    /// collision triggered an auto-rename.
+    /// collision triggered an auto-rename. The `hard_cap` (in bytes) is the
+    /// per-file rejection threshold; it is injected by the caller from App
+    /// Preferences rather than hard-coded, so the user-configured cap governs
+    /// every add.
     pub fn add_entry_attachment(
         &self,
         db_id: &str,
         entry_id: &str,
         source_path: &std::path::Path,
+        hard_cap: u64,
     ) -> Result<String, AppError> {
         let filename = source_path
             .file_name()
@@ -190,11 +250,11 @@ impl KdbxService {
 
         // Fast path: reject an obviously oversized file from its stat'd size
         // before opening it at all.
-        if metadata.len() > HARD_CAP_BYTES {
+        if metadata.len() > hard_cap {
             return Err(AppError::AttachmentTooLarge {
                 filename,
                 size: metadata.len(),
-                cap: HARD_CAP_BYTES,
+                cap: hard_cap,
             });
         }
 
@@ -217,14 +277,14 @@ impl KdbxService {
         }
 
         let mut bytes = Vec::new();
-        file.take(HARD_CAP_BYTES + 1)
+        file.take(hard_cap + 1)
             .read_to_end(&mut bytes)
             .map_err(|e| AppError::Io(e.to_string()))?;
-        if bytes.len() as u64 > HARD_CAP_BYTES {
+        if bytes.len() as u64 > hard_cap {
             return Err(AppError::AttachmentTooLarge {
                 filename,
                 size: bytes.len() as u64,
-                cap: HARD_CAP_BYTES,
+                cap: hard_cap,
             });
         }
 
@@ -254,10 +314,11 @@ impl KdbxService {
         db_id: &str,
         entry_id: &str,
         paths: &[std::path::PathBuf],
+        hard_cap: u64,
     ) -> Result<AddAttachmentsOutcome, AppError> {
         let mut outcome = AddAttachmentsOutcome::default();
         for path in paths {
-            match self.add_entry_attachment(db_id, entry_id, path) {
+            match self.add_entry_attachment(db_id, entry_id, path, hard_cap) {
                 Ok(stored_name) => outcome.added.push(stored_name),
                 Err(error) => outcome.failed.push(AttachmentAddFailure {
                     source_name: path
@@ -716,10 +777,134 @@ fn unique_attachment_name(entry: &keepass::db::EntryRef<'_>, filename: &str) -> 
 mod tests {
     use super::*;
     use crate::domain::secure::SecureString;
-    use crate::dto::entry::AttachmentMeta;
+    use crate::dto::entry::{AttachmentMeta, AttachmentSizeStatus};
     use crate::services::kdbx::test_support::create_test_database;
     use keepass::db::Value;
     use std::collections::HashMap;
+
+    /// The hard cap the attachment add/round-trip tests inject. A generous
+    /// fixed value so the round-trip cases never trip the cap; the over-cap
+    /// cases seed a file one byte past it.
+    const TEST_HARD_CAP: u64 = 25 * 1024 * 1024;
+
+    #[test]
+    fn classify_attachment_size_walks_the_thresholds() {
+        // soft = 5, hard = 25. Every boundary is pinned because the soft/hard
+        // edges decide whether the user is warned, silently allowed, or
+        // rejected — an off-by-one here is a user-visible behavior change.
+        let soft = 5;
+        let hard = 25;
+        // At or below the soft threshold: silent add.
+        assert_eq!(
+            classify_attachment_size(0, soft, hard),
+            AttachmentSizeStatus::Ok
+        );
+        assert_eq!(
+            classify_attachment_size(5, soft, hard),
+            AttachmentSizeStatus::Ok
+        );
+        // Above soft, up to and including the hard cap: warn.
+        assert_eq!(
+            classify_attachment_size(6, soft, hard),
+            AttachmentSizeStatus::OverSoft
+        );
+        assert_eq!(
+            classify_attachment_size(25, soft, hard),
+            AttachmentSizeStatus::OverSoft
+        );
+        // Above the hard cap: reject.
+        assert_eq!(
+            classify_attachment_size(26, soft, hard),
+            AttachmentSizeStatus::OverHard
+        );
+    }
+
+    #[test]
+    fn classify_attachment_size_handles_soft_equal_to_hard() {
+        // A coherent edge config: soft == hard means the warning band is empty,
+        // so a file is either Ok (<= the shared threshold) or OverHard.
+        assert_eq!(
+            classify_attachment_size(10, 10, 10),
+            AttachmentSizeStatus::Ok
+        );
+        assert_eq!(
+            classify_attachment_size(11, 10, 10),
+            AttachmentSizeStatus::OverHard
+        );
+    }
+
+    #[test]
+    fn plan_attachment_adds_classifies_each_file_and_flags_confirmation() {
+        // A mixed batch: one file under the soft threshold, one above it (but
+        // under the hard cap). The plan must classify each by its on-disk size,
+        // preserve pick order, and flag that confirmation is required because at
+        // least one file is over the soft threshold — the single signal the
+        // frontend reads before showing the warning prompt.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let small = dir.path().join("notes.txt");
+        std::fs::write(&small, vec![0u8; 3]).expect("seed small");
+        let large = dir.path().join("scan.pdf");
+        std::fs::write(&large, vec![0u8; 50]).expect("seed large");
+
+        let plan = plan_attachment_adds(
+            &[small.clone(), large.clone()],
+            10,  // soft
+            100, // hard
+        );
+
+        assert!(
+            plan.requires_confirmation,
+            "a file over the soft threshold must require confirmation"
+        );
+        assert_eq!(plan.items.len(), 2, "one plan item per path, in pick order");
+        assert_eq!(plan.items[0].source_name, "notes.txt");
+        assert_eq!(plan.items[0].size, 3);
+        assert_eq!(plan.items[0].status, AttachmentSizeStatus::Ok);
+        assert_eq!(plan.items[1].source_name, "scan.pdf");
+        assert_eq!(plan.items[1].size, 50);
+        assert_eq!(plan.items[1].status, AttachmentSizeStatus::OverSoft);
+    }
+
+    #[test]
+    fn plan_attachment_adds_requires_no_confirmation_when_all_under_soft() {
+        // Every file under the soft threshold: the add proceeds silently, so
+        // the plan must not require confirmation.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let a = dir.path().join("a.txt");
+        std::fs::write(&a, vec![0u8; 2]).expect("seed a");
+        let b = dir.path().join("b.txt");
+        std::fs::write(&b, vec![0u8; 4]).expect("seed b");
+
+        let plan = plan_attachment_adds(&[a, b], 10, 100);
+
+        assert!(
+            !plan.requires_confirmation,
+            "all-small batch must not require confirmation"
+        );
+        assert!(plan
+            .items
+            .iter()
+            .all(|item| item.status == AttachmentSizeStatus::Ok));
+    }
+
+    #[test]
+    fn plan_attachment_adds_does_not_require_confirmation_for_over_hard_only() {
+        // A file over the hard cap is OverHard, not OverSoft. It will be
+        // rejected at commit as a per-file failure — it must NOT trigger the
+        // soft-warning prompt, so a batch whose only large file is over-hard
+        // requires no confirmation.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let huge = dir.path().join("huge.bin");
+        std::fs::write(&huge, vec![0u8; 200]).expect("seed huge");
+
+        let plan = plan_attachment_adds(&[huge], 10, 100);
+
+        assert!(
+            !plan.requires_confirmation,
+            "an over-hard-only batch must not require the soft prompt"
+        );
+        assert_eq!(plan.items[0].status, AttachmentSizeStatus::OverHard);
+    }
 
     fn create_entry_with_expiry(
         service: &KdbxService,
@@ -1293,7 +1478,7 @@ mod tests {
         std::fs::write(&source, &payload).expect("seed source file");
 
         let stored = service
-            .add_entry_attachment(&db_path, &entry_a, &source)
+            .add_entry_attachment(&db_path, &entry_a, &source, TEST_HARD_CAP)
             .expect("add attachment");
         assert_eq!(stored, "codes.txt", "the stored filename is the basename");
 
@@ -1337,11 +1522,11 @@ mod tests {
             .with_vault(&db_path, |vault| Ok(vault.generation()))
             .expect("generation before add");
 
-        let oversized = vec![0u8; usize::try_from(HARD_CAP_BYTES + 1).expect("cap fits usize")];
+        let oversized = vec![0u8; usize::try_from(TEST_HARD_CAP + 1).expect("cap fits usize")];
         let source = dir.path().join("huge.bin");
         std::fs::write(&source, &oversized).expect("seed oversized file");
 
-        let result = service.add_entry_attachment(&db_path, &entry_a, &source);
+        let result = service.add_entry_attachment(&db_path, &entry_a, &source, TEST_HARD_CAP);
         assert!(
             matches!(result, Err(AppError::AttachmentTooLarge { ref filename, .. }) if filename == "huge.bin"),
             "an over-cap file must be rejected with AttachmentTooLarge, got {result:?}"
@@ -1376,7 +1561,7 @@ mod tests {
         let first = dir.path().join("scan.pdf");
         std::fs::write(&first, b"first-bytes").expect("seed first file");
         let stored_first = service
-            .add_entry_attachment(&db_path, &entry_a, &first)
+            .add_entry_attachment(&db_path, &entry_a, &first, TEST_HARD_CAP)
             .expect("add first");
         assert_eq!(stored_first, "scan.pdf", "the first add keeps its name");
 
@@ -1386,7 +1571,7 @@ mod tests {
         let second_file = second.join("scan.pdf");
         std::fs::write(&second_file, b"second-bytes").expect("seed second file");
         let stored_second = service
-            .add_entry_attachment(&db_path, &entry_a, &second_file)
+            .add_entry_attachment(&db_path, &entry_a, &second_file, TEST_HARD_CAP)
             .expect("add second");
         assert_eq!(
             stored_second, "scan (1).pdf",
@@ -1422,7 +1607,7 @@ mod tests {
         let not_a_file = dir.path().join("a-directory");
         std::fs::create_dir(&not_a_file).expect("mk dir");
 
-        let result = service.add_entry_attachment(&db_path, &entry_a, &not_a_file);
+        let result = service.add_entry_attachment(&db_path, &entry_a, &not_a_file, TEST_HARD_CAP);
         assert!(
             matches!(result, Err(AppError::InvalidInput(_))),
             "a non-regular file must be rejected, got {result:?}"
@@ -1449,7 +1634,7 @@ mod tests {
         std::fs::write(&second, b"second").expect("seed second");
 
         let outcome = service
-            .add_entry_attachments(&db_path, &entry_a, &[first, second])
+            .add_entry_attachments(&db_path, &entry_a, &[first, second], TEST_HARD_CAP)
             .expect("batch add");
 
         assert_eq!(
@@ -1473,14 +1658,14 @@ mod tests {
         let huge = dir.path().join("huge.bin");
         std::fs::write(
             &huge,
-            vec![0u8; usize::try_from(HARD_CAP_BYTES + 1).expect("cap fits usize")],
+            vec![0u8; usize::try_from(TEST_HARD_CAP + 1).expect("cap fits usize")],
         )
         .expect("seed huge");
         let ok_b = dir.path().join("ok-b.txt");
         std::fs::write(&ok_b, b"b").expect("seed ok-b");
 
         let outcome = service
-            .add_entry_attachments(&db_path, &entry_a, &[ok_a, huge, ok_b])
+            .add_entry_attachments(&db_path, &entry_a, &[ok_a, huge, ok_b], TEST_HARD_CAP)
             .expect("batch add");
 
         assert_eq!(
@@ -1508,7 +1693,7 @@ mod tests {
             .expect("generation before");
 
         let outcome = service
-            .add_entry_attachments(db_path, entry_id, &[])
+            .add_entry_attachments(db_path, entry_id, &[], TEST_HARD_CAP)
             .expect("empty add");
 
         assert!(outcome.added.is_empty(), "nothing is added");
@@ -1559,13 +1744,13 @@ mod tests {
         let dropped = dir.path().join("dropped.txt");
         std::fs::write(&dropped, b"from a drag-drop").expect("seed dropped file");
 
-        let buffer = crate::services::drag_drop::DropPathsBuffer::default();
+        let buffer = crate::services::drag_drop::PendingAttachmentPaths::default();
         buffer.replace(vec![dropped.clone()]);
 
         // The commit drains the buffer and hands only those paths to the feeder.
         let paths = buffer.take();
         let outcome = service
-            .add_entry_attachments(&db_path, &entry_a, &paths)
+            .add_entry_attachments(&db_path, &entry_a, &paths, TEST_HARD_CAP)
             .expect("commit drained drop");
 
         assert_eq!(
@@ -1597,7 +1782,7 @@ mod tests {
         // untouched — the same guarantee as a cancelled picker dialog.
         let (service, _dir, db_path, entry_a, _b) = create_test_database();
 
-        let buffer = crate::services::drag_drop::DropPathsBuffer::default();
+        let buffer = crate::services::drag_drop::PendingAttachmentPaths::default();
         assert!(buffer.take().is_empty(), "no drop means no buffered paths");
 
         assert_empty_add_is_inert(&service, &db_path, &entry_a);

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -276,8 +276,14 @@ impl KdbxService {
             )));
         }
 
+        // Read one byte past the cap to prove an over-cap file. `saturating_add`
+        // guards the edge where `hard_cap` is `u64::MAX` (a hand-edited
+        // settings.json the validator accepts): `hard_cap + 1` would overflow —
+        // panicking in overflow-checked builds, or wrapping to `take(0)` in
+        // release and silently storing an empty attachment. Saturating leaves
+        // the cap effectively unlimited, which is the intended meaning.
         let mut bytes = Vec::new();
-        file.take(hard_cap + 1)
+        file.take(hard_cap.saturating_add(1))
             .read_to_end(&mut bytes)
             .map_err(|e| AppError::Io(e.to_string()))?;
         if bytes.len() as u64 > hard_cap {
@@ -1547,6 +1553,35 @@ mod tests {
                 Ok(())
             })
             .expect("vault scope");
+    }
+
+    #[test]
+    fn add_entry_attachment_stores_the_real_bytes_when_the_cap_is_u64_max() {
+        // Regression: a hand-edited settings.json can set hardCapBytes to
+        // u64::MAX (the validator only rejects 0 and soft > hard). The read
+        // bound was `hard_cap + 1`, which overflows at u64::MAX — panicking in
+        // overflow-checked builds, or wrapping to take(0) in release and storing
+        // an empty attachment for any non-empty file. With saturating_add the
+        // file's real bytes round-trip and nothing is silently truncated.
+        let (service, dir, db_path, entry_a, _b) = create_test_database();
+
+        let payload = b"real-contents-not-empty";
+        let source = dir.path().join("notes.txt");
+        std::fs::write(&source, payload).expect("seed file");
+
+        let stored = service
+            .add_entry_attachment(&db_path, &entry_a, &source, u64::MAX)
+            .expect("add under an effectively unlimited cap");
+        assert_eq!(stored, "notes.txt");
+
+        let bytes = service
+            .get_entry_attachment(&db_path, &entry_a, "notes.txt")
+            .expect("read back attachment");
+        assert_eq!(
+            bytes.as_bytes(),
+            payload,
+            "the full file bytes must round-trip, not a truncated/empty blob"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -71,9 +71,13 @@ pub(crate) fn plan_attachment_adds(
     let requires_confirmation = items
         .iter()
         .any(|item| item.status == AttachmentSizeStatus::OverSoft);
+    // `batch_id` is owned by the buffer generation, which this pure builder has
+    // no access to; the prepare command overwrites it with the real id before
+    // returning the plan over IPC.
     AttachmentAddPlan {
         items,
         requires_confirmation,
+        batch_id: 0,
     }
 }
 
@@ -1780,10 +1784,10 @@ mod tests {
         std::fs::write(&dropped, b"from a drag-drop").expect("seed dropped file");
 
         let buffer = crate::services::drag_drop::PendingAttachmentPaths::default();
-        buffer.replace(vec![dropped.clone()]);
+        let batch = buffer.replace(vec![dropped.clone()]);
 
         // The commit drains the buffer and hands only those paths to the feeder.
-        let paths = buffer.take();
+        let paths = buffer.take(batch);
         let outcome = service
             .add_entry_attachments(&db_path, &entry_a, &paths, TEST_HARD_CAP)
             .expect("commit drained drop");
@@ -1804,7 +1808,7 @@ mod tests {
         );
 
         assert!(
-            buffer.take().is_empty(),
+            buffer.take(batch).is_empty(),
             "the buffer is drained, so a second commit reads nothing"
         );
     }
@@ -1818,7 +1822,7 @@ mod tests {
         let (service, _dir, db_path, entry_a, _b) = create_test_database();
 
         let buffer = crate::services::drag_drop::PendingAttachmentPaths::default();
-        assert!(buffer.take().is_empty(), "no drop means no buffered paths");
+        assert!(buffer.take(0).is_empty(), "no drop means no buffered paths");
 
         assert_empty_add_is_inert(&service, &db_path, &entry_a);
     }

--- a/src-tauri/src/services/settings.rs
+++ b/src-tauri/src/services/settings.rs
@@ -214,6 +214,22 @@ impl SettingsService {
                 "audit.retentionDays must be in 1..=365, got {r}"
             )));
         }
+        // Attachment guardrails: a coherent pair has a non-zero hard cap with
+        // the soft warning at or below it. Inverting them (or zeroing the cap)
+        // would either disable the warning step or reject every file, so reject
+        // at the boundary before the add flow ever reads the values.
+        let soft = prefs.attachments.soft_warn_bytes;
+        let hard = prefs.attachments.hard_cap_bytes;
+        if hard < 1 {
+            return Err(AppError::InvalidInput(format!(
+                "attachments.hardCapBytes must be at least 1, got {hard}"
+            )));
+        }
+        if soft > hard {
+            return Err(AppError::InvalidInput(format!(
+                "attachments.softWarnBytes ({soft}) must not exceed attachments.hardCapBytes ({hard})"
+            )));
+        }
         Ok(())
     }
 
@@ -275,8 +291,69 @@ pub fn diff_security_changes(old: &AppPreferences, new: &AppPreferences) -> Vec<
 #[allow(clippy::expect_used, clippy::panic)]
 mod validate_preferences_tests {
     use super::SettingsService;
-    use crate::commands::settings::{AppPreferences, AuditSettings, BackupSettings};
+    use crate::commands::settings::{
+        AppPreferences, AttachmentSettings, AuditSettings, BackupSettings,
+    };
     use crate::dto::error::AppError;
+
+    fn prefs_with_attachments(soft: u64, hard: u64) -> AppPreferences {
+        AppPreferences {
+            attachments: AttachmentSettings {
+                soft_warn_bytes: soft,
+                hard_cap_bytes: hard,
+            },
+            ..AppPreferences::default()
+        }
+    }
+
+    #[test]
+    fn attachment_soft_above_hard_is_rejected() {
+        // A soft warning that sits above the hard cap is nonsensical: every
+        // file the user could add is either rejected (over hard) or silent
+        // (under soft) — the warning step can never fire. Reject at the
+        // boundary so a hand-edited settings.json can't disable the warning by
+        // inverting the pair.
+        let prefs = prefs_with_attachments(30_000_000, 25_000_000);
+        match SettingsService::validate_preferences(&prefs) {
+            Err(AppError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("softWarnBytes") && msg.contains("hardCapBytes"),
+                    "error should name both fields, got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attachment_hard_cap_zero_is_rejected() {
+        // A zero hard cap would reject every possible file. Reject at the
+        // boundary rather than letting the add flow become a no-op.
+        let prefs = prefs_with_attachments(0, 0);
+        match SettingsService::validate_preferences(&prefs) {
+            Err(AppError::InvalidInput(msg)) => {
+                assert!(
+                    msg.contains("hardCapBytes"),
+                    "error should name hardCapBytes, got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn attachment_soft_equal_to_hard_is_accepted() {
+        // soft == hard is a valid boundary: every over-soft file is also over
+        // hard, so the warning never fires but the config is coherent.
+        let prefs = prefs_with_attachments(25_000_000, 25_000_000);
+        SettingsService::validate_preferences(&prefs).expect("soft == hard should validate");
+    }
+
+    #[test]
+    fn attachment_defaults_validate() {
+        let prefs = prefs_with_attachments(5_000_000, 25_000_000);
+        SettingsService::validate_preferences(&prefs).expect("documented defaults should validate");
+    }
 
     fn prefs_with_directory(dir: Option<&str>) -> AppPreferences {
         AppPreferences {

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -97,6 +97,9 @@ vi.mock("@/lib/tauri", () => ({
   database: { save: databaseSave },
 }));
 
+// The buffer generation a prepare returns and the commit must echo back.
+const BATCH_ID = 7;
+
 // A plan with no over-soft files: the add proceeds without a confirmation
 // prompt. `items` is non-empty so the flow reaches commit (an empty plan is a
 // no-op). Tests that don't care about the exact items reuse this.
@@ -104,6 +107,7 @@ function planWithoutConfirmation() {
   return {
     items: [{ sourceName: "file.txt", size: 10, status: "ok" as const }],
     requiresConfirmation: false,
+    batchId: BATCH_ID,
   };
 }
 
@@ -115,6 +119,7 @@ function planRequiringConfirmation() {
       { sourceName: "big.pdf", size: 8_000_000, status: "overSoft" as const },
     ],
     requiresConfirmation: true,
+    batchId: BATCH_ID,
   };
 }
 
@@ -610,19 +615,25 @@ describe("EntryItemDetails attachment add", () => {
     });
     // An under-soft batch is never prompted, and commit receives ids only.
     expect(ask).not.toHaveBeenCalled();
-    expect(commitPreparedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+    expect(commitPreparedAttachments).toHaveBeenCalledWith(
+      "db-1",
+      "entry-1",
+      BATCH_ID
+    );
     expect(toastSuccess).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
   });
 
-  it("ignores a second Add click while the first gesture is still in flight", async () => {
+  it("shows a busy indicator and ignores a second Add click while in flight", async () => {
     // Both write paths buffer paths in one shared Rust-side buffer, so a
     // concurrent gesture started before the first commits would clobber the
-    // first's paths. The in-flight guard must reject the second prepare until
-    // the first flow finishes.
+    // first's paths. While a flow is in flight the Add button must show a busy
+    // state (so the user sees the work) and reject a second prepare (so it can't
+    // be re-triggered or interrupted).
     let resolvePrepare!: (plan: {
       items: { sourceName: string; size: number; status: "ok" }[];
       requiresConfirmation: boolean;
+      batchId: number;
     }) => void;
     preparePickedAttachments.mockReturnValue(
       new Promise((resolve) => {
@@ -631,18 +642,30 @@ describe("EntryItemDetails attachment add", () => {
     );
 
     renderDetails({ attachments: [] });
-    clickAttachmentAction("entries.detail.addAttachment");
-    // Second click lands while the first prepare is still pending.
-    clickAttachmentAction("entries.detail.addAttachment");
+    const button = screen.getByRole("button", {
+      name: "entries.detail.addAttachment",
+    });
+    fireEvent.click(button);
 
+    // The button reflects the in-flight state: busy + disabled.
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(
+      screen.getByText("entries.detail.addingAttachments")
+    ).toBeInTheDocument();
+
+    // A second click while the first prepare is still pending is ignored.
+    fireEvent.click(button);
     expect(preparePickedAttachments).toHaveBeenCalledTimes(1);
 
-    // Let the first flow finish so the guard releases (and the test doesn't
-    // leak a pending promise).
-    resolvePrepare({ items: [], requiresConfirmation: false });
+    // Let the first flow finish so the guard releases and the busy state clears.
+    resolvePrepare({ items: [], requiresConfirmation: false, batchId: 0 });
     await waitFor(() => {
-      expect(preparePickedAttachments).toHaveBeenCalledTimes(1);
+      expect(button).not.toBeDisabled();
     });
+    expect(preparePickedAttachments).toHaveBeenCalledTimes(1);
   });
 
   it("does nothing when the picker comes back empty (cancelled)", async () => {
@@ -650,6 +673,7 @@ describe("EntryItemDetails attachment add", () => {
     preparePickedAttachments.mockResolvedValue({
       items: [],
       requiresConfirmation: false,
+      batchId: 0,
     });
 
     renderDetails({ attachments: [] });
@@ -678,7 +702,11 @@ describe("EntryItemDetails attachment add", () => {
     clickAttachmentAction("entries.detail.addAttachment");
 
     await waitFor(() => {
-      expect(commitPreparedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+      expect(commitPreparedAttachments).toHaveBeenCalledWith(
+        "db-1",
+        "entry-1",
+        BATCH_ID
+      );
     });
     expect(ask).toHaveBeenCalledTimes(1);
     expect(databaseSave).toHaveBeenCalledWith("db-1");
@@ -856,7 +884,11 @@ describe("EntryItemDetails attachment drop zone", () => {
     await fireDrop({ x: 50, y: 50 });
 
     await waitFor(() => {
-      expect(commitPreparedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+      expect(commitPreparedAttachments).toHaveBeenCalledWith(
+        "db-1",
+        "entry-1",
+        BATCH_ID
+      );
     });
     expect(databaseSave).toHaveBeenCalledWith("db-1");
     expect(toastSuccess).toHaveBeenCalled();

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -73,9 +73,10 @@ vi.mock("@/hooks/use-clipboard-timeout", () => ({
 
 const exportAttachment = vi.hoisted(() => vi.fn());
 const deleteAttachment = vi.hoisted(() => vi.fn());
-const addAttachments = vi.hoisted(() => vi.fn());
+const preparePickedAttachments = vi.hoisted(() => vi.fn());
+const prepareDroppedAttachments = vi.hoisted(() => vi.fn());
+const commitPreparedAttachments = vi.hoisted(() => vi.fn());
 const getAttachmentBytes = vi.hoisted(() => vi.fn());
-const commitDroppedAttachments = vi.hoisted(() => vi.fn());
 const databaseSave = vi.hoisted(() => vi.fn());
 const save = vi.hoisted(() => vi.fn());
 const ask = vi.hoisted(() => vi.fn());
@@ -88,12 +89,34 @@ vi.mock("@/lib/tauri", () => ({
     getProtectedCustomField: vi.fn(),
     exportAttachment,
     deleteAttachment,
-    addAttachments,
+    preparePickedAttachments,
+    prepareDroppedAttachments,
+    commitPreparedAttachments,
     getAttachmentBytes,
-    commitDroppedAttachments,
   },
   database: { save: databaseSave },
 }));
+
+// A plan with no over-soft files: the add proceeds without a confirmation
+// prompt. `items` is non-empty so the flow reaches commit (an empty plan is a
+// no-op). Tests that don't care about the exact items reuse this.
+function planWithoutConfirmation() {
+  return {
+    items: [{ sourceName: "file.txt", size: 10, status: "ok" as const }],
+    requiresConfirmation: false,
+  };
+}
+
+// A plan flagged as requiring confirmation (at least one over-soft file), used
+// by the soft-warning tests.
+function planRequiringConfirmation() {
+  return {
+    items: [
+      { sourceName: "big.pdf", size: 8_000_000, status: "overSoft" as const },
+    ],
+    requiresConfirmation: true,
+  };
+}
 
 // Mutable holder for the responsive breakpoint so each test can render the
 // desktop (drop zone present) or mobile (drop zone hidden) layout.
@@ -558,18 +581,22 @@ describe("EntryItemDetails attachment add", () => {
   beforeEach(() => {
     state.entry = null;
     state.isTransitioning = false;
-    addAttachments.mockReset();
+    preparePickedAttachments.mockReset();
+    commitPreparedAttachments.mockReset();
+    ask.mockReset();
     databaseSave.mockReset();
     toastSuccess.mockReset();
     toastError.mockReset();
   });
 
-  it("invokes the Rust-side picker command with no path, then persists", async () => {
-    // The dialog now lives in Rust: the frontend hands the command only the
-    // db/entry ids — never a path — so a fabricated path can't reach the read
-    // (ADR-0004 trust boundary). On a non-empty outcome it persists once and
-    // reports success.
-    addAttachments.mockResolvedValue({
+  it("prepares via the Rust-side picker, commits with no path, then persists", async () => {
+    // The two-phase flow: prepare opens the dialog and buffers paths in Rust,
+    // returning a size plan; commit stores them. The frontend hands the commit
+    // only db/entry ids — never a path — so a fabricated path can't reach the
+    // read (ADR-0004 trust boundary). With no over-soft file there is no prompt;
+    // on a non-empty outcome it persists once and reports success.
+    preparePickedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockResolvedValue({
       added: ["codes.txt", "scan.pdf"],
       failed: [],
     });
@@ -581,21 +608,65 @@ describe("EntryItemDetails attachment add", () => {
     await waitFor(() => {
       expect(databaseSave).toHaveBeenCalledWith("db-1");
     });
-    // The command receives ids only — no caller-supplied path argument.
-    expect(addAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+    // An under-soft batch is never prompted, and commit receives ids only.
+    expect(ask).not.toHaveBeenCalled();
+    expect(commitPreparedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
     expect(toastSuccess).toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
   });
 
   it("does nothing when the picker comes back empty (cancelled)", async () => {
-    addAttachments.mockResolvedValue({ added: [], failed: [] });
+    // A cancelled dialog yields an empty plan — the flow never reaches commit.
+    preparePickedAttachments.mockResolvedValue({
+      items: [],
+      requiresConfirmation: false,
+    });
 
     renderDetails({ attachments: [] });
     clickAttachmentAction("entries.detail.addAttachment");
 
     await waitFor(() => {
-      expect(addAttachments).toHaveBeenCalled();
+      expect(preparePickedAttachments).toHaveBeenCalled();
     });
+    expect(commitPreparedAttachments).not.toHaveBeenCalled();
+    expect(databaseSave).not.toHaveBeenCalled();
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("prompts for confirmation when a file is over the soft threshold and commits on confirm", async () => {
+    // AC: adding a file above the soft threshold prompts; confirming proceeds.
+    preparePickedAttachments.mockResolvedValue(planRequiringConfirmation());
+    ask.mockResolvedValue(true);
+    commitPreparedAttachments.mockResolvedValue({
+      added: ["big.pdf"],
+      failed: [],
+    });
+    databaseSave.mockResolvedValue(undefined);
+
+    renderDetails({ attachments: [] });
+    clickAttachmentAction("entries.detail.addAttachment");
+
+    await waitFor(() => {
+      expect(commitPreparedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+    });
+    expect(ask).toHaveBeenCalledTimes(1);
+    expect(databaseSave).toHaveBeenCalledWith("db-1");
+    expect(toastSuccess).toHaveBeenCalled();
+  });
+
+  it("aborts the whole batch when the soft-warning is declined", async () => {
+    // AC: cancelling aborts. Nothing is committed, persisted, or reported.
+    preparePickedAttachments.mockResolvedValue(planRequiringConfirmation());
+    ask.mockResolvedValue(false);
+
+    renderDetails({ attachments: [] });
+    clickAttachmentAction("entries.detail.addAttachment");
+
+    await waitFor(() => {
+      expect(ask).toHaveBeenCalledTimes(1);
+    });
+    expect(commitPreparedAttachments).not.toHaveBeenCalled();
     expect(databaseSave).not.toHaveBeenCalled();
     expect(toastSuccess).not.toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
@@ -611,11 +682,12 @@ describe("EntryItemDetails attachment add", () => {
     expect(button).toBeDisabled();
 
     fireEvent.click(button);
-    expect(addAttachments).not.toHaveBeenCalled();
+    expect(preparePickedAttachments).not.toHaveBeenCalled();
   });
 
-  it("surfaces a batch error toast when the command itself rejects", async () => {
-    addAttachments.mockRejectedValue(new Error("vault locked"));
+  it("surfaces a batch error toast when the commit itself rejects", async () => {
+    preparePickedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockRejectedValue(new Error("vault locked"));
 
     renderDetails({ attachments: [] });
     clickAttachmentAction("entries.detail.addAttachment");
@@ -631,7 +703,8 @@ describe("EntryItemDetails attachment add", () => {
     // Each per-file failure must get its own toast so the user can tell which
     // files failed (the string names the file + the backend reason); a single
     // collapsed toast would hide that.
-    addAttachments.mockResolvedValue({
+    preparePickedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockResolvedValue({
       added: [],
       failed: [
         { sourceName: "huge-a.bin", reason: "too large" },
@@ -653,7 +726,8 @@ describe("EntryItemDetails attachment add", () => {
   it("persists the survivors when some files in the batch failed", async () => {
     // A mixed outcome: the survivors still persist and report success, with
     // one error toast for the failure and one success toast for what landed.
-    addAttachments.mockResolvedValue({
+    preparePickedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockResolvedValue({
       added: ["ok-a.txt", "ok-b.txt"],
       failed: [{ sourceName: "huge.bin", reason: "too large" }],
     });
@@ -701,7 +775,9 @@ describe("EntryItemDetails attachment drop zone", () => {
     state.isTransitioning = false;
     mobile.isMobile = false;
     dragDrop.handler = null;
-    commitDroppedAttachments.mockReset();
+    prepareDroppedAttachments.mockReset();
+    commitPreparedAttachments.mockReset();
+    ask.mockReset();
     databaseSave.mockReset();
     toastSuccess.mockReset();
     toastError.mockReset();
@@ -732,10 +808,12 @@ describe("EntryItemDetails attachment drop zone", () => {
   });
 
   it("commits a drop that lands inside the panel via the shared add path", async () => {
-    // A drop on the selected Entry's panel drains the Rust-side buffer (the
-    // command takes only ids — no path) and then goes through the exact same
-    // tail as the picker: persist once, refresh, success toast.
-    commitDroppedAttachments.mockResolvedValue({
+    // A drop on the selected Entry's panel prepares (peeks) the Rust-side buffer
+    // for its size plan, then commits (the command takes only ids — no path) and
+    // goes through the exact same tail as the picker: persist once, refresh,
+    // success toast.
+    prepareDroppedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockResolvedValue({
       added: ["dropped.txt"],
       failed: [],
     });
@@ -748,7 +826,7 @@ describe("EntryItemDetails attachment drop zone", () => {
     await fireDrop({ x: 50, y: 50 });
 
     await waitFor(() => {
-      expect(commitDroppedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
+      expect(commitPreparedAttachments).toHaveBeenCalledWith("db-1", "entry-1");
     });
     expect(databaseSave).toHaveBeenCalledWith("db-1");
     expect(toastSuccess).toHaveBeenCalled();
@@ -756,10 +834,29 @@ describe("EntryItemDetails attachment drop zone", () => {
     rect.mockRestore();
   });
 
+  it("aborts a dropped batch when the soft-warning is declined", async () => {
+    // The drop path shares the picker's prepare→confirm→commit flow: an
+    // over-soft file prompts, and declining aborts the whole batch.
+    prepareDroppedAttachments.mockResolvedValue(planRequiringConfirmation());
+    ask.mockResolvedValue(false);
+    const rect = mockPanelRect();
+
+    renderDetails({ attachments: [] });
+    await fireDrop({ x: 50, y: 50 });
+
+    await waitFor(() => {
+      expect(ask).toHaveBeenCalledTimes(1);
+    });
+    expect(commitPreparedAttachments).not.toHaveBeenCalled();
+    expect(databaseSave).not.toHaveBeenCalled();
+    rect.mockRestore();
+  });
+
   it("does not persist when a dropped batch wholly fails", async () => {
     // Same no-phantom-save guard as the picker: a fully-failed drop reports its
     // per-file failures but never persists or reports success.
-    commitDroppedAttachments.mockResolvedValue({
+    prepareDroppedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockResolvedValue({
       added: [],
       failed: [{ sourceName: "huge.bin", reason: "too large" }],
     });
@@ -782,7 +879,7 @@ describe("EntryItemDetails attachment drop zone", () => {
     renderDetails({ attachments: [] });
     await fireDrop({ x: 500, y: 500 });
 
-    expect(commitDroppedAttachments).not.toHaveBeenCalled();
+    expect(prepareDroppedAttachments).not.toHaveBeenCalled();
     expect(databaseSave).not.toHaveBeenCalled();
     rect.mockRestore();
   });
@@ -795,7 +892,7 @@ describe("EntryItemDetails attachment drop zone", () => {
     renderDetails({ attachments: [] });
     await fireDrop({ x: 50, y: 50 });
 
-    expect(commitDroppedAttachments).not.toHaveBeenCalled();
+    expect(prepareDroppedAttachments).not.toHaveBeenCalled();
     rect.mockRestore();
   });
 
@@ -832,7 +929,8 @@ describe("EntryItemDetails attachment drop zone", () => {
   });
 
   it("surfaces a batch error toast when a dropped commit rejects", async () => {
-    commitDroppedAttachments.mockRejectedValue(new Error("vault locked"));
+    prepareDroppedAttachments.mockResolvedValue(planWithoutConfirmation());
+    commitPreparedAttachments.mockRejectedValue(new Error("vault locked"));
     const rect = mockPanelRect();
 
     renderDetails({ attachments: [] });

--- a/src/components/entries/EntryItemDetails.test.tsx
+++ b/src/components/entries/EntryItemDetails.test.tsx
@@ -615,6 +615,36 @@ describe("EntryItemDetails attachment add", () => {
     expect(toastError).not.toHaveBeenCalled();
   });
 
+  it("ignores a second Add click while the first gesture is still in flight", async () => {
+    // Both write paths buffer paths in one shared Rust-side buffer, so a
+    // concurrent gesture started before the first commits would clobber the
+    // first's paths. The in-flight guard must reject the second prepare until
+    // the first flow finishes.
+    let resolvePrepare!: (plan: {
+      items: { sourceName: string; size: number; status: "ok" }[];
+      requiresConfirmation: boolean;
+    }) => void;
+    preparePickedAttachments.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePrepare = resolve;
+      })
+    );
+
+    renderDetails({ attachments: [] });
+    clickAttachmentAction("entries.detail.addAttachment");
+    // Second click lands while the first prepare is still pending.
+    clickAttachmentAction("entries.detail.addAttachment");
+
+    expect(preparePickedAttachments).toHaveBeenCalledTimes(1);
+
+    // Let the first flow finish so the guard releases (and the test doesn't
+    // leak a pending promise).
+    resolvePrepare({ items: [], requiresConfirmation: false });
+    await waitFor(() => {
+      expect(preparePickedAttachments).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("does nothing when the picker comes back empty (cancelled)", async () => {
     // A cancelled dialog yields an empty plan — the flow never reaches commit.
     preparePickedAttachments.mockResolvedValue({

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -593,6 +593,12 @@ function AttachmentsSection({
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
   const panelRef = useRef<HTMLDivElement>(null);
+  // Guards against overlapping add gestures. Both write paths (picker, drop)
+  // buffer their paths in one shared Rust-side buffer, so a second gesture
+  // started while the first is still awaiting its confirmation prompt would
+  // overwrite the first's paths before it commits. This ref rejects a
+  // concurrent prepare so each gesture owns the buffer for its whole lifetime.
+  const addInFlightRef = useRef(false);
   // The Attachment the user opened the Preview modal on, or null when the
   // modal is closed. Kept at the section level so the modal sits outside the
   // row mapping (one modal, not one per row).
@@ -690,43 +696,51 @@ function AttachmentsSection({
       Awaited<ReturnType<typeof entriesApi.preparePickedAttachments>>
     >
   ) => {
-    let plan: Awaited<ReturnType<typeof entriesApi.preparePickedAttachments>>;
+    // Reject a concurrent gesture: the first one owns the shared buffer until it
+    // commits or aborts, so a second prepare here would clobber its paths.
+    if (addInFlightRef.current) return;
+    addInFlightRef.current = true;
     try {
-      plan = await prepare();
-    } catch (error) {
-      console.error("Failed to prepare attachments:", error);
-      toast.error(t("entries.detail.attachmentAddBatchFailed"));
-      return;
+      let plan: Awaited<ReturnType<typeof entriesApi.preparePickedAttachments>>;
+      try {
+        plan = await prepare();
+      } catch (error) {
+        console.error("Failed to prepare attachments:", error);
+        toast.error(t("entries.detail.attachmentAddBatchFailed"));
+        return;
+      }
+
+      // Nothing picked/dropped: a true no-op, so we never reach commit.
+      if (plan.items.length === 0) return;
+
+      if (plan.requiresConfirmation) {
+        const confirmed = await ask(
+          t("entries.detail.attachmentSoftWarnConfirm"),
+          {
+            title: t("entries.detail.attachmentSoftWarnConfirmTitle"),
+            kind: "warning",
+          }
+        );
+        // Abort the whole batch on decline: the buffered paths stay until the
+        // next pick/drop overwrites them, but nothing is stored now.
+        if (!confirmed) return;
+      }
+
+      let outcome: Awaited<
+        ReturnType<typeof entriesApi.commitPreparedAttachments>
+      >;
+      try {
+        outcome = await entriesApi.commitPreparedAttachments(dbId, entryId);
+      } catch (error) {
+        console.error("Failed to add attachments:", error);
+        toast.error(t("entries.detail.attachmentAddBatchFailed"));
+        return;
+      }
+
+      await applyAddOutcome(outcome);
+    } finally {
+      addInFlightRef.current = false;
     }
-
-    // Nothing picked/dropped: a true no-op, so we never reach commit.
-    if (plan.items.length === 0) return;
-
-    if (plan.requiresConfirmation) {
-      const confirmed = await ask(
-        t("entries.detail.attachmentSoftWarnConfirm"),
-        {
-          title: t("entries.detail.attachmentSoftWarnConfirmTitle"),
-          kind: "warning",
-        }
-      );
-      // Abort the whole batch on decline: the buffered paths stay until the
-      // next pick/drop overwrites them, but nothing is stored now.
-      if (!confirmed) return;
-    }
-
-    let outcome: Awaited<
-      ReturnType<typeof entriesApi.commitPreparedAttachments>
-    >;
-    try {
-      outcome = await entriesApi.commitPreparedAttachments(dbId, entryId);
-    } catch (error) {
-      console.error("Failed to add attachments:", error);
-      toast.error(t("entries.detail.attachmentAddBatchFailed"));
-      return;
-    }
-
-    await applyAddOutcome(outcome);
   };
 
   // Add is the primary write path: the picker opens the multi-select dialog in

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -596,9 +596,12 @@ function AttachmentsSection({
   // Guards against overlapping add gestures. Both write paths (picker, drop)
   // buffer their paths in one shared Rust-side buffer, so a second gesture
   // started while the first is still awaiting its confirmation prompt would
-  // overwrite the first's paths before it commits. This ref rejects a
-  // concurrent prepare so each gesture owns the buffer for its whole lifetime.
+  // overwrite the first's paths before it commits. The ref is the synchronous
+  // guard (a double-click can't slip through between renders); `isAdding` is the
+  // rendered mirror that drives the spinner and disables the controls so the
+  // user can see the work and can't accidentally re-trigger or interrupt it.
   const addInFlightRef = useRef(false);
+  const [isAdding, setIsAdding] = useState(false);
   // The Attachment the user opened the Preview modal on, or null when the
   // modal is closed. Kept at the section level so the modal sits outside the
   // row mapping (one modal, not one per row).
@@ -700,6 +703,7 @@ function AttachmentsSection({
     // commits or aborts, so a second prepare here would clobber its paths.
     if (addInFlightRef.current) return;
     addInFlightRef.current = true;
+    setIsAdding(true);
     try {
       let plan: Awaited<ReturnType<typeof entriesApi.preparePickedAttachments>>;
       try {
@@ -730,7 +734,13 @@ function AttachmentsSection({
         ReturnType<typeof entriesApi.commitPreparedAttachments>
       >;
       try {
-        outcome = await entriesApi.commitPreparedAttachments(dbId, entryId);
+        // Echo the prepared batch id so a superseded batch (a later pick/drop)
+        // commits nothing rather than the wrong file.
+        outcome = await entriesApi.commitPreparedAttachments(
+          dbId,
+          entryId,
+          plan.batchId
+        );
       } catch (error) {
         console.error("Failed to add attachments:", error);
         toast.error(t("entries.detail.attachmentAddBatchFailed"));
@@ -740,6 +750,7 @@ function AttachmentsSection({
       await applyAddOutcome(outcome);
     } finally {
       addInFlightRef.current = false;
+      setIsAdding(false);
     }
   };
 
@@ -761,8 +772,12 @@ function AttachmentsSection({
 
   // The native drag-drop event is window-global; the hook acts only on desktop
   // and only when a drop lands inside this panel (and not mid-transition).
+  // Ignore drops while an add is already in flight: the in-flight gesture owns
+  // the buffer, and accepting another drop would only supersede it (and be a
+  // no-op at commit anyway). Disabling here keeps the drop zone honest with the
+  // busy state the user sees.
   const { isDragOver } = useAttachmentDrop({
-    enabled: !isMobile && !isDisabled,
+    enabled: !isMobile && !isDisabled && !isAdding,
     panelRef,
     onDrop: handleDrop,
   });
@@ -812,11 +827,21 @@ function AttachmentsSection({
           size="sm"
           className="h-7 gap-1.5"
           aria-label={t("entries.detail.addAttachment")}
-          disabled={isDisabled}
+          aria-busy={isAdding}
+          disabled={isDisabled || isAdding}
           onClick={() => void handleAdd()}
         >
-          <Paperclip className="h-4 w-4" />
-          {t("entries.detail.addAttachment")}
+          {isAdding ? (
+            <>
+              <Loader2 className="h-4 w-4 animate-spin" />
+              {t("entries.detail.addingAttachments")}
+            </>
+          ) : (
+            <>
+              <Paperclip className="h-4 w-4" />
+              {t("entries.detail.addAttachment")}
+            </>
+          )}
         </Button>
       </div>
       <Separator />

--- a/src/components/entries/EntryItemDetails.tsx
+++ b/src/components/entries/EntryItemDetails.tsx
@@ -656,7 +656,7 @@ function AttachmentsSection({
   // at least one file actually landed in the in-memory Vault — so a
   // wholly-failed, cancelled, or empty batch leaves no phantom unsaved state.
   const applyAddOutcome = async (
-    outcome: Awaited<ReturnType<typeof entriesApi.addAttachments>>
+    outcome: Awaited<ReturnType<typeof entriesApi.commitPreparedAttachments>>
   ) => {
     for (const failure of outcome.failed) {
       toast.error(
@@ -676,17 +676,50 @@ function AttachmentsSection({
     }
   };
 
-  // Add is the primary write path. The multi-select file dialog is opened in
-  // Rust by the add command — the frontend passes no path, so a fabricated
-  // path can never reach the backend read (the trust boundary in ADR-0004).
-  // A failure on one file doesn't abort the rest; a cancelled dialog comes back
-  // as an empty outcome — a no-op handled by the shared tail below.
-  const handleAdd = async () => {
-    if (isDisabled) return;
-
-    let outcome: Awaited<ReturnType<typeof entriesApi.addAttachments>>;
+  // Shared two-phase add flow for both write paths. Phase 1 (`prepare`) buffers
+  // the picked/dropped paths in Rust and returns their size classification
+  // against the configured thresholds — no bytes read, no Vault mutation. If any
+  // file is over the soft threshold we prompt before committing; declining
+  // aborts the whole batch (nothing is stored). Phase 2 (`commit`) drains the
+  // buffer and stores the files, returning the batch outcome handled by the
+  // shared tail. An empty plan (cancelled dialog, or a drop with nothing
+  // buffered) is a no-op. The frontend never sees a path — the trust boundary in
+  // ADR-0004.
+  const runAddFlow = async (
+    prepare: () => Promise<
+      Awaited<ReturnType<typeof entriesApi.preparePickedAttachments>>
+    >
+  ) => {
+    let plan: Awaited<ReturnType<typeof entriesApi.preparePickedAttachments>>;
     try {
-      outcome = await entriesApi.addAttachments(dbId, entryId);
+      plan = await prepare();
+    } catch (error) {
+      console.error("Failed to prepare attachments:", error);
+      toast.error(t("entries.detail.attachmentAddBatchFailed"));
+      return;
+    }
+
+    // Nothing picked/dropped: a true no-op, so we never reach commit.
+    if (plan.items.length === 0) return;
+
+    if (plan.requiresConfirmation) {
+      const confirmed = await ask(
+        t("entries.detail.attachmentSoftWarnConfirm"),
+        {
+          title: t("entries.detail.attachmentSoftWarnConfirmTitle"),
+          kind: "warning",
+        }
+      );
+      // Abort the whole batch on decline: the buffered paths stay until the
+      // next pick/drop overwrites them, but nothing is stored now.
+      if (!confirmed) return;
+    }
+
+    let outcome: Awaited<
+      ReturnType<typeof entriesApi.commitPreparedAttachments>
+    >;
+    try {
+      outcome = await entriesApi.commitPreparedAttachments(dbId, entryId);
     } catch (error) {
       console.error("Failed to add attachments:", error);
       toast.error(t("entries.detail.attachmentAddBatchFailed"));
@@ -696,26 +729,20 @@ function AttachmentsSection({
     await applyAddOutcome(outcome);
   };
 
+  // Add is the primary write path: the picker opens the multi-select dialog in
+  // Rust (ADR-0004) and buffers the chosen paths for the shared flow.
+  const handleAdd = async () => {
+    if (isDisabled) return;
+    await runAddFlow(() => entriesApi.preparePickedAttachments());
+  };
+
   // Drag-and-drop is the second write path (desktop only). The dropped paths
-  // were captured in Rust from the native window event (ADR-0004) — this only
-  // tells the backend to drain that buffer onto the selected Entry. The drop
-  // hook has already scoped the drop to this panel; from here it's identical to
-  // the picker (same feeder, same outcome handling).
+  // were captured in Rust from the native window event (ADR-0004); the drop hook
+  // has already scoped the drop to this panel. From here it's identical to the
+  // picker — same classification, prompt, and commit.
   const handleDrop = () => {
     if (isDisabled) return;
-    void (async () => {
-      let outcome: Awaited<
-        ReturnType<typeof entriesApi.commitDroppedAttachments>
-      >;
-      try {
-        outcome = await entriesApi.commitDroppedAttachments(dbId, entryId);
-      } catch (error) {
-        console.error("Failed to add dropped attachments:", error);
-        toast.error(t("entries.detail.attachmentAddBatchFailed"));
-        return;
-      }
-      await applyAddOutcome(outcome);
-    })();
+    void runAddFlow(() => entriesApi.prepareDroppedAttachments());
   };
 
   // The native drag-drop event is window-global; the hook acts only on desktop

--- a/src/components/settings/SettingsEditor.tsx
+++ b/src/components/settings/SettingsEditor.tsx
@@ -26,6 +26,7 @@ import {
 import { isColorPresetId } from "@/lib/theme-presets";
 import { AdvancedSettingsSection } from "@/components/settings/sections/AdvancedSettingsSection";
 import { AppearanceSettingsSection } from "@/components/settings/sections/AppearanceSettingsSection";
+import { AttachmentsSettingsSection } from "@/components/settings/sections/AttachmentsSettingsSection";
 import { AuditLogSection } from "@/components/settings/sections/AuditLogSection";
 import { AuditLogSettingsSection } from "@/components/settings/sections/AuditLogSettingsSection";
 import { BackupsListSection } from "@/components/settings/sections/BackupsListSection";
@@ -285,6 +286,7 @@ export function SettingsEditor({
       <AdvancedSettingsSection draft={draft} updateDraft={updateDraft} />
       <BackupsSettingsSection draft={draft} updateDraft={updateDraft} />
       <BackupsListSection dbId={dbId} backupsEnabled={draft.backups.enabled} />
+      <AttachmentsSettingsSection draft={draft} updateDraft={updateDraft} />
       <AuditLogSettingsSection draft={draft} updateDraft={updateDraft} />
       <AuditLogSection dbId={dbId} isLocked={isLocked} />
       <DatabaseSettingsSection

--- a/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/src/components/settings/__tests__/SettingsView.test.tsx
@@ -127,6 +127,7 @@ function makePreferences(): AppPreferences {
       enabled: true,
       retentionDays: 90,
     },
+    attachments: { softWarnBytes: 5_000_000, hardCapBytes: 25_000_000 },
   };
 }
 

--- a/src/components/settings/sections/AttachmentsSettingsSection.tsx
+++ b/src/components/settings/sections/AttachmentsSettingsSection.tsx
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+import { useTranslation } from "react-i18next";
+import { Input } from "@/components/ui/input";
+import { SettingsSection } from "@/components/settings/SettingsSection";
+import { ATTACHMENT_BYTES_PER_MB, type AppPreferences } from "@/lib/types";
+
+interface AttachmentsSettingsSectionProps {
+  draft: AppPreferences;
+  updateDraft: (updater: (previous: AppPreferences) => AppPreferences) => void;
+}
+
+// Lower bound on the MB inputs: 1 MB. The backend enforces the real invariant
+// (hardCapBytes >= 1, softWarnBytes <= hardCapBytes); these attributes just keep
+// the spinbutton from stepping into obviously useless values.
+const MIN_MB = 1;
+
+/// Converts a byte-valued threshold to the decimal MB shown in the input.
+function bytesToMb(bytes: number): number {
+  return Math.round(bytes / ATTACHMENT_BYTES_PER_MB);
+}
+
+export function AttachmentsSettingsSection({
+  draft,
+  updateDraft,
+}: Readonly<AttachmentsSettingsSectionProps>) {
+  const { t } = useTranslation();
+
+  // Parses an MB input and writes it back to the draft as bytes via `apply`. A
+  // blank or non-numeric value is ignored so a half-typed field never writes
+  // NaN bytes into the draft.
+  const onMbChange = (
+    value: string,
+    apply: (previous: AppPreferences, bytes: number) => AppPreferences
+  ) => {
+    const mb = Number.parseInt(value, 10);
+    if (Number.isNaN(mb)) return;
+    updateDraft((previous) => apply(previous, mb * ATTACHMENT_BYTES_PER_MB));
+  };
+
+  return (
+    <SettingsSection
+      id="attachments-settings"
+      title={t("settings.attachments.title")}
+      description={t("settings.attachments.description")}
+    >
+      <div className="flex flex-col gap-2 text-sm">
+        <label htmlFor="attachment-soft-warn" className="flex flex-col gap-1">
+          <span>{t("settings.attachments.softWarn.label")}</span>
+          <span className="text-muted-foreground">
+            {t("settings.attachments.softWarn.description")}
+          </span>
+        </label>
+        <Input
+          id="attachment-soft-warn"
+          aria-label={t("settings.attachments.softWarn.label")}
+          type="number"
+          inputMode="numeric"
+          min={MIN_MB}
+          className="w-32"
+          value={bytesToMb(draft.attachments.softWarnBytes)}
+          onChange={(event) =>
+            onMbChange(event.target.value, (previous, bytes) => ({
+              ...previous,
+              attachments: {
+                ...previous.attachments,
+                softWarnBytes: bytes,
+              },
+            }))
+          }
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 text-sm">
+        <label htmlFor="attachment-hard-cap" className="flex flex-col gap-1">
+          <span>{t("settings.attachments.hardCap.label")}</span>
+          <span className="text-muted-foreground">
+            {t("settings.attachments.hardCap.description")}
+          </span>
+        </label>
+        <Input
+          id="attachment-hard-cap"
+          aria-label={t("settings.attachments.hardCap.label")}
+          type="number"
+          inputMode="numeric"
+          min={MIN_MB}
+          className="w-32"
+          value={bytesToMb(draft.attachments.hardCapBytes)}
+          onChange={(event) =>
+            onMbChange(event.target.value, (previous, bytes) => ({
+              ...previous,
+              attachments: {
+                ...previous.attachments,
+                hardCapBytes: bytes,
+              },
+            }))
+          }
+        />
+      </div>
+    </SettingsSection>
+  );
+}

--- a/src/components/settings/sections/__tests__/AttachmentsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AttachmentsSettingsSection.test.tsx
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { AttachmentsSettingsSection } from "@/components/settings/sections/AttachmentsSettingsSection";
+import type { AppPreferences } from "@/lib/types";
+
+function makeDraft(
+  attachments: { softWarnBytes: number; hardCapBytes: number } = {
+    softWarnBytes: 5_000_000,
+    hardCapBytes: 25_000_000,
+  }
+): AppPreferences {
+  return {
+    general: {
+      language: "en",
+      startupBehavior: "showUnlockScreen",
+      defaultDatabasePath: null,
+    },
+    security: {
+      autoLockTimeout: 300,
+      clipboardClearTimeout: 30,
+      clearClipboardOnLock: true,
+      showClipboardCountdown: false,
+      showPasswordByDefault: false,
+      minimizeToTray: true,
+      startMinimized: false,
+      preventScreenCapture: true,
+      autoDownloadFavicons: false,
+      allowThirdPartyFaviconFallbacks: false,
+    },
+    appearance: {
+      theme: "system",
+      colorPreset: "default",
+      fontSize: 14,
+      entryListColumns: {
+        username: true,
+        url: true,
+        modifiedAt: true,
+        tags: true,
+      },
+    },
+    browserIntegration: { enabled: false, allowedSites: [] },
+    advanced: { debugMode: false, dataLocation: "/tmp" },
+    backups: { enabled: true, maxVersions: 10, onOpen: false },
+    audit: { enabled: true, retentionDays: 90 },
+    attachments,
+  };
+}
+
+describe("AttachmentsSettingsSection", () => {
+  it("renders the thresholds as decimal MB from the byte-valued draft", () => {
+    // The draft stores bytes; the UI surfaces decimal MB. 5_000_000 B -> 5 MB,
+    // 25_000_000 B -> 25 MB (the documented defaults).
+    render(
+      <AttachmentsSettingsSection draft={makeDraft()} updateDraft={vi.fn()} />
+    );
+
+    expect(
+      screen.getByRole("spinbutton", {
+        name: "settings.attachments.softWarn.label",
+      })
+    ).toHaveValue(5);
+    expect(
+      screen.getByRole("spinbutton", {
+        name: "settings.attachments.hardCap.label",
+      })
+    ).toHaveValue(25);
+  });
+
+  it("converts the soft-warning MB input back to bytes in the draft", () => {
+    const updateDraft = vi.fn();
+    render(
+      <AttachmentsSettingsSection
+        draft={makeDraft()}
+        updateDraft={updateDraft}
+      />
+    );
+
+    const input = screen.getByRole("spinbutton", {
+      name: "settings.attachments.softWarn.label",
+    });
+    fireEvent.change(input, { target: { value: "10" } });
+
+    const calls = updateDraft.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (!lastCall) throw new Error("expected updateDraft to be called");
+    const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft());
+    expect(next.attachments.softWarnBytes).toBe(10_000_000);
+    // The hard cap is left untouched.
+    expect(next.attachments.hardCapBytes).toBe(25_000_000);
+  });
+
+  it("converts the hard-cap MB input back to bytes in the draft", () => {
+    const updateDraft = vi.fn();
+    render(
+      <AttachmentsSettingsSection
+        draft={makeDraft()}
+        updateDraft={updateDraft}
+      />
+    );
+
+    const input = screen.getByRole("spinbutton", {
+      name: "settings.attachments.hardCap.label",
+    });
+    fireEvent.change(input, { target: { value: "50" } });
+
+    const calls = updateDraft.mock.calls;
+    const lastCall = calls[calls.length - 1];
+    if (!lastCall) throw new Error("expected updateDraft to be called");
+    const updater = lastCall[0] as (prev: AppPreferences) => AppPreferences;
+    const next = updater(makeDraft());
+    expect(next.attachments.hardCapBytes).toBe(50_000_000);
+    expect(next.attachments.softWarnBytes).toBe(5_000_000);
+  });
+
+  it("ignores a non-numeric MB input rather than writing NaN bytes", () => {
+    const updateDraft = vi.fn();
+    render(
+      <AttachmentsSettingsSection
+        draft={makeDraft()}
+        updateDraft={updateDraft}
+      />
+    );
+
+    const input = screen.getByRole("spinbutton", {
+      name: "settings.attachments.softWarn.label",
+    });
+    fireEvent.change(input, { target: { value: "" } });
+
+    expect(updateDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/settings/sections/__tests__/AuditLogSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/AuditLogSettingsSection.test.tsx
@@ -45,6 +45,7 @@ function makeDraft(
     advanced: { debugMode: false, dataLocation: "/tmp" },
     backups: { enabled: true, maxVersions: 10, onOpen: false },
     audit,
+    attachments: { softWarnBytes: 5_000_000, hardCapBytes: 25_000_000 },
   };
 }
 

--- a/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
+++ b/src/components/settings/sections/__tests__/BackupsSettingsSection.test.tsx
@@ -64,6 +64,7 @@ function makeDraft(
     advanced: { debugMode: false, dataLocation: "/tmp" },
     backups: { enabled: true, maxVersions, directory, onOpen },
     audit: { enabled: true, retentionDays: 90 },
+    attachments: { softWarnBytes: 5_000_000, hardCapBytes: 25_000_000 },
   };
 }
 

--- a/src/hooks/__tests__/use-app-preferences.test.tsx
+++ b/src/hooks/__tests__/use-app-preferences.test.tsx
@@ -67,6 +67,7 @@ function makePreferences(): AppPreferences {
       enabled: true,
       retentionDays: 90,
     },
+    attachments: { softWarnBytes: 5_000_000, hardCapBytes: 25_000_000 },
   };
 }
 

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -178,6 +178,7 @@ describe("tauri wrappers validation", () => {
         enabled: true,
         retentionDays: 90,
       },
+      attachments: { softWarnBytes: 5_000_000, hardCapBytes: 25_000_000 },
     } as const;
 
     vi.mocked(invoke)
@@ -247,6 +248,7 @@ describe("tauri wrappers validation", () => {
           enabled: true,
           retentionDays: 90,
         },
+        attachments: { softWarnBytes: 5_000_000, hardCapBytes: 25_000_000 },
       })
     ).rejects.toThrow();
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -337,21 +337,29 @@ export const entries = {
   },
 
   /**
-   * Phase 2 (shared): drains the buffered paths and stores each as a native
-   * KDBX binary, enforcing the configured hard cap. Called after the frontend
-   * has resolved any soft-warning confirmation, for both the picker and the
-   * drop. The backend drains the buffer, so a commit with no preceding prepare
-   * returns an empty outcome. Returns the batch outcome — `added` stored names
-   * plus per-file `failed` entries (basename + backend reason). The caller
-   * persists via `database.save` and refreshes the entry when anything landed.
+   * Phase 2 (shared): drains the buffered paths for `batchId` and stores each as
+   * a native KDBX binary, enforcing the configured hard cap. Called after the
+   * frontend has resolved any soft-warning confirmation, for both the picker and
+   * the drop. `batchId` comes from the plan returned by the matching prepare; the
+   * backend stores the batch only if that id still matches the current buffer
+   * generation, so a later pick/drop that superseded the prepared batch (e.g. a
+   * stray drop while the confirmation prompt was open) makes this commit a no-op
+   * rather than attaching the wrong file. Returns the batch outcome — `added`
+   * stored names plus per-file `failed` entries. The caller persists via
+   * `database.save` and refreshes the entry when anything landed.
    */
   async commitPreparedAttachments(
     dbId: string,
-    id: string
+    id: string,
+    batchId: number
   ): Promise<AddAttachmentsOutcome> {
     DbIdSchema.parse({ dbId });
     IdSchema.parse({ id });
-    const result = await invoke("commit_prepared_attachments", { dbId, id });
+    const result = await invoke("commit_prepared_attachments", {
+      dbId,
+      id,
+      batchId,
+    });
     return AddAttachmentsOutcomeSchema.parse(result);
   },
 

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { z } from "zod/v4";
 import type {
   AddAttachmentsOutcome,
+  AttachmentAddPlan,
   AppPreferences,
   AuditEventsResponse,
   AuditFilter,
@@ -30,6 +31,7 @@ import type {
 } from "./types";
 import {
   AddAttachmentsOutcomeSchema,
+  AttachmentAddPlanSchema,
   AppPreferencesSchema,
   AuditEventsResponseSchema,
   AuditStatusSchema,
@@ -307,45 +309,49 @@ export const entries = {
   },
 
   /**
-   * Adds files to an Entry as native KDBX binaries. The multi-select file
-   * dialog is opened *in Rust* by this command — the frontend passes no path,
-   * so a renderer-supplied or fabricated path can never reach the read (the
-   * trust boundary in ADR-0004). A cancelled dialog is a no-op (empty outcome).
-   * The backend reads each picked file, enforces the hard size cap, and
-   * auto-renames on a filename collision; one bad pick never aborts the rest.
-   * Returns the batch outcome — `added` stored names plus per-file `failed`
-   * entries (basename + backend reason). The caller persists via
-   * `database.save` and refreshes the entry when anything landed.
+   * Phase 1 (picker): opens the multi-select file dialog *in Rust*, buffers the
+   * picked paths backend-side, and returns the size-classification plan against
+   * the configured thresholds — without reading bytes or mutating the Vault.
+   * The frontend passes no path, so a fabricated path can never reach the read
+   * (the trust boundary in ADR-0004). A cancelled dialog returns an empty plan
+   * (no-op). The caller inspects `requiresConfirmation`: if true it shows the
+   * soft-warning prompt before calling {@link commitPreparedAttachments};
+   * otherwise it commits directly.
    */
-  async addAttachments(
-    dbId: string,
-    id: string
-  ): Promise<AddAttachmentsOutcome> {
-    DbIdSchema.parse({ dbId });
-    IdSchema.parse({ id });
-    const result = await invoke("add_entry_attachments", { dbId, id });
-    return AddAttachmentsOutcomeSchema.parse(result);
+  async preparePickedAttachments(): Promise<AttachmentAddPlan> {
+    const result = await invoke("prepare_picked_attachments");
+    return AttachmentAddPlanSchema.parse(result);
   },
 
   /**
-   * Adds the files from the most recent native drag-drop event to an Entry.
-   * The paths were captured *in Rust* from the `tauri://drag-drop` window event
-   * and buffered backend-side — this call passes only the target ids, so a
-   * renderer-supplied path can never reach the read (the same trust boundary as
-   * the picker, ADR-0004). The caller is responsible for only invoking this
-   * when a drop lands on the selected Entry's panel; the backend drains the
-   * buffer, so a commit with no preceding drop returns an empty outcome. Files
-   * go through the same feeder as the picker (hard cap, auto-rename, per-file
-   * failures); the caller persists via `database.save` and refreshes when
-   * anything landed.
+   * Phase 1 (drag-drop): classifies the paths captured *in Rust* from the most
+   * recent native `tauri://drag-drop` event against the configured thresholds,
+   * without draining them (a peek) — so they survive for the commit that
+   * follows a confirmation. The renderer supplies no path (ADR-0004). A peek
+   * with no preceding drop returns an empty plan. The caller is responsible for
+   * only invoking this when a drop lands on the selected Entry's panel.
    */
-  async commitDroppedAttachments(
+  async prepareDroppedAttachments(): Promise<AttachmentAddPlan> {
+    const result = await invoke("prepare_dropped_attachments");
+    return AttachmentAddPlanSchema.parse(result);
+  },
+
+  /**
+   * Phase 2 (shared): drains the buffered paths and stores each as a native
+   * KDBX binary, enforcing the configured hard cap. Called after the frontend
+   * has resolved any soft-warning confirmation, for both the picker and the
+   * drop. The backend drains the buffer, so a commit with no preceding prepare
+   * returns an empty outcome. Returns the batch outcome — `added` stored names
+   * plus per-file `failed` entries (basename + backend reason). The caller
+   * persists via `database.save` and refreshes the entry when anything landed.
+   */
+  async commitPreparedAttachments(
     dbId: string,
     id: string
   ): Promise<AddAttachmentsOutcome> {
     DbIdSchema.parse({ dbId });
     IdSchema.parse({ id });
-    const result = await invoke("commit_dropped_attachments", { dbId, id });
+    const result = await invoke("commit_prepared_attachments", { dbId, id });
     return AddAttachmentsOutcomeSchema.parse(result);
   },
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,6 +37,34 @@ export const AddAttachmentsOutcomeSchema = z.object({
 });
 export type AddAttachmentsOutcome = z.infer<typeof AddAttachmentsOutcomeSchema>;
 
+/// Where a candidate attachment's size falls relative to the configured
+/// guardrails. Mirrors the Rust `AttachmentSizeStatus` (serde camelCase):
+/// `ok` adds silently, `overSoft` prompts for confirmation, `overHard` is
+/// rejected at commit.
+export const AttachmentSizeStatusSchema = z.enum([
+  "ok",
+  "overSoft",
+  "overHard",
+]);
+export type AttachmentSizeStatus = z.infer<typeof AttachmentSizeStatusSchema>;
+
+export const AttachmentPlanItemSchema = z.object({
+  sourceName: z.string(),
+  size: z.number().int().nonnegative(),
+  status: AttachmentSizeStatusSchema,
+});
+export type AttachmentPlanItem = z.infer<typeof AttachmentPlanItemSchema>;
+
+/// The size-classification plan returned by the prepare step.
+/// `requiresConfirmation` is the single signal the add flow reads before
+/// showing the soft-warning prompt: true iff at least one picked file is over
+/// the soft threshold (files over the hard cap do not gate the prompt).
+export const AttachmentAddPlanSchema = z.object({
+  items: z.array(AttachmentPlanItemSchema),
+  requiresConfirmation: z.boolean(),
+});
+export type AttachmentAddPlan = z.infer<typeof AttachmentAddPlanSchema>;
+
 export const EntrySchema = z.object({
   id: z.string(),
   groupId: z.string(),
@@ -318,6 +346,22 @@ export const AppPreferencesAuditSchema = z.object({
 export type AuditPreferences = z.infer<typeof AppPreferencesAuditSchema>;
 export const DEFAULT_AUDIT_RETENTION_DAYS = 90;
 
+/// Per-file attachment size guardrails, stored as raw bytes. `softWarnBytes`
+/// is the threshold above which the add flow prompts ("add anyway?");
+/// `hardCapBytes` is the rejection threshold. The backend validates the pair
+/// (`hardCapBytes >= 1`, `softWarnBytes <= hardCapBytes`); the UI surfaces them
+/// in decimal MB. There is no aggregate Vault cap.
+export const AttachmentSettingsSchema = z.object({
+  softWarnBytes: z.number().int().nonnegative(),
+  hardCapBytes: z.number().int().positive(),
+});
+export type AttachmentSettings = z.infer<typeof AttachmentSettingsSchema>;
+export const DEFAULT_ATTACHMENT_SOFT_WARN_BYTES = 5_000_000;
+export const DEFAULT_ATTACHMENT_HARD_CAP_BYTES = 25_000_000;
+/// Decimal-MB factor for converting the byte-valued thresholds to and from the
+/// MB inputs shown in the Settings UI.
+export const ATTACHMENT_BYTES_PER_MB = 1_000_000;
+
 export const AppPreferencesSchema = z.object({
   general: GeneralSettingsSchema,
   security: SecuritySettingsSchema,
@@ -326,6 +370,7 @@ export const AppPreferencesSchema = z.object({
   advanced: AdvancedSettingsSchema,
   backups: BackupSettingsSchema,
   audit: AppPreferencesAuditSchema,
+  attachments: AttachmentSettingsSchema,
 });
 export type AppPreferences = z.infer<typeof AppPreferencesSchema>;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,6 +62,9 @@ export type AttachmentPlanItem = z.infer<typeof AttachmentPlanItemSchema>;
 export const AttachmentAddPlanSchema = z.object({
   items: z.array(AttachmentPlanItemSchema),
   requiresConfirmation: z.boolean(),
+  // Generation of the buffered batch; echoed back to commit so a superseded
+  // batch (a later pick/drop) makes a stale commit a no-op.
+  batchId: z.number().int().nonnegative(),
 });
 export type AttachmentAddPlan = z.infer<typeof AttachmentAddPlanSchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -364,6 +364,7 @@
       "attachments": "Anhänge",
       "noAttachments": "Keine Anhänge",
       "addAttachment": "Anhang hinzufügen",
+      "addingAttachments": "Wird hinzugefügt…",
       "dropToAttach": "Dateien hier ablegen, um sie anzuhängen",
       "attachmentsAdded_one": "{{count}} Anhang hinzugefügt",
       "attachmentsAdded_other": "{{count}} Anhänge hinzugefügt",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -173,6 +173,18 @@
         "validation": "Die Aufbewahrung muss zwischen 1 und 365 Tagen liegen."
       }
     },
+    "attachments": {
+      "title": "Anhänge",
+      "description": "Größenbeschränkungen pro Datei für an Einträge angehängte Dateien.",
+      "softWarn": {
+        "label": "Warnen ab (MB)",
+        "description": "Beim Hinzufügen einer größeren Datei wird vor dem Speichern eine Bestätigung verlangt."
+      },
+      "hardCap": {
+        "label": "Ablehnen ab (MB)",
+        "description": "Größere Dateien werden abgelehnt. Muss mindestens dem Warnschwellenwert entsprechen."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",
@@ -350,6 +362,8 @@
       "attachmentsAdded_other": "{{count}} Anhänge hinzugefügt",
       "attachmentAddFailed": "{{filename}} konnte nicht hinzugefügt werden: {{reason}}",
       "attachmentAddBatchFailed": "Anhänge konnten nicht hinzugefügt werden",
+      "attachmentSoftWarnConfirmTitle": "Großen Anhang hinzufügen?",
+      "attachmentSoftWarnConfirm": "Große Anhänge vergrößern den Tresor und verlangsamen das Speichern – trotzdem hinzufügen?",
       "downloadAttachment": "Anhang herunterladen",
       "attachmentDownloaded": "{{filename}} heruntergeladen",
       "attachmentDownloadFailed": "{{filename}} konnte nicht heruntergeladen werden",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -173,6 +173,18 @@
         "validation": "Retention must be between 1 and 365 days."
       }
     },
+    "attachments": {
+      "title": "Attachments",
+      "description": "Per-file size guardrails for files attached to entries.",
+      "softWarn": {
+        "label": "Warn above (MB)",
+        "description": "Adding a file larger than this prompts for confirmation before it is stored."
+      },
+      "hardCap": {
+        "label": "Reject above (MB)",
+        "description": "Files larger than this are rejected. Must be at least the warning threshold."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",
@@ -373,6 +385,8 @@
       "attachmentsAdded_other": "Added {{count}} attachments",
       "attachmentAddFailed": "Failed to add {{filename}}: {{reason}}",
       "attachmentAddBatchFailed": "Failed to add attachments",
+      "attachmentSoftWarnConfirmTitle": "Add large attachment?",
+      "attachmentSoftWarnConfirm": "Large attachments increase vault size and slow saving — add anyway?",
       "downloadAttachment": "Download attachment",
       "attachmentDownloaded": "Downloaded {{filename}}",
       "attachmentDownloadFailed": "Failed to download {{filename}}",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -387,6 +387,7 @@
       "attachments": "Attachments",
       "noAttachments": "No attachments",
       "addAttachment": "Add attachment",
+      "addingAttachments": "Adding…",
       "dropToAttach": "Drop files here to attach",
       "attachmentsAdded_one": "Added {{count}} attachment",
       "attachmentsAdded_other": "Added {{count}} attachments",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -364,6 +364,7 @@
       "attachments": "Adjuntos",
       "noAttachments": "Sin adjuntos",
       "addAttachment": "Añadir adjunto",
+      "addingAttachments": "Añadiendo…",
       "dropToAttach": "Suelta archivos aquí para adjuntarlos",
       "attachmentsAdded_one": "{{count}} adjunto añadido",
       "attachmentsAdded_other": "{{count}} adjuntos añadidos",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -173,6 +173,18 @@
         "validation": "La retención debe estar entre 1 y 365 días."
       }
     },
+    "attachments": {
+      "title": "Adjuntos",
+      "description": "Límites de tamaño por archivo para los archivos adjuntos a las entradas.",
+      "softWarn": {
+        "label": "Advertir a partir de (MB)",
+        "description": "Añadir un archivo mayor que esto pide confirmación antes de guardarlo."
+      },
+      "hardCap": {
+        "label": "Rechazar a partir de (MB)",
+        "description": "Los archivos mayores que esto se rechazan. Debe ser al menos el umbral de advertencia."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",
@@ -350,6 +362,8 @@
       "attachmentsAdded_other": "{{count}} adjuntos añadidos",
       "attachmentAddFailed": "No se pudo añadir {{filename}}: {{reason}}",
       "attachmentAddBatchFailed": "No se pudieron añadir los adjuntos",
+      "attachmentSoftWarnConfirmTitle": "¿Añadir un adjunto grande?",
+      "attachmentSoftWarnConfirm": "Los adjuntos grandes aumentan el tamaño del baúl y ralentizan el guardado: ¿añadir de todos modos?",
       "downloadAttachment": "Descargar adjunto",
       "attachmentDownloaded": "{{filename}} descargado",
       "attachmentDownloadFailed": "No se pudo descargar {{filename}}",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -364,6 +364,7 @@
       "attachments": "Pièces jointes",
       "noAttachments": "Aucune pièce jointe",
       "addAttachment": "Ajouter une pièce jointe",
+      "addingAttachments": "Ajout…",
       "dropToAttach": "Déposez des fichiers ici pour les joindre",
       "attachmentsAdded_one": "{{count}} pièce jointe ajoutée",
       "attachmentsAdded_other": "{{count}} pièces jointes ajoutées",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -173,6 +173,18 @@
         "validation": "La conservation doit être comprise entre 1 et 365 jours."
       }
     },
+    "attachments": {
+      "title": "Pièces jointes",
+      "description": "Limites de taille par fichier pour les fichiers joints aux entrées.",
+      "softWarn": {
+        "label": "Avertir au-delà de (Mo)",
+        "description": "Ajouter un fichier plus grand que cela demande une confirmation avant l'enregistrement."
+      },
+      "hardCap": {
+        "label": "Refuser au-delà de (Mo)",
+        "description": "Les fichiers plus grands que cela sont refusés. Doit être au moins égal au seuil d'avertissement."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",
@@ -350,6 +362,8 @@
       "attachmentsAdded_other": "{{count}} pièces jointes ajoutées",
       "attachmentAddFailed": "Échec de l'ajout de {{filename}} : {{reason}}",
       "attachmentAddBatchFailed": "Échec de l'ajout des pièces jointes",
+      "attachmentSoftWarnConfirmTitle": "Ajouter une pièce jointe volumineuse ?",
+      "attachmentSoftWarnConfirm": "Les pièces jointes volumineuses augmentent la taille du coffre et ralentissent l'enregistrement — ajouter quand même ?",
       "downloadAttachment": "Télécharger la pièce jointe",
       "attachmentDownloaded": "{{filename}} téléchargé",
       "attachmentDownloadFailed": "Échec du téléchargement de {{filename}}",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -364,6 +364,7 @@
       "attachments": "Prilozi",
       "noAttachments": "Nema priloga",
       "addAttachment": "Dodaj prilog",
+      "addingAttachments": "Dodavanje…",
       "dropToAttach": "Prevucite datoteke ovde da biste ih priložili",
       "attachmentsAdded_one": "Dodat {{count}} prilog",
       "attachmentsAdded_other": "Dodato {{count}} priloga",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -173,6 +173,18 @@
         "validation": "Čuvanje mora biti između 1 i 365 dana."
       }
     },
+    "attachments": {
+      "title": "Prilozi",
+      "description": "Ograničenja veličine po datoteci za datoteke priložene unosima.",
+      "softWarn": {
+        "label": "Upozori iznad (MB)",
+        "description": "Dodavanje datoteke veće od ovoga traži potvrdu pre čuvanja."
+      },
+      "hardCap": {
+        "label": "Odbij iznad (MB)",
+        "description": "Datoteke veće od ovoga se odbijaju. Mora biti najmanje jednako pragu upozorenja."
+      }
+    },
     "backups": {
       "title": "Backups",
       "description": "Automatic snapshots of your vault file before every save.",
@@ -350,6 +362,8 @@
       "attachmentsAdded_other": "Dodato {{count}} priloga",
       "attachmentAddFailed": "Dodavanje priloga {{filename}} nije uspelo: {{reason}}",
       "attachmentAddBatchFailed": "Dodavanje priloga nije uspelo",
+      "attachmentSoftWarnConfirmTitle": "Dodati veliki prilog?",
+      "attachmentSoftWarnConfirm": "Veliki prilozi povećavaju veličinu sefa i usporavaju čuvanje — ipak dodati?",
       "downloadAttachment": "Preuzmi prilog",
       "attachmentDownloaded": "Preuzeto: {{filename}}",
       "attachmentDownloadFailed": "Preuzimanje nije uspelo: {{filename}}",


### PR DESCRIPTION
Closes #288.

## What

Makes the per-file attachment guardrails configurable App Preferences and adds the soft-warning confirmation step (parent: #280, builds on #283/#286/#287).

## Design

The add flow is now **two-phase** so a confirmation prompt can sit between picking and storing while file paths stay Rust-side (the ADR-0004 trust boundary — the renderer never names a file):

- **`prepare_picked_attachments` / `prepare_dropped_attachments`** — buffer the picked/dropped paths in Rust and return an `AttachmentAddPlan` classifying each file against the configured thresholds (`ok` / `overSoft` / `overHard`). No bytes read, no Vault mutation.
- **`commit_prepared_attachments`** — drains the buffer and stores each file, enforcing the configured hard cap. Shared by both the picker and drag-drop.

The frontend inspects `requiresConfirmation`: an over-soft file prompts *"Large attachments increase vault size and slow saving — add anyway?"*; **declining aborts the whole batch**. Files over the hard cap are rejected at commit as per-file failures and do not gate the prompt.

## Acceptance criteria

- [x] Soft-warn and hard-cap thresholds are editable App Preferences with documented defaults (**5 MB / 25 MB**, decimal)
- [x] Settings UI (new Attachments section) lets the user view/change both thresholds in MB
- [x] Adding a file above the soft threshold prompts; confirming proceeds, cancelling aborts
- [x] The hard cap used by the add flow comes from preferences
- [x] No aggregate Vault-size cap
- [x] Tests cover the soft-warn decision boundary and that the add flow honors the configured thresholds

## Tests

- **Backend (Seam 1):** `classify_attachment_size` boundary walk, `plan_attachment_adds` classification + `requiresConfirmation`, hard-cap rejection via injected cap, `AttachmentSettings` serde/defaults, validation (soft > hard and hard == 0 rejected), buffer `peek`/`take`. All 356 backend tests pass; clippy clean.
- **Frontend (Seam 3):** `EntryItemDetails` prepare→confirm→commit flow (prompt on over-soft, commit on confirm, abort on decline, no-op on empty) for both picker and drop; new `AttachmentsSettingsSection` MB↔bytes conversion.

## Notes

- **Behavior change:** per the decimal-MB decision, the hard-cap default is now **25 MB (25,000,000 bytes)**, slightly below the previous 25 MiB constant.
- i18n keys added across all five locales (en/de/es/fr/sr).
- `DropPathsBuffer` was renamed to `PendingAttachmentPaths` (now serves both picker and drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)