### PR TITLE
feat(core): extend entry history snapshots to all qualifying mutators (#323)

### DIFF
--- a/src-tauri/src/services/kdbx/custom_icons.rs
+++ b/src-tauri/src/services/kdbx/custom_icons.rs
@@ -223,6 +223,23 @@ mod tests {
     use super::*;
     use crate::services::kdbx::test_support::create_test_database;
 
+    /// Returns the UUID of the first Custom Icon in the pool — the shape tests
+    /// use to address an icon they just seeded via `assign_entry_custom_icon`.
+    fn first_custom_icon_uuid(service: &KdbxService, db_path: &str) -> String {
+        service
+            .with_vault(db_path, |vault| {
+                Ok(vault
+                    .db()
+                    .iter_all_custom_icons()
+                    .next()
+                    .expect("custom icon exists")
+                    .id()
+                    .uuid()
+                    .to_string())
+            })
+            .expect("vault scope")
+    }
+
     #[test]
     fn detect_icon_mime_recognizes_supported_signatures() {
         assert_eq!(
@@ -247,18 +264,7 @@ mod tests {
             .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
             .expect("seed icon");
 
-        let icon_uuid = service
-            .with_vault(&db_path, |vault| {
-                Ok(vault
-                    .db()
-                    .iter_all_custom_icons()
-                    .next()
-                    .expect("custom icon exists")
-                    .id()
-                    .uuid()
-                    .to_string())
-            })
-            .expect("vault scope");
+        let icon_uuid = first_custom_icon_uuid(&service, &db_path);
 
         let changed = service
             .set_entry_custom_icon(&db_path, &entry_b, &icon_uuid)
@@ -530,18 +536,7 @@ mod tests {
         service
             .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
             .expect("seed icon in pool");
-        let icon_uuid = service
-            .with_vault(&db_path, |vault| {
-                Ok(vault
-                    .db()
-                    .iter_all_custom_icons()
-                    .next()
-                    .expect("custom icon exists")
-                    .id()
-                    .uuid()
-                    .to_string())
-            })
-            .expect("vault scope");
+        let icon_uuid = first_custom_icon_uuid(&service, &db_path);
 
         assert!(service
             .set_entry_custom_icon(&db_path, &entry_b, &icon_uuid)
@@ -587,18 +582,7 @@ mod tests {
         service
             .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
             .expect("assign icon");
-        let icon_uuid = service
-            .with_vault(&db_path, |vault| {
-                Ok(vault
-                    .db()
-                    .iter_all_custom_icons()
-                    .next()
-                    .expect("custom icon exists")
-                    .id()
-                    .uuid()
-                    .to_string())
-            })
-            .expect("vault scope");
+        let icon_uuid = first_custom_icon_uuid(&service, &db_path);
         let before = service
             .list_entry_history(&db_path, &entry_a)
             .expect("history after assign")

--- a/src-tauri/src/services/kdbx/custom_icons.rs
+++ b/src-tauri/src/services/kdbx/custom_icons.rs
@@ -7,6 +7,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use uuid::Uuid;
 
+use super::entries::snapshot_entry_history;
 use super::KdbxService;
 
 impl KdbxService {
@@ -56,10 +57,13 @@ impl KdbxService {
                 if matches!(entry.icon(), Some(Icon::Custom(cid)) if *cid == icon_cid) {
                     false
                 } else {
+                    // Snapshot the prior icon state before swapping (#323).
+                    let before = (*entry.as_ref()).clone();
                     entry
                         .set_icon_custom(icon_cid)
                         .map_err(|e| AppError::Kdbx(e.to_string()))?;
                     entry.times.last_modification = Some(Times::now());
+                    snapshot_entry_history(&mut entry, before);
                     true
                 }
             };
@@ -76,8 +80,11 @@ impl KdbxService {
             let changed = {
                 let mut entry = vault.entry_mut(entry_id)?;
                 if matches!(entry.icon(), Some(Icon::Custom(_))) {
+                    // Snapshot the prior (icon-bearing) state before removing it (#323).
+                    let before = (*entry.as_ref()).clone();
                     entry.set_icon_none();
                     entry.times.last_modification = Some(Times::now());
+                    snapshot_entry_history(&mut entry, before);
                     true
                 } else {
                     false
@@ -128,6 +135,10 @@ impl KdbxService {
                     .entry_mut(eid)
                     .ok_or_else(|| AppError::EntryNotFound(entry_id.to_string()))?;
 
+                // Snapshot the prior icon state before any swap (#323). Cloned
+                // up front, kept only when the icon actually changes below.
+                let before = (*entry.as_ref()).clone();
+
                 match existing_cid {
                     Some(cid)
                         if matches!(entry.icon(), Some(Icon::Custom(current)) if *current == cid) =>
@@ -139,11 +150,13 @@ impl KdbxService {
                             .set_icon_custom(cid)
                             .map_err(|e| AppError::Kdbx(e.to_string()))?;
                         entry.times.last_modification = Some(Times::now());
+                        snapshot_entry_history(&mut entry, before);
                         true
                     }
                     None => {
                         entry.set_icon_custom_new(icon_bytes.to_vec());
                         entry.times.last_modification = Some(Times::now());
+                        snapshot_entry_history(&mut entry, before);
                         true
                     }
                 }
@@ -476,5 +489,132 @@ mod tests {
                 Ok(())
             })
             .expect("vault scope");
+    }
+
+    #[test]
+    fn assigning_a_custom_icon_snapshots_the_prior_state() {
+        // Setting an Entry's Custom Icon / Favicon is a content change, so the
+        // chokepoint captures the prior (iconless) state first (#323).
+        let (service, _dir, db_path, entry_a, _entry_b) = create_test_database();
+        let icon_bytes = [0x89, b'P', b'N', b'G', 7];
+
+        assert!(service
+            .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
+            .expect("assign icon"));
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after icon assign");
+        assert_eq!(history.len(), 1, "assigning an icon captures one version");
+
+        service
+            .with_vault(&db_path, |vault| {
+                let entry = vault.find_entry(&entry_a).expect("entry ref");
+                assert!(
+                    !matches!(
+                        entry.historical(0).expect("version").icon(),
+                        Some(Icon::Custom(_))
+                    ),
+                    "the snapshot predates the icon, so it carries no custom icon"
+                );
+                Ok(())
+            })
+            .expect("vault scope");
+    }
+
+    #[test]
+    fn setting_an_existing_custom_icon_snapshots_the_prior_state() {
+        // Pointing an Entry at an already-stored Custom Icon also snapshots.
+        let (service, _dir, db_path, entry_a, entry_b) = create_test_database();
+        let icon_bytes = [0x89, b'P', b'N', b'G', 8];
+        service
+            .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
+            .expect("seed icon in pool");
+        let icon_uuid = service
+            .with_vault(&db_path, |vault| {
+                Ok(vault
+                    .db()
+                    .iter_all_custom_icons()
+                    .next()
+                    .expect("custom icon exists")
+                    .id()
+                    .uuid()
+                    .to_string())
+            })
+            .expect("vault scope");
+
+        assert!(service
+            .set_entry_custom_icon(&db_path, &entry_b, &icon_uuid)
+            .expect("set icon on b"));
+
+        let history = service
+            .list_entry_history(&db_path, &entry_b)
+            .expect("list history after set");
+        assert_eq!(history.len(), 1, "setting an icon captures one version");
+    }
+
+    #[test]
+    fn clearing_a_custom_icon_snapshots_the_prior_state() {
+        // Removing a Custom Icon is a content change too: the prior state (with
+        // the icon) must be recoverable.
+        let (service, _dir, db_path, entry_a, _entry_b) = create_test_database();
+        let icon_bytes = [0x89, b'P', b'N', b'G', 9];
+        service
+            .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
+            .expect("assign icon");
+        let before = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("history after assign")
+            .len();
+
+        assert!(service
+            .clear_entry_custom_icon(&db_path, &entry_a)
+            .expect("clear icon"));
+
+        let after = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("history after clear")
+            .len();
+        assert_eq!(after, before + 1, "clearing the icon adds one version");
+    }
+
+    #[test]
+    fn a_no_op_icon_set_snapshots_nothing() {
+        // Re-pointing an Entry at the icon it already has changes nothing, so it
+        // must not accrue a history version.
+        let (service, _dir, db_path, entry_a, _entry_b) = create_test_database();
+        let icon_bytes = [0x89, b'P', b'N', b'G', 10];
+        service
+            .assign_entry_custom_icon(&db_path, &entry_a, &icon_bytes, "image/png", true)
+            .expect("assign icon");
+        let icon_uuid = service
+            .with_vault(&db_path, |vault| {
+                Ok(vault
+                    .db()
+                    .iter_all_custom_icons()
+                    .next()
+                    .expect("custom icon exists")
+                    .id()
+                    .uuid()
+                    .to_string())
+            })
+            .expect("vault scope");
+        let before = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("history after assign")
+            .len();
+
+        assert!(
+            !service
+                .set_entry_custom_icon(&db_path, &entry_a, &icon_uuid)
+                .expect("re-set same icon"),
+            "re-setting the same icon reports no change"
+        );
+
+        let after = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("history after no-op set")
+            .len();
+        assert_eq!(after, before, "a no-op icon set accrues no version");
     }
 }

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -111,6 +111,23 @@ pub(crate) fn snapshot_entry_history(entry: &mut KeepassEntry, mut pre_image: Ke
     entry.history.get_or_insert_default().add_entry(pre_image);
 }
 
+/// Runs `mutate` against a clone-guarded `entry`, pushing a pre-mutation
+/// history snapshot through the chokepoint only when the closure reports a
+/// real change. The shared shape behind the bulk tag mutators (rename/delete),
+/// where one snapshot must land per touched Entry and nothing on the rest.
+fn snapshot_on_change(
+    entry: &mut KeepassEntry,
+    mutate: impl FnOnce(&mut KeepassEntry) -> bool,
+) -> bool {
+    let before = entry.clone();
+    if mutate(entry) {
+        snapshot_entry_history(entry, before);
+        true
+    } else {
+        false
+    }
+}
+
 /// Whether an edit changed any *stored content* of the Entry, ignoring the
 /// volatile `last_modification` bump and the history list itself. Gates the
 /// history snapshot so content-preserving updates don't accrue junk versions:
@@ -627,16 +644,9 @@ impl KdbxService {
             }
 
             // One snapshot per touched Entry, captured before its tags are
-            // rewritten (#323). The pre-image is cloned eagerly and only kept
-            // when the rename actually changed this Entry.
+            // rewritten (#323), kept only when the rename actually changed it.
             let count = vault.modify_all_entries(&|entry| {
-                let before = entry.clone();
-                if rename_tag_in_entry(entry, old_name, new_name) {
-                    snapshot_entry_history(entry, before);
-                    true
-                } else {
-                    false
-                }
+                snapshot_on_change(entry, |e| rename_tag_in_entry(e, old_name, new_name))
             });
 
             if count > 0 {
@@ -652,13 +662,7 @@ impl KdbxService {
     pub fn delete_tag(&self, db_id: &str, tag_name: &str) -> Result<u32, AppError> {
         self.with_vault_mut(db_id, |vault| {
             let count = vault.modify_all_entries(&|entry| {
-                let before = entry.clone();
-                if delete_tag_in_entry(entry, tag_name) {
-                    snapshot_entry_history(entry, before);
-                    true
-                } else {
-                    false
-                }
+                snapshot_on_change(entry, |e| delete_tag_in_entry(e, tag_name))
             });
 
             if count > 0 {

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -13,7 +13,7 @@ use super::conversions::{
     apply_custom_fields, apply_expiry, convert_entry, is_standard_entry_field, parse_expiry_time,
     replace_custom_fields, validate_expiry_enabled,
 };
-use super::recycle::is_in_recycle_bin;
+use super::recycle::{is_group_in_recycle_bin, is_in_recycle_bin};
 use super::KdbxService;
 
 /// Classifies a candidate attachment's size against the configured guardrails.
@@ -88,11 +88,23 @@ pub(crate) fn plan_attachment_adds(
 /// stripped (KDBX never nests history, and keeping it would grow each version
 /// exponentially), inserted newest-first by [`keepass::db::History::add_entry`].
 ///
-/// S1 wires this only into `update_entry`; later slices route the remaining
-/// content/location mutators (tags, move, attachments, icon) through the same
-/// helper so coverage stays uniform. Retention pruning is intentionally not
-/// enforced here yet (S6) — history may grow unbounded for now.
-fn snapshot_entry_history(entry: &mut keepass::db::EntryMut<'_>, mut pre_image: KeepassEntry) {
+/// S1 wired this only into `update_entry`; S2 routes the remaining
+/// content/location mutators (bulk tags, move between real Groups, attachment
+/// add, custom-icon/Favicon) through the same helper so coverage stays uniform.
+/// Retention pruning is intentionally not enforced here yet (S6) — history may
+/// grow unbounded for now.
+///
+/// Takes `&mut KeepassEntry` rather than an `EntryMut` so both the `EntryMut`
+/// call sites (via deref coercion) and the raw-`Entry` closures handed to
+/// [`Vault::modify_all_entries`] can funnel through the one chokepoint.
+///
+/// NOTE (#323): attachment **deletion** is deliberately *not* yet routed here.
+/// A pre-image clone shares the live Entry's binary-pool `AttachmentId` but is
+/// not registered as a pool back-reference, and the crate's delete path GCs a
+/// blob keyed only by `entry_id` — so snapshotting a delete would leave the
+/// history version pointing at a reclaimed (and later possibly reused) blob.
+/// Snapshot-on-delete plus blob retention land together in a follow-up.
+pub(crate) fn snapshot_entry_history(entry: &mut KeepassEntry, mut pre_image: KeepassEntry) {
     // `History::add_entry` also strips nested history, but clearing it here
     // makes the intent explicit and keeps the pushed snapshot minimal.
     pre_image.history = None;
@@ -263,6 +275,12 @@ impl KdbxService {
     /// bumped and the Vault is marked modified (the caller persists). Deleting
     /// an unknown filename is an [`AppError::AttachmentNotFound`] that leaves
     /// the Vault untouched.
+    ///
+    /// NOTE (#323): this path deliberately does **not** route through the
+    /// snapshot chokepoint yet. The pool GC above reclaims (and later reuses)
+    /// the blob keyed only by `entry_id`, so a snapshot taken here would point
+    /// the history version at a freed/reused blob. Snapshot-on-delete plus the
+    /// required binary-pool blob retention land together in a follow-up.
     pub fn delete_entry_attachment(
         &self,
         db_id: &str,
@@ -370,9 +388,14 @@ impl KdbxService {
         self.with_vault_mut(db_id, |vault| {
             let stored_name = {
                 let mut entry = vault.entry_mut(entry_id)?;
+                // Snapshot the pre-add state before the new binary lands (#323).
+                // The pre-image predates the add, so it never references the new
+                // blob — the deferred delete-path retention concern doesn't apply.
+                let before: KeepassEntry = (*entry.as_ref()).clone();
                 let stored_name = unique_attachment_name(&entry.as_ref(), &filename);
                 entry.add_attachment(stored_name.clone(), Value::unprotected(bytes));
                 entry.times.last_modification = Some(Times::now());
+                snapshot_entry_history(&mut entry, before);
                 stored_name
             };
             vault.mark_modified();
@@ -603,8 +626,18 @@ impl KdbxService {
                 return Ok(0);
             }
 
-            let count =
-                vault.modify_all_entries(&|entry| rename_tag_in_entry(entry, old_name, new_name));
+            // One snapshot per touched Entry, captured before its tags are
+            // rewritten (#323). The pre-image is cloned eagerly and only kept
+            // when the rename actually changed this Entry.
+            let count = vault.modify_all_entries(&|entry| {
+                let before = entry.clone();
+                if rename_tag_in_entry(entry, old_name, new_name) {
+                    snapshot_entry_history(entry, before);
+                    true
+                } else {
+                    false
+                }
+            });
 
             if count > 0 {
                 vault.mark_modified();
@@ -618,7 +651,15 @@ impl KdbxService {
     /// Returns the number of entries that were modified.
     pub fn delete_tag(&self, db_id: &str, tag_name: &str) -> Result<u32, AppError> {
         self.with_vault_mut(db_id, |vault| {
-            let count = vault.modify_all_entries(&|entry| delete_tag_in_entry(entry, tag_name));
+            let count = vault.modify_all_entries(&|entry| {
+                let before = entry.clone();
+                if delete_tag_in_entry(entry, tag_name) {
+                    snapshot_entry_history(entry, before);
+                    true
+                } else {
+                    false
+                }
+            });
 
             if count > 0 {
                 vault.mark_modified();
@@ -639,17 +680,39 @@ impl KdbxService {
             let eid = vault.find_entry_id(id)?;
             let target_gid = vault.find_group_id(target_group_id)?;
 
+            // Snapshot a real relocation, but exclude Recycle-Bin transitions
+            // (trashing or restoring) and a no-op same-Group move — those carry
+            // no content change worth a history version (#323). Resolved while
+            // the borrow is immutable, before the move mutates the tree.
+            let should_snapshot = {
+                let entry = vault
+                    .db()
+                    .entry(eid)
+                    .ok_or_else(|| AppError::EntryNotFound(id.to_string()))?;
+                let current_parent = entry.parent().id();
+                let recycle_uuid = vault.db().meta.recyclebin_uuid;
+                let touches_recycle = recycle_uuid.is_some_and(|rid| {
+                    is_in_recycle_bin(vault.db(), &entry, rid)
+                        || is_group_in_recycle_bin(vault.db(), Some(target_gid), rid)
+                });
+                current_parent != target_gid && !touches_recycle
+            };
+
             let now = Times::now();
             {
                 let mut entry = vault
                     .db_mut()
                     .entry_mut(eid)
                     .ok_or_else(|| AppError::EntryNotFound(id.to_string()))?;
+                let before: KeepassEntry = (*entry.as_ref()).clone();
                 entry.times.last_modification = Some(now);
                 entry.times.location_changed = Some(now);
                 entry
                     .move_to(target_gid)
                     .map_err(|e| AppError::Kdbx(e.to_string()))?;
+                if should_snapshot {
+                    snapshot_entry_history(&mut entry, before);
+                }
             }
 
             let entry_ref = vault
@@ -2148,6 +2211,293 @@ mod tests {
         assert_eq!(
             history[0].username, "alice",
             "the reopened version preserves the prior username"
+        );
+    }
+
+    /// Sets an Entry's tags directly through the vault, bypassing
+    /// `update_entry` so the seeding itself records no history version.
+    fn seed_tags(service: &KdbxService, db_path: &str, entry_id: &str, tags: &[&str]) {
+        service
+            .with_vault_mut(db_path, |vault| {
+                let mut entry = vault.entry_mut(entry_id)?;
+                entry.tags = tags.iter().map(|t| (*t).to_string()).collect();
+                Ok(())
+            })
+            .expect("seed tags");
+    }
+
+    /// Reads a historical version's tags by reaching through the live Entry's
+    /// native KDBX history — the listing DTO carries no tags, so structural
+    /// assertions inspect the version directly.
+    fn historical_tags(
+        service: &KdbxService,
+        db_path: &str,
+        entry_id: &str,
+        index: usize,
+    ) -> Vec<String> {
+        service
+            .with_vault(db_path, |vault| {
+                let entry = vault.find_entry(entry_id)?;
+                Ok(entry
+                    .historical(index)
+                    .expect("history version exists")
+                    .tags
+                    .clone())
+            })
+            .expect("read historical tags")
+    }
+
+    #[test]
+    fn reading_an_entry_snapshots_nothing() {
+        // Access-only paths — fetching the Entry, its password, an attachment,
+        // or listing its history — are not edits and must never accrue a
+        // history version (#323).
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        seed_attachment(&service, &db_path, &entry_a, "codes.txt", b"data");
+
+        service.get_entry(&db_path, &entry_a).expect("get entry");
+        service
+            .get_entry_password(&db_path, &entry_a)
+            .expect("get password");
+        service
+            .get_entry_attachment(&db_path, &entry_a, "codes.txt")
+            .expect("get attachment");
+        service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after reads");
+        assert!(
+            history.is_empty(),
+            "reading or accessing an Entry must not create a history version"
+        );
+    }
+
+    #[test]
+    fn adding_an_attachment_snapshots_the_prior_state() {
+        // Adding an Attachment changes the Entry's stored content, so the
+        // chokepoint captures the prior state first. The history version
+        // predates the add, so it carries none of the new attachment.
+        let (service, dir, db_path, entry_a, _b) = create_test_database();
+
+        let source = dir.path().join("codes.txt");
+        std::fs::write(&source, b"recovery-codes").expect("seed source file");
+
+        service
+            .add_entry_attachment(&db_path, &entry_a, &source, TEST_HARD_CAP)
+            .expect("add attachment");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after add");
+        assert_eq!(
+            history.len(),
+            1,
+            "adding an attachment captures one version"
+        );
+
+        let prior_attachments = service
+            .with_vault(&db_path, |vault| {
+                let entry = vault.find_entry(&entry_a)?;
+                Ok(entry
+                    .historical(0)
+                    .expect("history version exists")
+                    .attachments()
+                    .count())
+            })
+            .expect("inspect historical attachments");
+        assert_eq!(
+            prior_attachments, 0,
+            "the snapshot predates the add, so it holds no attachment"
+        );
+    }
+
+    #[test]
+    fn bulk_rename_tag_snapshots_each_affected_entry() {
+        // A vault-wide tag rename must capture a per-Entry snapshot before
+        // rewriting the tag, matching KeePassXC — and only on Entries that
+        // actually carried the tag.
+        let (service, _dir, db_path, entry_a, entry_b) = create_test_database();
+        seed_tags(&service, &db_path, &entry_a, &["work", "urgent"]);
+        // entry_b never carries the tag, so it must stay untouched.
+
+        let count = service
+            .rename_tag(&db_path, "work", "office")
+            .expect("rename tag across vault");
+        assert_eq!(count, 1, "only the one tagged Entry is modified");
+
+        let history_a = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history for affected entry");
+        assert_eq!(history_a.len(), 1, "the affected Entry gets one snapshot");
+        assert_eq!(
+            historical_tags(&service, &db_path, &entry_a, 0),
+            vec!["work".to_string(), "urgent".to_string()],
+            "the snapshot preserves the tags as they were before the rename"
+        );
+
+        let live = service.get_entry(&db_path, &entry_a).expect("get entry");
+        assert!(
+            live.tags.contains(&"office".to_string()),
+            "the live Entry reflects the renamed tag"
+        );
+
+        let history_b = service
+            .list_entry_history(&db_path, &entry_b)
+            .expect("list history for untouched entry");
+        assert!(
+            history_b.is_empty(),
+            "an Entry without the tag accrues no snapshot"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_tag_snapshots_each_affected_entry() {
+        // Deleting a tag vault-wide likewise snapshots each Entry that loses it.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        seed_tags(&service, &db_path, &entry_a, &["work", "urgent"]);
+
+        let count = service
+            .delete_tag(&db_path, "urgent")
+            .expect("delete tag across vault");
+        assert_eq!(count, 1, "the one tagged Entry is modified");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after tag delete");
+        assert_eq!(history.len(), 1, "the affected Entry gets one snapshot");
+        assert_eq!(
+            historical_tags(&service, &db_path, &entry_a, 0),
+            vec!["work".to_string(), "urgent".to_string()],
+            "the snapshot preserves the deleted tag"
+        );
+    }
+
+    #[test]
+    fn a_no_op_tag_rename_snapshots_nothing() {
+        // Renaming a tag no Entry carries (or renaming a tag to itself) changes
+        // no stored content, so it must not accrue history versions.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        seed_tags(&service, &db_path, &entry_a, &["work"]);
+
+        let missing = service
+            .rename_tag(&db_path, "nonexistent", "office")
+            .expect("rename a tag nobody has");
+        assert_eq!(missing, 0, "no Entry carries the tag");
+
+        let identity = service
+            .rename_tag(&db_path, "work", "work")
+            .expect("rename a tag to itself");
+        assert_eq!(identity, 0, "renaming a tag to itself is a no-op");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after no-op renames");
+        assert!(
+            history.is_empty(),
+            "no-op tag renames must not create history versions"
+        );
+    }
+
+    #[test]
+    fn moving_between_real_groups_snapshots_prior_state() {
+        // Moving an Entry between two real Groups changes its stored location,
+        // so the chokepoint captures the prior state before the move lands.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        let target = service
+            .create_group(&db_path, None, "Target", None)
+            .expect("create target group");
+
+        service
+            .move_entry(&db_path, &entry_a, &target.id)
+            .expect("move entry to a real group");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after move");
+        assert_eq!(
+            history.len(),
+            1,
+            "a move between real Groups captures exactly one version"
+        );
+    }
+
+    #[test]
+    fn sending_to_recycle_bin_does_not_snapshot() {
+        // Deletion is a Recycle-Bin transition, not a content edit: it is
+        // already reversible, so it must not accrue history noise.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+
+        service
+            .delete_entry(&db_path, &entry_a)
+            .expect("send entry to recycle bin");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after delete");
+        assert!(
+            history.is_empty(),
+            "sending to the Recycle Bin must not create a history version"
+        );
+    }
+
+    #[test]
+    fn restoring_from_recycle_bin_does_not_snapshot() {
+        // Restoring a trashed Entry (a move *out* of the Recycle Bin) is the
+        // mirror of deletion and is likewise excluded from history.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        let root = service.get_info(&db_path).expect("info").root_group_id;
+
+        service
+            .delete_entry(&db_path, &entry_a)
+            .expect("send entry to recycle bin");
+        service
+            .move_entry(&db_path, &entry_a, &root)
+            .expect("restore entry to a real group");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after restore");
+        assert!(
+            history.is_empty(),
+            "restoring from the Recycle Bin must not create a history version"
+        );
+    }
+
+    #[test]
+    fn moving_into_recycle_bin_via_move_does_not_snapshot() {
+        // A move whose *target* is the Recycle Bin is a trash transition, not a
+        // relocation, and shares the deletion exclusion.
+        let (service, _dir, db_path, entry_a, entry_b) = create_test_database();
+
+        // Materialise the Recycle Bin by trashing a throwaway entry, then read
+        // its group id back from vault meta.
+        service
+            .delete_entry(&db_path, &entry_b)
+            .expect("trash throwaway to create recycle bin");
+        let recycle_gid = service
+            .with_vault(&db_path, |vault| {
+                Ok(vault
+                    .db()
+                    .meta
+                    .recyclebin_uuid
+                    .map(|u| u.to_string())
+                    .expect("recycle bin exists"))
+            })
+            .expect("read recycle uuid");
+
+        service
+            .move_entry(&db_path, &entry_a, &recycle_gid)
+            .expect("move entry into the recycle bin");
+
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after move into recycle bin");
+        assert!(
+            history.is_empty(),
+            "moving into the Recycle Bin must not create a history version"
         );
     }
 }

--- a/src-tauri/src/services/kdbx/recycle.rs
+++ b/src-tauri/src/services/kdbx/recycle.rs
@@ -6,7 +6,7 @@
 //! domain state — so callers in `password_health` can use it without
 //! pulling in KDBX-internal dependencies.
 
-use keepass::db::EntryRef;
+use keepass::db::{EntryRef, GroupId};
 use keepass::Database;
 
 /// Walks `entry`'s ancestor chain looking for `recycle_uuid`. Returns
@@ -18,7 +18,19 @@ pub(crate) fn is_in_recycle_bin(
     entry: &EntryRef<'_>,
     recycle_uuid: uuid::Uuid,
 ) -> bool {
-    let mut current_id = Some(entry.parent().id());
+    is_group_in_recycle_bin(db, Some(entry.parent().id()), recycle_uuid)
+}
+
+/// Walks the chain of `start`'s self-and-ancestors looking for `recycle_uuid`.
+/// Returns `true` when the group *is* the Recycle Bin or sits anywhere beneath
+/// it. Used to recognise a move whose destination is the trash, which — like
+/// `delete_entry` — must be excluded from history snapshots (#323).
+pub(crate) fn is_group_in_recycle_bin(
+    db: &Database,
+    start: Option<GroupId>,
+    recycle_uuid: uuid::Uuid,
+) -> bool {
+    let mut current_id = start;
     while let Some(gid) = current_id {
         if gid.uuid() == recycle_uuid {
             return true;


### PR DESCRIPTION
## Summary

Closes #323 (Entry History S2). Widens the snapshot **chokepoint** introduced in #322 (ADR-0008) so it captures a pre-mutation history version before *every* qualifying change to an Entry's stored content or location — matching KeePassXC — while keeping all such paths funnelling through the single helper.

### Triggers now routed through the chokepoint
- **Bulk `rename_tag` / `delete_tag`** — one snapshot per affected Entry, preserving prior tags; untouched Entries and no-op renames snapshot nothing.
- **`move_entry`** — snapshots a real→real relocation; excludes Recycle-Bin transitions (trash send via `delete_entry`, restore-out, move-into-bin) and no-op same-Group moves (new `is_group_in_recycle_bin` helper).
- **`add_entry_attachment`** — snapshots the pre-add state.
- **`set` / `clear` / `assign` custom icon** (and Favicon, transitively via the favicon fetch path) — snapshots on a real icon change. Verified the crate never GCs custom-icon blobs, so these are safe.

### Exclusions (tested)
Access-only reads (`get_entry`, `get_entry_password`, `get_entry_attachment`, `list_entry_history`) and all Recycle-Bin transitions remain snapshot-free.

### Refactor
`snapshot_entry_history` now takes `&mut Entry` so both `EntryMut` call sites (via deref coercion) and the raw-`Entry` closures handed to `modify_all_entries` route through the one chokepoint. Made `pub(crate)` for reuse from `custom_icons.rs`.

## Deferred → #332

`delete_entry_attachment` is **deliberately not** routed through the chokepoint. The `keepass` 0.13.x attachment GC is keyed by `entry_id` only (ignoring history index) and deletes the blob from the binary pool when the live reference is dropped — so a snapshot taken here would point the history version at a reclaimed, later-reused blob (latent corruption, not just loss). Retention isn't achievable through the crate's public API (`Entry.attachments` and `Database.attachments` are `pub(crate)`; the crate already handles this correctly for custom icons but not attachments). Per maintainer decision, snapshot-on-delete **plus** the required blob retention land together in #332, which carries the full technical findings.

## Acceptance criteria

- [x] Tag changes via the per-Entry editor (already, #322) and via bulk rename/delete push a snapshot per affected Entry
- [x] Moving between real Groups snapshots; Recycle-Bin send/restore does not
- [x] Adding an Attachment pushes a snapshot
- [x] Changing custom icon / Favicon pushes a snapshot
- [x] Reading/accessing an Entry pushes no snapshot
- [x] All qualifying mutators route through the single chokepoint
- [x] Service-level round-trip tests cover each trigger and each exclusion
- [ ] **Deleting** an Attachment snapshot + binary-pool blob retention → deferred to #332

## Testing

`cargo test --lib` (377 pass), `cargo clippy --lib --tests` (clean), `cargo fmt --check` (clean). New service-level round-trip tests in `entries.rs` and `custom_icons.rs` cover each trigger and exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
