### PR TITLE
feat(core): snapshot on attachment delete + binary-pool blob retention (#332)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2455,7 +2455,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -2874,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "keepass"
-version = "0.13.8"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c21ad5c74f28ca9d2efd52b041a5a7be659e0681d0d3dc57e625ee050a6bd853"
+checksum = "9eaf00f9ef8d75959f78f128959f923304c273544eaa62dcb34f585520a34a5b"
 dependencies = [
  "aes 0.9.0",
  "base64 0.22.1",
@@ -5353,7 +5353,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]
@@ -5710,7 +5710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6590,7 +6590,7 @@ dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-implement",
  "windows-interface",
 ]
@@ -6614,7 +6614,7 @@ checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6689,7 +6689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6701,7 +6701,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -6713,21 +6713,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -6736,7 +6723,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6781,7 +6768,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -6795,30 +6782,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7273,7 +7242,7 @@ dependencies = [
  "webkit2gtk-sys",
  "webview2-com",
  "windows 0.61.3",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2875,8 +2875,7 @@ dependencies = [
 [[package]]
 name = "keepass"
 version = "0.13.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaf00f9ef8d75959f78f128959f923304c273544eaa62dcb34f585520a34a5b"
+source = "git+https://github.com/SchnitzelAndSpaetzle/keepass-rs?rev=1ebb51275b678ce4c7f545b33dd8e743bf6b8ee8#1ebb51275b678ce4c7f545b33dd8e743bf6b8ee8"
 dependencies = [
  "aes 0.9.0",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,3 +79,12 @@ must_use_candidate = "allow"
 missing_errors_doc = "allow"
 missing_panics_doc = "allow"
 cargo_common_metadata = "allow"
+
+# Temporary fork of keepass 0.13.10 that retains attachment binaries referenced
+# by historical entry versions instead of garbage-collecting them on the last
+# *live* reference (which corrupts Entry History on attachment delete; see #332).
+# The only diff vs upstream v0.13.10 is in remove_attachment_by_name/_by_id,
+# mirroring set_icon_none. To be dropped once the fix is released upstream
+# (PR pending against sseemayer/keepass-rs).
+[patch.crates-io]
+keepass = { git = "https://github.com/SchnitzelAndSpaetzle/keepass-rs", rev = "1ebb51275b678ce4c7f545b33dd8e743bf6b8ee8" }

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -98,12 +98,13 @@ pub(crate) fn plan_attachment_adds(
 /// call sites (via deref coercion) and the raw-`Entry` closures handed to
 /// [`Vault::modify_all_entries`] can funnel through the one chokepoint.
 ///
-/// NOTE (#323): attachment **deletion** is deliberately *not* yet routed here.
-/// A pre-image clone shares the live Entry's binary-pool `AttachmentId` but is
-/// not registered as a pool back-reference, and the crate's delete path GCs a
-/// blob keyed only by `entry_id` — so snapshotting a delete would leave the
-/// history version pointing at a reclaimed (and later possibly reused) blob.
-/// Snapshot-on-delete plus blob retention land together in a follow-up.
+/// Attachment retention (#332): a pushed pre-image clones the live Entry's
+/// `attachments` map, sharing the same binary-pool `AttachmentId`s. The patched
+/// `keepass` fork never garbage-collects a binary on attachment removal (it
+/// drops only the exact live back-reference, mirroring `set_icon_none`), so a
+/// blob referenced by *any* snapshot survives a later `delete_entry_attachment`
+/// and a save/reopen round-trip, and its id is never reused. Pruning genuinely
+/// orphaned binaries is a deferred follow-up.
 pub(crate) fn snapshot_entry_history(entry: &mut KeepassEntry, mut pre_image: KeepassEntry) {
     // `History::add_entry` also strips nested history, but clearing it here
     // makes the intent explicit and keeps the pushed snapshot minimal.
@@ -285,19 +286,17 @@ impl KdbxService {
         })
     }
 
-    /// Removes a single Attachment from an Entry, keyed by its filename. The
-    /// `keepass` crate drops the Entry's reference and — when it was the last
-    /// reference — the now-orphaned blob from the Vault-level binary pool, so
-    /// no separate pool cleanup is needed. The Entry's modification time is
-    /// bumped and the Vault is marked modified (the caller persists). Deleting
-    /// an unknown filename is an [`AppError::AttachmentNotFound`] that leaves
-    /// the Vault untouched.
-    ///
-    /// NOTE (#323): this path deliberately does **not** route through the
-    /// snapshot chokepoint yet. The pool GC above reclaims (and later reuses)
-    /// the blob keyed only by `entry_id`, so a snapshot taken here would point
-    /// the history version at a freed/reused blob. Snapshot-on-delete plus the
-    /// required binary-pool blob retention land together in a follow-up.
+    /// Removes a single Attachment from an Entry, keyed by its filename, after
+    /// snapshotting the pre-delete state into Entry History so the removed file
+    /// stays recoverable (#332). The patched `keepass` fork drops only the live
+    /// reference and retains the binary in the Vault pool for as long as any
+    /// history Version references it (mirroring the custom-icon path), so the
+    /// snapshot — and any earlier snapshot referencing the same blob — survives
+    /// a save/reopen round-trip without the freed id being reused. The Entry's
+    /// modification time is bumped and the Vault is marked modified (the caller
+    /// persists). Deleting an unknown filename is an
+    /// [`AppError::AttachmentNotFound`] that leaves the Vault untouched and
+    /// snapshots nothing.
     pub fn delete_entry_attachment(
         &self,
         db_id: &str,
@@ -310,8 +309,12 @@ impl KdbxService {
                 if entry.attachment_by_name_mut(filename).is_none() {
                     return Err(AppError::AttachmentNotFound(filename.to_string()));
                 }
+                // Snapshot the pre-delete state (still referencing the blob)
+                // before dropping the live reference, mirroring the add path.
+                let before: KeepassEntry = (*entry.as_ref()).clone();
                 entry.remove_attachment_by_name(filename);
                 entry.times.last_modification = Some(Times::now());
+                snapshot_entry_history(&mut entry, before);
             }
             vault.mark_modified();
             Ok(())
@@ -407,7 +410,7 @@ impl KdbxService {
                 let mut entry = vault.entry_mut(entry_id)?;
                 // Snapshot the pre-add state before the new binary lands (#323).
                 // The pre-image predates the add, so it never references the new
-                // blob — the deferred delete-path retention concern doesn't apply.
+                // blob.
                 let before: KeepassEntry = (*entry.as_ref()).clone();
                 let stored_name = unique_attachment_name(&entry.as_ref(), &filename);
                 entry.add_attachment(stored_name.clone(), Value::unprotected(bytes));
@@ -1557,11 +1560,11 @@ mod tests {
     }
 
     #[test]
-    fn delete_entry_attachment_removes_reference_and_orphaned_blob() {
-        // Deleting the only Attachment referencing a pooled blob must drop both
-        // the Entry's reference and the now-orphaned blob from the Vault-level
-        // pool, and mark the Vault modified. Prior art for the binary-in-vault
-        // round-trip shape: services/kdbx/custom_icons.rs.
+    fn delete_entry_attachment_snapshots_and_retains_blob_for_history() {
+        // Deleting an Attachment captures a pre-delete history version and
+        // retains the binary in the Vault pool for as long as that version
+        // references it (#332) — it is NOT GC'd on the last *live* reference,
+        // mirroring how custom icons are kept. The Vault is marked modified.
         let (service, _dir, db_path, entry_a, _b) = create_test_database();
         let generation_before =
             seed_attachment(&service, &db_path, &entry_a, "codes.txt", b"secret");
@@ -1570,19 +1573,39 @@ mod tests {
             .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
             .expect("delete attachment");
 
+        // The live Entry no longer references the attachment...
         let entry = service.get_entry(&db_path, &entry_a).expect("get entry");
         assert!(
             entry.attachments.is_empty(),
-            "the Entry's attachment reference must be gone after delete"
+            "the live Entry's attachment reference must be gone after delete"
         );
 
+        // ...exactly one pre-delete version was captured...
+        let history = service
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history");
+        assert_eq!(
+            history.len(),
+            1,
+            "deleting an attachment captures one history version"
+        );
+
+        let expected: &[u8] = b"secret";
         service
             .with_vault(&db_path, |vault| {
+                // ...the blob is retained, referenced only by that version...
                 assert_eq!(
                     vault.db().num_attachments(),
-                    0,
-                    "the orphaned blob must be cleaned from the Vault pool"
+                    1,
+                    "the blob must be retained while a history version references it"
                 );
+                // ...and that version still resolves the original bytes.
+                let entry = vault.find_entry(&entry_a)?;
+                let hist = entry.historical(0).expect("history version exists");
+                let att = hist
+                    .attachment_by_name("codes.txt")
+                    .expect("history retains the attachment binary");
+                assert_eq!(att.data.get().as_slice(), expected);
                 assert!(
                     vault.generation() > generation_before,
                     "a successful delete must mark the Vault modified"
@@ -2249,6 +2272,176 @@ mod tests {
                     .clone())
             })
             .expect("read historical tags")
+    }
+
+    /// Reads a historical version's attachment bytes by reaching through the
+    /// live Entry's native KDBX history. Returns `None` when that version does
+    /// not carry the named attachment. The listing DTO carries no attachment
+    /// bytes, so retention assertions inspect the version directly.
+    fn historical_attachment_bytes(
+        service: &KdbxService,
+        db_path: &str,
+        entry_id: &str,
+        index: usize,
+        filename: &str,
+    ) -> Option<Vec<u8>> {
+        service
+            .with_vault(db_path, |vault| {
+                let entry = vault.find_entry(entry_id)?;
+                Ok(entry
+                    .historical(index)
+                    .and_then(|h| h.attachment_by_name(filename).map(|a| a.data.get().clone())))
+            })
+            .expect("read historical attachment")
+    }
+
+    #[test]
+    fn attachment_blob_is_retrievable_from_history_after_delete_and_reopen() {
+        // The interop proof point (#332): after deleting an Attachment, the
+        // captured version's binary must survive being written to disk and read
+        // back with a *fresh* service — the blob is not GC'd at delete time and
+        // the on-disk pool round-trips it.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        seed_attachment(&service, &db_path, &entry_a, "codes.txt", b"secret");
+
+        service
+            .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
+            .expect("delete attachment");
+        service.save(&db_path).expect("save vault");
+        service.close(&db_path).expect("close vault");
+
+        let reopened = KdbxService::new();
+        reopened.open(&db_path, "testpass").expect("reopen vault");
+
+        // The live Entry still has no attachment after the round-trip...
+        let entry = reopened.get_entry(&db_path, &entry_a).expect("get entry");
+        assert!(
+            entry.attachments.is_empty(),
+            "the live Entry must not regain the deleted attachment on reopen"
+        );
+
+        // ...the version is still listed...
+        let history = reopened
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after reopen");
+        assert_eq!(
+            history.len(),
+            1,
+            "the pre-delete version must survive the on-disk round-trip"
+        );
+
+        // ...and its blob is still retrievable verbatim.
+        let bytes = historical_attachment_bytes(&reopened, &db_path, &entry_a, 0, "codes.txt");
+        assert_eq!(
+            bytes.as_deref(),
+            Some(b"secret".as_slice()),
+            "the deleted attachment's bytes must round-trip through history"
+        );
+    }
+
+    #[test]
+    fn a_blob_from_an_earlier_snapshot_survives_a_later_attachment_delete() {
+        // Broadened retention (#332): the binary-pool GC was keyed by entry id
+        // only, so deleting an attachment could reclaim a blob that an *earlier*
+        // snapshot (from any trigger) still referenced. Here a field-edit
+        // snapshot captures the attachment-bearing state; a subsequent delete
+        // must not strip that earlier version's blob, across save/reopen.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        seed_attachment(&service, &db_path, &entry_a, "codes.txt", b"secret");
+
+        // Field edit snapshots the attachment-bearing state at index 0.
+        service
+            .update_entry(
+                &db_path,
+                &entry_a,
+                UpdateEntryData {
+                    username: Some("bob".to_string()),
+                    ..empty_update()
+                },
+            )
+            .expect("rename username");
+
+        // Deleting the live attachment pushes a pre-delete snapshot at index 0,
+        // demoting the field-edit version (username "alice") to index 1.
+        service
+            .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
+            .expect("delete attachment");
+        service.save(&db_path).expect("save vault");
+        service.close(&db_path).expect("close vault");
+
+        let reopened = KdbxService::new();
+        reopened.open(&db_path, "testpass").expect("reopen vault");
+
+        let history = reopened
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after reopen");
+        assert_eq!(history.len(), 2, "field-edit and delete versions both kept");
+        assert_eq!(
+            history[1].username, "alice",
+            "index 1 is the earlier field-edit version"
+        );
+
+        // The earlier field-edit version's blob must still resolve.
+        let bytes = historical_attachment_bytes(&reopened, &db_path, &entry_a, 1, "codes.txt");
+        assert_eq!(
+            bytes.as_deref(),
+            Some(b"secret".as_slice()),
+            "a delete must not reclaim a blob an earlier snapshot references"
+        );
+    }
+
+    #[test]
+    fn deleting_then_adding_an_attachment_never_reuses_the_freed_id() {
+        // AC4 (#332): because a deleted blob is retained (never freed), the next
+        // add cannot reuse its id and silently re-resolve the history reference
+        // to the new bytes. Observable behaviourally: the history version's
+        // bytes stay the ORIGINAL, the new live attachment carries its own
+        // bytes, and both binaries coexist in the pool.
+        let (service, dir, db_path, entry_a, _b) = create_test_database();
+        seed_attachment(&service, &db_path, &entry_a, "a.txt", b"original");
+
+        // Delete snapshots the pre-delete state (still referencing a.txt) and
+        // retains the blob.
+        service
+            .delete_entry_attachment(&db_path, &entry_a, "a.txt")
+            .expect("delete a.txt");
+
+        // Add a *different* file. If the freed id were reused, the history
+        // version's "a.txt" would alias these new bytes.
+        let source = dir.path().join("b.txt");
+        std::fs::write(&source, b"different").expect("seed source file");
+        let stored = service
+            .add_entry_attachment(&db_path, &entry_a, &source, TEST_HARD_CAP)
+            .expect("add b.txt");
+
+        // History order after the add (newest-first): [0] pre-add (no
+        // attachment), [1] pre-delete (a.txt). The retained blob is at index 1.
+        let history = historical_attachment_bytes(&service, &db_path, &entry_a, 1, "a.txt");
+        assert_eq!(
+            history.as_deref(),
+            Some(b"original".as_slice()),
+            "the history version's attachment must keep its ORIGINAL bytes"
+        );
+
+        let live = service
+            .get_entry_attachment(&db_path, &entry_a, &stored)
+            .expect("fetch new attachment");
+        assert_eq!(
+            live.as_bytes(),
+            b"different".as_slice(),
+            "the newly added attachment carries its own bytes"
+        );
+
+        service
+            .with_vault(&db_path, |vault| {
+                assert_eq!(
+                    vault.db().num_attachments(),
+                    2,
+                    "both the retained and the newly added binary must coexist"
+                );
+                Ok(())
+            })
+            .expect("vault scope");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #332 (Entry History follow-up to #323; PRD #321, ADR-0008). Routes `delete_entry_attachment` through the snapshot **chokepoint** so deleting an attachment captures a pre-delete history version, and **retains the binary** in the Vault pool for as long as any history Version references it — matching KeePassXC, whose history entries each own their bytes.

Targets `321-prd-…` so it's tested alongside the rest of the history work before merging to `main`.

## Why a keepass fork

The `keepass` 0.13.x binary-pool GC reclaims a blob on its last **live** reference, keyed by `entry_id` only (ignoring the history index), and `AttachmentId::next_free` reuses the freed id on the next add — so a snapshot taken at delete time would point a history version at a reclaimed, later-reused blob (**latent corruption**, not just loss). The pool internals (`Entry.attachments`, `Database.attachments`) are `pub(crate)`, so the behaviour can't be changed from mithril.

**Decisive finding:** the in-memory back-ref set is never read across save→reopen — `to_xml` dumps the whole pool and each entry/history-entry re-resolves its own `Ref="id"` on load. So the entire bug reduces to one GC branch firing. The crate already does the right thing for **custom icons** (`set_icon_none` drops only the exact `(entry_id, history_index)` ref and never GCs); attachments were the inconsistent path.

Fix: a temporary fork of **keepass 0.13.10** (`SchnitzelAndSpaetzle/keepass-rs`, branch `mithril-attachment-retention-0.13.10`) pinned via `[patch.crates-io]`. The only behavioural diff (`remove_attachment_by_name`/`_by_id`) mirrors `set_icon_none`: drop the exact live back-ref, never GC. Never freeing the id structurally prevents reuse. An upstream PR to `sseemayer/keepass-rs` will follow; the patch is dropped once a released version carries the fix.

## Changes

- **`keepass` fork**: `remove_attachment_by_*` mirror `set_icon_none` (exact-match retain, no GC) + a programmatic round-trip regression test.
- **`delete_entry_attachment`**: clone pre-image → remove → `snapshot_entry_history`. Stale `NOTE(#323)` deferral comments replaced with retention notes.
- **`Cargo.toml`**: bump `keepass` 0.13.8 → 0.13.10 (separate commit), add `[patch.crates-io]` → fork rev; `Cargo.lock` committed.

## Acceptance criteria

- [x] Deleting an Attachment pushes a snapshot per affected Entry
- [x] The chokepoint retains blobs referenced by a snapshot's attachments
- [x] After delete, the prior version is listable AND its blob retrievable across save → reopen
- [x] No `AttachmentId` reuse can re-resolve an existing history version's reference
- [x] A blob referenced by **any** history Version (not only the delete snapshot) survives a subsequent delete across save → reopen
- [x] Service-level round-trip tests cover snapshot-on-delete and blob retention

## Testing

`cargo test --lib` → **380 pass**; `cargo clippy --all-targets --all-features` clean; `cargo fmt --check` clean. New service-level round-trip tests in `entries.rs`; regression test in the keepass fork.

## Deferred (follow-up issue)

Save-time orphan prune (KeePassXC `fillBinaryIdxMap`-style rebuild of the pool from live+history, dropping zero-ref entries). Never-GC means a truly-orphaned blob — attachment deleted *and* its history pruned away — lingers in the pool (bounded, slow growth). All ACs hold without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)