### PR TITLE
feat(core): restore an Entry to a past version (+ entry.history_restored audit) (#328)

### DIFF
--- a/src-tauri/src/commands/entries.rs
+++ b/src-tauri/src/commands/entries.rs
@@ -72,6 +72,25 @@ pub fn audit_attachment_exported_on_success<T>(
     result
 }
 
+/// Maps a `restore_entry_history` outcome through the audit subsystem: a
+/// successful restore records exactly one `entry.history_restored` event
+/// carrying the Entry's UUID; any error path (including a guard mismatch)
+/// records nothing.
+///
+/// Kept as a free function (mirroring the reveal/export wrappers above) so
+/// integration tests can drive it without a Tauri runtime.
+pub fn audit_entry_history_restored_on_success<T>(
+    audit: &AuditService,
+    vault_path: &str,
+    entry_id: &str,
+    result: Result<T, AppError>,
+) -> Result<T, AppError> {
+    if result.is_ok() {
+        audit.record_entry_history_restored(Path::new(vault_path), entry_id);
+    }
+    result
+}
+
 /// Lists entries, optionally filtered by group.
 /// The `db_id` is the path to the database file.
 #[tauri::command]
@@ -185,6 +204,32 @@ pub async fn get_history_protected_field(
         &db_id,
         &id,
         state.get_history_protected_field(&db_id, &id, index, &fingerprint, &key),
+    )
+}
+
+/// Restores an Entry to a past version, addressed by `index` in the
+/// newest-first history list and guarded by `fingerprint` (a stale guard
+/// errors rather than restoring the wrong version). The current state is
+/// snapshotted into history first so the restore is undoable, then the live
+/// Entry's content — all fields including the password, attachments, icon and
+/// expiry — is overwritten from the chosen version; UUID and parent Group are
+/// untouched. The restored secret is read in Rust and never crosses IPC. A
+/// successful restore appends one `entry.history_restored` event; a failure
+/// (including a guard mismatch) records nothing.
+#[tauri::command]
+pub async fn restore_entry_history(
+    db_id: String,
+    id: String,
+    index: usize,
+    fingerprint: String,
+    state: State<'_, Arc<KdbxService>>,
+    audit: State<'_, Arc<AuditService>>,
+) -> Result<Entry, AppError> {
+    audit_entry_history_restored_on_success(
+        audit.inner(),
+        &db_id,
+        &id,
+        state.restore_entry_history(&db_id, &id, index, &fingerprint),
     )
 }
 

--- a/src-tauri/src/dto/audit.rs
+++ b/src-tauri/src/dto/audit.rs
@@ -19,6 +19,7 @@ pub enum AuditEventKindDto {
     EntryPasswordCopied,
     EntryProtectedFieldRevealed,
     EntryAttachmentExported,
+    EntryHistoryRestored,
     PreferencesSecurityChanged,
     AuditCleared,
 }
@@ -204,6 +205,18 @@ impl From<AuditEvent> for AuditEventDto {
                 setting_name: None,
                 attachment_id: Some(attachment_id),
             },
+            AuditEvent::EntryHistoryRestored {
+                timestamp,
+                entry_id,
+            } => Self {
+                kind: AuditEventKindDto::EntryHistoryRestored,
+                timestamp,
+                attempt_count: None,
+                reason: None,
+                entry_id: Some(entry_id),
+                setting_name: None,
+                attachment_id: None,
+            },
             AuditEvent::AuditCleared { timestamp } => Self {
                 kind: AuditEventKindDto::AuditCleared,
                 timestamp,
@@ -356,6 +369,30 @@ mod tests {
             json.contains("\"attachmentId\":\"recovery-codes.txt\""),
             "attachmentId must be camelCase on the wire, got: {json}"
         );
+    }
+
+    #[test]
+    fn entry_history_restored_event_converts_to_dto_with_camel_case_kind_and_entry_id() {
+        let ts = Utc.with_ymd_and_hms(2026, 6, 18, 10, 0, 0).unwrap();
+        let dto: AuditEventDto = AuditEvent::EntryHistoryRestored {
+            timestamp: ts,
+            entry_id: "uuid-restore".to_string(),
+        }
+        .into();
+
+        assert!(matches!(dto.kind, AuditEventKindDto::EntryHistoryRestored));
+        assert_eq!(dto.timestamp, ts);
+        assert_eq!(dto.entry_id.as_deref(), Some("uuid-restore"));
+        assert!(dto.attempt_count.is_none());
+        assert!(dto.reason.is_none());
+        assert!(dto.attachment_id.is_none());
+
+        let json = serde_json::to_string(&dto).expect("ser");
+        assert!(
+            json.contains("\"entryHistoryRestored\""),
+            "kind must serialize as camelCase, got: {json}"
+        );
+        assert!(json.contains("\"entryId\":\"uuid-restore\""));
     }
 
     /// The clear-log surviving event reaches the UI as a camelCase

--- a/src-tauri/src/dto/error.rs
+++ b/src-tauri/src/dto/error.rs
@@ -45,6 +45,9 @@ pub enum AppError {
     #[error("History version no longer matches: index {0} has changed or was pruned")]
     HistoryVersionMismatch(usize),
 
+    #[error("History version unchanged: this version's content matches the current entry")]
+    HistoryVersionUnchanged,
+
     #[error("Group not found: {0}")]
     GroupNotFound(String),
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,9 +23,9 @@ use commands::{
     list_entries, list_entry_history, list_groups, list_open_databases, lock_database, move_entry,
     move_group, open_database, open_database_with_keyfile, open_database_with_keyfile_only,
     prepare_dropped_attachments, prepare_picked_attachments, remove_recent_database, rename_group,
-    rename_tag, report_activity, reset_app_preferences, restore_backup, save_database,
-    set_entry_custom_icon, set_window_content_protected, store_session_key, unlock_database,
-    update_app_preferences, update_entry, update_group,
+    rename_tag, report_activity, reset_app_preferences, restore_backup, restore_entry_history,
+    save_database, set_entry_custom_icon, set_window_content_protected, store_session_key,
+    unlock_database, update_app_preferences, update_entry, update_group,
 };
 use services::audit::format::Reason;
 use services::audit::key::FileBackedAuditKey;
@@ -98,6 +98,7 @@ pub fn build_app<R: Runtime>(builder: tauri::Builder<R>) -> tauri::Builder<R> {
             get_entry_protected_custom_field,
             get_history_entry_password,
             get_history_protected_field,
+            restore_entry_history,
             create_entry,
             update_entry,
             delete_entry,

--- a/src-tauri/src/services/audit/format.rs
+++ b/src-tauri/src/services/audit/format.rs
@@ -52,6 +52,11 @@ pub enum AuditEvent {
         entry_id: String,
         attachment_id: String,
     },
+    #[serde(rename = "entry.history_restored")]
+    EntryHistoryRestored {
+        timestamp: DateTime<Utc>,
+        entry_id: String,
+    },
     #[serde(rename = "preferences.security_changed")]
     PreferencesSecurityChanged {
         timestamp: DateTime<Utc>,
@@ -248,6 +253,22 @@ mod tests {
         assert!(json.contains("\"kind\":\"entry.attachment_exported\""));
         assert!(json.contains("\"entry_id\":\"uuid-4\""));
         assert!(json.contains("\"attachment_id\":\"recovery-codes.txt\""));
+    }
+
+    /// Restoring an Entry to a past version (#328) carries the Entry's UUID and
+    /// nothing more; the wire tag is pinned to the dotted form so already-written
+    /// logs stay readable across refactors of the Rust enum.
+    #[test]
+    fn entry_history_restored_round_trips_with_entry_id_and_dotted_kind() {
+        let event = AuditEvent::EntryHistoryRestored {
+            timestamp: Utc.with_ymd_and_hms(2026, 6, 18, 10, 0, 0).unwrap(),
+            entry_id: "uuid-5".to_string(),
+        };
+        let parsed = AuditEvent::from_bytes(&event.to_bytes()).expect("parse");
+        assert_eq!(parsed, event);
+        let json = String::from_utf8(event.to_bytes()).expect("utf8");
+        assert!(json.contains("\"kind\":\"entry.history_restored\""));
+        assert!(json.contains("\"entry_id\":\"uuid-5\""));
     }
 
     /// Manual clear of the audit log emits exactly one surviving event

--- a/src-tauri/src/services/audit/retention.rs
+++ b/src-tauri/src/services/audit/retention.rs
@@ -89,6 +89,7 @@ fn event_timestamp(event: &AuditEvent) -> DateTime<Utc> {
         | AuditEvent::EntryPasswordCopied { timestamp, .. }
         | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
         | AuditEvent::EntryAttachmentExported { timestamp, .. }
+        | AuditEvent::EntryHistoryRestored { timestamp, .. }
         | AuditEvent::PreferencesSecurityChanged { timestamp, .. }
         | AuditEvent::AuditCleared { timestamp } => *timestamp,
     }

--- a/src-tauri/src/services/audit/service.rs
+++ b/src-tauri/src/services/audit/service.rs
@@ -231,6 +231,7 @@ impl AuditService {
             | AuditEvent::EntryPasswordCopied { timestamp, .. }
             | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
             | AuditEvent::EntryAttachmentExported { timestamp, .. }
+            | AuditEvent::EntryHistoryRestored { timestamp, .. }
             | AuditEvent::PreferencesSecurityChanged { timestamp, .. }
             | AuditEvent::AuditCleared { timestamp } => *timestamp,
         };
@@ -424,6 +425,18 @@ impl AuditService {
             timestamp: Utc::now(),
             entry_id: entry_id.to_string(),
             attachment_id: attachment_id.to_string(),
+        };
+        self.record(vault_path, &event);
+    }
+
+    /// Appends one `entry.history_restored` event after an Entry is
+    /// successfully restored to a past version (#328), carrying the Entry's
+    /// UUID. Infallible by contract — restoring a version is a content-changing
+    /// action the audit log records, the same as a reveal or export.
+    pub fn record_entry_history_restored(&self, vault_path: &Path, entry_id: &str) {
+        let event = AuditEvent::EntryHistoryRestored {
+            timestamp: Utc::now(),
+            entry_id: entry_id.to_string(),
         };
         self.record(vault_path, &event);
     }
@@ -649,6 +662,7 @@ fn event_timestamp(event: &AuditEvent) -> DateTime<Utc> {
         | AuditEvent::EntryPasswordCopied { timestamp, .. }
         | AuditEvent::EntryProtectedFieldRevealed { timestamp, .. }
         | AuditEvent::EntryAttachmentExported { timestamp, .. }
+        | AuditEvent::EntryHistoryRestored { timestamp, .. }
         | AuditEvent::PreferencesSecurityChanged { timestamp, .. }
         | AuditEvent::AuditCleared { timestamp } => *timestamp,
     }

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -7,7 +7,7 @@ use crate::dto::entry::{
 use crate::dto::error::AppError;
 use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
 use keepass::db::{Entry as KeepassEntry, EntryRef, Icon, Times, Value};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{Read, Write};
 
 use super::conversions::{
@@ -229,6 +229,42 @@ fn changed_field_names(before: &EntryRef<'_>, after: &EntryRef<'_>) -> Vec<Strin
 /// One restored attachment: its filename and the original `Value` (carrying the
 /// protected/unprotected flag, so restore preserves it).
 type RestoredAttachment = (String, Value<Vec<u8>>);
+
+/// Whether restoring `source` (with its `restored_attachments`) onto `live`
+/// would actually change any restorable content. Restore copies content but
+/// never identity or location, so a version that differs from the live Entry
+/// only in where it lived (a move-only snapshot) restores to a no-op. Comparing
+/// only the restorable subset — and attachments by name→`Value`, not pool id —
+/// lets the caller reject that no-op instead of bumping mtime, snapshotting,
+/// auditing, and reporting a phantom success (#328).
+fn restore_changes_content(
+    live: &EntryRef<'_>,
+    source: &KeepassEntry,
+    restored_attachments: &[RestoredAttachment],
+) -> bool {
+    if live.fields != source.fields
+        || live.tags != source.tags
+        || live.custom_data != source.custom_data
+        || live.autotype != source.autotype
+        || live.foreground_color != source.foreground_color
+        || live.background_color != source.background_color
+        || live.override_url != source.override_url
+        || live.quality_check != source.quality_check
+        || live.icon() != source.icon()
+        || live.times.expires != source.times.expires
+        || live.times.expiry != source.times.expiry
+    {
+        return true;
+    }
+    // Attachments by content (name → bytes + protection flag), not by the
+    // pool ids the rebuild would churn.
+    let live_attachments: BTreeMap<String, Value<Vec<u8>>> = live
+        .attachments_named()
+        .map(|(name, att)| (name.to_string(), att.data.clone()))
+        .collect();
+    let restored: BTreeMap<String, Value<Vec<u8>>> = restored_attachments.iter().cloned().collect();
+    live_attachments != restored
+}
 
 fn history_fingerprint(snapshot: &EntryRef<'_>, key: &[u8; blake3::KEY_LEN]) -> String {
     // Length-prefix every segment so distinct field boundaries can't collide by
@@ -582,6 +618,15 @@ impl KdbxService {
                         .collect();
                     ((*snapshot).clone(), attachments)
                 };
+
+                // Reject a no-op restore: a version that differs from the live
+                // Entry only in where it lived (a move-only snapshot) would
+                // otherwise bump mtime, append a junk history version, audit,
+                // save, and report a phantom success even though nothing
+                // restorable changed. Checked before any mutation.
+                if !restore_changes_content(&entry.as_ref(), &source, &restored_attachments) {
+                    return Err(AppError::HistoryVersionUnchanged);
+                }
 
                 // Snapshot the pre-restore state so the restore is undoable: it
                 // becomes the newest history version. Attachment binaries that

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -212,7 +212,7 @@ fn changed_field_names(before: &EntryRef<'_>, after: &EntryRef<'_>) -> Vec<Strin
 /// A stable per-version content fingerprint: a hex **keyed BLAKE3 MAC** over the
 /// snapshot's `modified_at`, every field (key + protected flag + resolved value,
 /// so a password rotation registers even when it shares a second with its
-/// predecessor), tags, icon, expiry and attachment names. This is the addressing
+/// predecessor), tags, icon, expiry and attachment names + bytes. This is the addressing
 /// guard for per-version reveal/restore (ADR-0008): a version is addressed by
 /// `index` but only acted on when its fingerprint still matches, so a concurrent
 /// edit that shifts the list can't silently retarget. `modified_at` alone is
@@ -226,6 +226,10 @@ fn changed_field_names(before: &EntryRef<'_>, after: &EntryRef<'_>) -> Vec<Strin
 /// require the key, which never leaves the backend. Inputs are streamed directly
 /// into the hasher rather than collected into an owned buffer, so no extra
 /// plaintext copy of the secrets lingers in allocator memory after the call.
+/// One restored attachment: its filename and the original `Value` (carrying the
+/// protected/unprotected flag, so restore preserves it).
+type RestoredAttachment = (String, Value<Vec<u8>>);
+
 fn history_fingerprint(snapshot: &EntryRef<'_>, key: &[u8; blake3::KEY_LEN]) -> String {
     // Length-prefix every segment so distinct field boundaries can't collide by
     // concatenation (e.g. key "ab"+value "c" vs key "a"+value "bc").
@@ -281,10 +285,17 @@ fn history_fingerprint(snapshot: &EntryRef<'_>, key: &[u8; blake3::KEY_LEN]) -> 
             .as_bytes(),
     );
 
-    let mut attachments: Vec<&str> = snapshot.attachments_named().map(|(name, _)| name).collect();
-    attachments.sort_unstable();
-    for name in attachments {
+    // Attachment name *and* bytes, in name order. Restore copies the actual
+    // bytes, so the guard must cover them too: a same-second delete + re-add of
+    // a different file under the same name would otherwise share a fingerprint
+    // and let a stale index shift restore onto the wrong bytes. Bytes are
+    // streamed straight into the hasher (no owned copy lingers); `AttachmentRef`
+    // borrows the snapshot's Database, which outlives this call.
+    let mut attachments: Vec<_> = snapshot.attachments_named().collect();
+    attachments.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, attachment) in &attachments {
         feed(&mut hasher, name.as_bytes());
+        feed(&mut hasher, attachment.get());
     }
 
     hasher.finalize().to_hex().to_string()
@@ -550,7 +561,7 @@ impl KdbxService {
                 // (incl. the password), tags, icon, expiry, attachments, and the
                 // remaining metadata — can be reapplied without holding the
                 // immutable borrow across the mutation.
-                let (source, restored_attachments): (KeepassEntry, Vec<(String, Vec<u8>)>) = {
+                let (source, restored_attachments): (KeepassEntry, Vec<RestoredAttachment>) = {
                     let live = entry.as_ref();
                     let snapshot = live
                         .historical(index)
@@ -559,13 +570,15 @@ impl KdbxService {
                     {
                         return Err(AppError::HistoryVersionMismatch(index));
                     }
-                    // Attachment bytes must be read here, while the snapshot's
+                    // Attachments must be read here, while the snapshot's
                     // `EntryRef` still has Database access — the owned clone
                     // below can't resolve binaries on its own (the map is
-                    // crate-private and keyed into the pool).
+                    // crate-private and keyed into the pool). The whole `Value`
+                    // is cloned (not just the bytes) so a protected attachment
+                    // from an imported vault stays protected after restore.
                     let attachments = snapshot
                         .attachments_named()
-                        .map(|(name, att)| (name.to_string(), att.get().clone()))
+                        .map(|(name, att)| (name.to_string(), att.data.clone()))
                         .collect();
                     ((*snapshot).clone(), attachments)
                 };
@@ -601,9 +614,9 @@ impl KdbxService {
 
                 // Attachments: the map is crate-private and shares binary-pool
                 // ids, so rebuild it through the public add/remove API. Re-adding
-                // by value restores the same bytes under the same names; ids the
-                // live Entry no longer references survive via `before` and are
-                // pruned at save time.
+                // by value restores the same bytes (and protection flag) under
+                // the same names; ids the live Entry no longer references survive
+                // via `before` and are pruned at save time.
                 let live_names: Vec<String> = entry
                     .as_ref()
                     .attachments_named()
@@ -612,8 +625,8 @@ impl KdbxService {
                 for name in live_names {
                     entry.remove_attachment_by_name(&name);
                 }
-                for (name, bytes) in restored_attachments {
-                    entry.add_attachment(name, Value::unprotected(bytes));
+                for (name, value) in restored_attachments {
+                    entry.add_attachment(name, value);
                 }
 
                 // Expiry (flag + timestamp), then bump last_modification to now.

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -6,7 +6,7 @@ use crate::dto::entry::{
 };
 use crate::dto::error::AppError;
 use crate::utils::atomic_write::{atomic_write, AtomicWriteOptions};
-use keepass::db::{Entry as KeepassEntry, EntryRef, Times, Value};
+use keepass::db::{Entry as KeepassEntry, EntryRef, Icon, Times, Value};
 use std::collections::BTreeSet;
 use std::io::{Read, Write};
 
@@ -516,6 +516,123 @@ impl KdbxService {
                 }),
                 Value::Unprotected(_) => Err(AppError::CustomFieldNotProtected(key.to_string())),
             }
+        })
+    }
+
+    /// Restores an Entry to a past version, addressed by `index` in the
+    /// newest-first history list and guarded by `fingerprint` — the same
+    /// addressing mechanism as the per-version reveal (ADR-0008); a
+    /// stale/mismatched guard errors [`AppError::HistoryVersionMismatch`]
+    /// rather than restoring the wrong version. The current state is first
+    /// snapshotted into history (so the restore is itself undoable), then the
+    /// live Entry's content — all fields including the password — is overwritten
+    /// from the chosen version and `last_modification` bumped to now. The
+    /// Entry's UUID and parent Group are left untouched: a version carries
+    /// content, not location. The restored secret is read in-process and never
+    /// crosses IPC.
+    pub fn restore_entry_history(
+        &self,
+        db_id: &str,
+        id: &str,
+        index: usize,
+        fingerprint: &str,
+    ) -> Result<Entry, AppError> {
+        self.with_vault_mut(db_id, |vault| {
+            let eid = vault.find_entry_id(id)?;
+            let group_uuid = {
+                let mut entry = vault.entry_mut(id)?;
+
+                // Resolve + guard the target version, then clone its content out
+                // before any mutation. The fingerprint is re-checked against the
+                // live snapshot inside the same Vault lock, so a concurrent edit
+                // that shifted indices is caught here. A full owned clone of the
+                // snapshot Entry is taken so every content field — text fields
+                // (incl. the password), tags, icon, expiry, attachments, and the
+                // remaining metadata — can be reapplied without holding the
+                // immutable borrow across the mutation.
+                let (source, restored_attachments): (KeepassEntry, Vec<(String, Vec<u8>)>) = {
+                    let live = entry.as_ref();
+                    let snapshot = live
+                        .historical(index)
+                        .ok_or(AppError::HistoryVersionMismatch(index))?;
+                    if history_fingerprint(&snapshot, &self.history_fingerprint_key) != fingerprint
+                    {
+                        return Err(AppError::HistoryVersionMismatch(index));
+                    }
+                    // Attachment bytes must be read here, while the snapshot's
+                    // `EntryRef` still has Database access — the owned clone
+                    // below can't resolve binaries on its own (the map is
+                    // crate-private and keyed into the pool).
+                    let attachments = snapshot
+                        .attachments_named()
+                        .map(|(name, att)| (name.to_string(), att.get().clone()))
+                        .collect();
+                    ((*snapshot).clone(), attachments)
+                };
+
+                // Snapshot the pre-restore state so the restore is undoable: it
+                // becomes the newest history version. Attachment binaries that
+                // the live Entry still references are kept alive by this
+                // snapshot's reference even though the live map is overwritten
+                // below (the fork's retention rule).
+                let before: KeepassEntry = (*entry.as_ref()).clone();
+
+                // Overwrite content from the chosen version. Identity (UUID),
+                // location (parent Group), and the history list are deliberately
+                // left untouched — a version carries content, not where the
+                // Entry lives.
+                entry.fields.clone_from(&source.fields);
+                entry.tags.clone_from(&source.tags);
+                entry.custom_data.clone_from(&source.custom_data);
+                entry.autotype.clone_from(&source.autotype);
+                entry.foreground_color.clone_from(&source.foreground_color);
+                entry.background_color.clone_from(&source.background_color);
+                entry.override_url.clone_from(&source.override_url);
+                entry.quality_check = source.quality_check;
+
+                // Icon: the field is crate-private, so go through the setters.
+                match source.icon() {
+                    None => entry.set_icon_none(),
+                    Some(Icon::BuiltIn(n)) => entry.set_icon_builtin(*n),
+                    Some(Icon::Custom(cid)) => entry
+                        .set_icon_custom(*cid)
+                        .map_err(|e| AppError::Kdbx(e.to_string()))?,
+                }
+
+                // Attachments: the map is crate-private and shares binary-pool
+                // ids, so rebuild it through the public add/remove API. Re-adding
+                // by value restores the same bytes under the same names; ids the
+                // live Entry no longer references survive via `before` and are
+                // pruned at save time.
+                let live_names: Vec<String> = entry
+                    .as_ref()
+                    .attachments_named()
+                    .map(|(name, _)| name.to_string())
+                    .collect();
+                for name in live_names {
+                    entry.remove_attachment_by_name(&name);
+                }
+                for (name, bytes) in restored_attachments {
+                    entry.add_attachment(name, Value::unprotected(bytes));
+                }
+
+                // Expiry (flag + timestamp), then bump last_modification to now.
+                entry.times.expires = source.times.expires;
+                entry.times.expiry = source.times.expiry;
+                entry.times.last_modification = Some(Times::now());
+
+                snapshot_entry_history(&mut entry, before);
+
+                entry.as_ref().parent().id().uuid().to_string()
+            };
+
+            let entry_ref = vault
+                .db()
+                .entry(eid)
+                .ok_or_else(|| AppError::EntryNotFound(id.to_string()))?;
+            let result = convert_entry(&entry_ref, &group_uuid);
+            vault.mark_modified();
+            Ok(result)
         })
     }
 

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -321,16 +321,22 @@ fn history_fingerprint(snapshot: &EntryRef<'_>, key: &[u8; blake3::KEY_LEN]) -> 
             .as_bytes(),
     );
 
-    // Attachment name *and* bytes, in name order. Restore copies the actual
-    // bytes, so the guard must cover them too: a same-second delete + re-add of
-    // a different file under the same name would otherwise share a fingerprint
-    // and let a stale index shift restore onto the wrong bytes. Bytes are
-    // streamed straight into the hasher (no owned copy lingers); `AttachmentRef`
-    // borrows the snapshot's Database, which outlives this call.
+    // Attachment name, protection flag, *and* bytes, in name order. Restore
+    // copies the whole `Value` — bytes and protected/unprotected state — so the
+    // guard must cover all three: a same-second delete + re-add of a different
+    // file (or the same file with a flipped protection flag) under the same name
+    // would otherwise share a fingerprint and let a stale index shift restore
+    // onto the wrong content. Bytes are streamed straight into the hasher (no
+    // owned copy lingers); `AttachmentRef` borrows the snapshot's Database, which
+    // outlives this call.
     let mut attachments: Vec<_> = snapshot.attachments_named().collect();
     attachments.sort_by(|a, b| a.0.cmp(b.0));
     for (name, attachment) in &attachments {
         feed(&mut hasher, name.as_bytes());
+        feed(
+            &mut hasher,
+            &[u8::from(matches!(attachment.data, Value::Protected(_)))],
+        );
         feed(&mut hasher, attachment.get());
     }
 
@@ -1435,6 +1441,36 @@ mod tests {
                 Ok(())
             })
             .expect("with_vault");
+    }
+
+    #[test]
+    fn history_fingerprint_distinguishes_attachment_protection_state() {
+        // Restore preserves an attachment's protected/unprotected `Value`, so the
+        // guard must too: two same-second versions whose attachment differs only
+        // by that flag (same name, same bytes) must not share a fingerprint, or a
+        // stale index could shift restore onto the wrong protection state. The
+        // app's own add path only stores unprotected, so this is constructed
+        // directly via the keepass API (imported vaults can carry protected
+        // binaries).
+        let (service, _dir, db, entry_a, _entry_b) = create_test_database();
+        let key = [7u8; blake3::KEY_LEN];
+        service
+            .with_vault_mut(&db, |vault| {
+                let mut entry = vault.entry_mut(&entry_a)?;
+                entry.add_attachment("f.txt", Value::protected(vec![1u8, 2, 3]));
+                let protected_fp = history_fingerprint(&entry.as_ref(), &key);
+
+                entry.remove_attachment_by_name("f.txt");
+                entry.add_attachment("f.txt", Value::unprotected(vec![1u8, 2, 3]));
+                let unprotected_fp = history_fingerprint(&entry.as_ref(), &key);
+
+                assert_ne!(
+                    protected_fp, unprotected_fp,
+                    "fingerprint must reflect an attachment's protection state, not just its bytes"
+                );
+                Ok(())
+            })
+            .expect("with_vault_mut");
     }
 
     #[test]

--- a/src-tauri/tests/commands/entries_test.rs
+++ b/src-tauri/tests/commands/entries_test.rs
@@ -20,7 +20,8 @@ use std::time::Duration;
 use tempfile::TempDir;
 
 use mithril_vault_lib::commands::entries::{
-    audit_entry_password_revealed_on_success, audit_entry_protected_field_revealed_on_success,
+    audit_entry_history_restored_on_success, audit_entry_password_revealed_on_success,
+    audit_entry_protected_field_revealed_on_success,
 };
 use mithril_vault_lib::services::audit::format::AuditEvent;
 use mithril_vault_lib::services::audit::key::InMemoryAuditKey;
@@ -387,6 +388,40 @@ fn password_update(password: &str) -> UpdateEntryData {
     }
 }
 
+/// An `UpdateEntryData` that changes only the built-in icon.
+fn icon_update(icon_id: u32) -> UpdateEntryData {
+    UpdateEntryData {
+        title: None,
+        username: None,
+        password: None,
+        url: None,
+        notes: None,
+        icon_id: Some(icon_id),
+        tags: None,
+        custom_fields: None,
+        protected_custom_fields: None,
+        expires: None,
+        expiry_time: None,
+    }
+}
+
+/// An `UpdateEntryData` that enables expiry at the given RFC3339 timestamp.
+fn expiry_update(expiry_time: &str) -> UpdateEntryData {
+    UpdateEntryData {
+        title: None,
+        username: None,
+        password: None,
+        url: None,
+        notes: None,
+        icon_id: None,
+        tags: None,
+        custom_fields: None,
+        protected_custom_fields: None,
+        expires: Some(true),
+        expiry_time: Some(expiry_time.to_string()),
+    }
+}
+
 /// Creates one entry with the given password and protected custom field, then
 /// returns the service, its temp dir, the db path and the new entry id.
 fn create_entry_with_secret(
@@ -670,6 +705,321 @@ fn a_guard_failure_records_no_audit_event() {
     assert!(
         events.is_empty(),
         "no event must be recorded on a guard failure"
+    );
+}
+
+// ============================================================================
+// Entry History: restore from a version (#328)
+// ============================================================================
+
+#[test]
+fn restore_history_overwrites_live_content_from_the_chosen_version() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    // Rotate the password so "orig-pw" lands in history as the only prior version.
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = &history[0];
+
+    let restored = service
+        .restore_entry_history(&db, &entry_id, version.index, &version.fingerprint)
+        .expect("restore");
+
+    // The live Entry's content is now the chosen version's — the password it
+    // carried back then, read in Rust and applied without crossing IPC.
+    let pw = service
+        .get_entry_password(&db, &entry_id)
+        .expect("password");
+    assert_eq!(pw, "orig-pw", "restore must overwrite the live password");
+    // The returned DTO is the same Entry (identity unchanged).
+    assert_eq!(restored.id, entry_id);
+}
+
+#[test]
+fn restore_history_snapshots_the_pre_restore_state_as_the_newest_version() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+
+    // One prior version ("orig-pw") exists before the restore.
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    assert_eq!(history.len(), 1);
+    let target = history[0].clone();
+
+    service
+        .restore_entry_history(&db, &entry_id, target.index, &target.fingerprint)
+        .expect("restore");
+
+    // The pre-restore live state ("new-pw") is captured as the newest history
+    // version, so the restore is itself undoable.
+    let after = service.list_entry_history(&db, &entry_id).expect("history");
+    assert_eq!(
+        after.len(),
+        2,
+        "restore must append the pre-restore state to history"
+    );
+    let newest = &after[0];
+    let pre_restore_pw = service
+        .get_history_entry_password(&db, &entry_id, newest.index, &newest.fingerprint)
+        .expect("history password");
+    assert_eq!(
+        pre_restore_pw, "new-pw",
+        "the newest history version must be the pre-restore state"
+    );
+}
+
+#[test]
+fn restore_history_preserves_uuid_and_parent_group_and_bumps_mtime() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    // Edit so "orig-pw" lands in history while the entry is still in root.
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+
+    // Move the entry to a different Group *after* the target version was
+    // recorded, so the snapshot's stored parent (root) differs from the live
+    // parent. A restore must not drag the Entry back to where it used to live.
+    let groups = service.list_groups(&db).expect("groups");
+    let root = &groups[0];
+    let target_group = root.children.first().expect("a default child group");
+    let moved = service
+        .move_entry(&db, &entry_id, &target_group.id)
+        .expect("move entry");
+    assert_eq!(moved.group_id, target_group.id);
+
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    // The oldest version is the "orig-pw" snapshot recorded while in root.
+    let target = history.last().expect("oldest version").clone();
+    let pre_modified = service
+        .get_entry(&db, &entry_id)
+        .expect("entry")
+        .modified_at;
+
+    let restored = service
+        .restore_entry_history(&db, &entry_id, target.index, &target.fingerprint)
+        .expect("restore");
+
+    // Content is restored, but identity and location are untouched: a version
+    // carries content, not where the Entry lives.
+    assert_eq!(restored.id, entry_id, "UUID must be unchanged by a restore");
+    assert_eq!(
+        restored.group_id, target_group.id,
+        "parent Group must be unchanged by a restore"
+    );
+    assert!(
+        restored.modified_at >= pre_modified,
+        "last_modification must advance to now, got {} (was {pre_modified})",
+        restored.modified_at
+    );
+}
+
+#[test]
+fn restore_history_overwrites_the_icon() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "pw", None);
+    // Set a built-in icon, then change it so the first icon lands in history.
+    service
+        .update_entry(&db, &entry_id, icon_update(1))
+        .expect("set icon 1");
+    service
+        .update_entry(&db, &entry_id, icon_update(2))
+        .expect("set icon 2");
+
+    // The snapshot with icon 1 is the version immediately before the icon-2 edit.
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = history
+        .iter()
+        .find(|v| v.changed_fields.iter().any(|f| f == "icon"))
+        .expect("a version recording the icon change")
+        .clone();
+
+    let restored = service
+        .restore_entry_history(&db, &entry_id, version.index, &version.fingerprint)
+        .expect("restore");
+    assert_eq!(
+        restored.icon_id,
+        Some(1),
+        "restore must bring back the version's icon"
+    );
+}
+
+#[test]
+fn restore_history_overwrites_the_expiry() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "pw", None);
+    // Set an expiry, then clear it so the expiring version lands in history.
+    service
+        .update_entry(&db, &entry_id, expiry_update("2030-01-01T00:00:00Z"))
+        .expect("set expiry");
+    let live_with_expiry = service.get_entry(&db, &entry_id).expect("entry");
+    assert!(live_with_expiry.expires);
+
+    // Now disable expiry on the live entry; the expiring snapshot becomes the
+    // newest history version (index 0).
+    let mut clear = expiry_update("2030-01-01T00:00:00Z");
+    clear.expires = Some(false);
+    service
+        .update_entry(&db, &entry_id, clear)
+        .expect("clear expiry");
+
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = history[0].clone();
+
+    // Restoring the expiring version brings the expiry flag + timestamp back.
+    let restored = service
+        .restore_entry_history(&db, &entry_id, version.index, &version.fingerprint)
+        .expect("restore");
+    assert!(
+        restored.expires,
+        "restore must bring back the version's expiry"
+    );
+    assert_eq!(restored.expiry_time, live_with_expiry.expiry_time);
+}
+
+#[test]
+fn restore_history_overwrites_attachments() {
+    let (service, dir, db, entry_id) = create_entry_with_secret("svc", "pw", None);
+    // Attach a file (snapshots the pre-add, attachment-less state), then delete
+    // it (snapshots the pre-delete state — the version that carries the file).
+    let att_path = dir.path().join("secret.txt");
+    std::fs::write(&att_path, b"top secret bytes").expect("write attachment file");
+    service
+        .add_entry_attachment(&db, &entry_id, &att_path, 25 * 1024 * 1024)
+        .expect("add attachment");
+    service
+        .delete_entry_attachment(&db, &entry_id, "secret.txt")
+        .expect("delete attachment");
+
+    let live = service.get_entry(&db, &entry_id).expect("entry");
+    assert!(
+        live.attachments.is_empty(),
+        "attachment must be gone before the restore"
+    );
+
+    // The newest history version is the pre-delete state, which still carries
+    // the attachment.
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = history
+        .iter()
+        .find(|v| v.changed_fields.iter().any(|f| f == "attachments"))
+        .expect("a version recording the attachment")
+        .clone();
+
+    let restored = service
+        .restore_entry_history(&db, &entry_id, version.index, &version.fingerprint)
+        .expect("restore");
+    assert_eq!(
+        restored.attachments.len(),
+        1,
+        "restore must bring back the version's attachment"
+    );
+    assert_eq!(restored.attachments[0].filename, "secret.txt");
+
+    // The restored attachment carries the original bytes.
+    let bytes = service
+        .get_entry_attachment(&db, &entry_id, "secret.txt")
+        .expect("attachment bytes");
+    assert_eq!(bytes.to_vec(), b"top secret bytes".to_vec());
+}
+
+#[test]
+fn restore_history_rejects_a_stale_fingerprint() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = &history[0];
+
+    // A mismatched fingerprint must not restore the wrong version — it errors,
+    // and the live Entry is left untouched.
+    let result =
+        service.restore_entry_history(&db, &entry_id, version.index, "not-the-fingerprint");
+    assert!(
+        matches!(result, Err(AppError::HistoryVersionMismatch(idx)) if idx == version.index),
+        "a stale fingerprint must error, got {result:?}"
+    );
+    let pw = service
+        .get_entry_password(&db, &entry_id)
+        .expect("password");
+    assert_eq!(
+        pw, "new-pw",
+        "a rejected restore must not mutate the live Entry"
+    );
+}
+
+#[test]
+fn restore_history_rejects_an_out_of_range_index() {
+    let (service, _dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+
+    let result = service.restore_entry_history(&db, &entry_id, 99, "anything");
+    assert!(
+        matches!(result, Err(AppError::HistoryVersionMismatch(99))),
+        "an out-of-range index must error, got {result:?}"
+    );
+}
+
+#[test]
+fn a_restore_records_one_history_restored_event_carrying_the_entry_id() {
+    let (service, dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = &history[0];
+
+    let audit = AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+    let restored = audit_entry_history_restored_on_success(
+        &audit,
+        &db,
+        &entry_id,
+        service.restore_entry_history(&db, &entry_id, version.index, &version.fingerprint),
+    )
+    .expect("restore");
+    assert_eq!(restored.id, entry_id);
+
+    let events = audit
+        .read(Path::new(&db), &AuditFilter::default())
+        .expect("read audit");
+    assert_eq!(
+        events.len(),
+        1,
+        "exactly one event for a successful restore"
+    );
+    match &events[0] {
+        AuditEvent::EntryHistoryRestored { entry_id: id, .. } => assert_eq!(id, &entry_id),
+        other => panic!("unexpected event kind: {other:?}"),
+    }
+}
+
+#[test]
+fn a_rejected_restore_records_no_audit_event() {
+    let (service, dir, db, entry_id) = create_entry_with_secret("svc", "orig-pw", None);
+    service
+        .update_entry(&db, &entry_id, password_update("new-pw"))
+        .expect("update password");
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    let version = &history[0];
+
+    let audit = AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+    let result = audit_entry_history_restored_on_success(
+        &audit,
+        &db,
+        &entry_id,
+        service.restore_entry_history(&db, &entry_id, version.index, "stale-fingerprint"),
+    );
+    assert!(matches!(result, Err(AppError::HistoryVersionMismatch(_))));
+
+    let events = audit
+        .read(Path::new(&db), &AuditFilter::default())
+        .expect("read audit");
+    assert!(
+        events.is_empty(),
+        "a guard failure must record no audit event"
     );
 }
 

--- a/src-tauri/tests/commands/entries_test.rs
+++ b/src-tauri/tests/commands/entries_test.rs
@@ -1023,6 +1023,59 @@ fn a_rejected_restore_records_no_audit_event() {
     );
 }
 
+#[test]
+fn restore_guard_covers_attachment_bytes_for_same_second_versions() {
+    let (service, dir, db, entry_id) = create_entry_with_secret("svc", "pw", None);
+    let path = dir.path().join("f.txt");
+    // Rapid add/delete cycles, each storing DIFFERENT bytes under the SAME
+    // filename, so several with-attachment snapshots land within the same second
+    // differing only in attachment bytes. A name-only fingerprint can't tell
+    // them apart; the byte-aware one must.
+    for i in 0..6u8 {
+        std::fs::write(&path, [i; 8]).expect("write attachment");
+        service
+            .add_entry_attachment(&db, &entry_id, &path, 25 * 1024 * 1024)
+            .expect("add attachment");
+        service
+            .delete_entry_attachment(&db, &entry_id, "f.txt")
+            .expect("delete attachment");
+    }
+
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    // Each delete's pre-image (the with-attachment snapshot) lands at an even
+    // index in the newest-first list.
+    let with_att: Vec<_> = history.iter().step_by(2).collect();
+
+    // Find two with-attachment snapshots that share a second-precision
+    // timestamp — guaranteed among rapid edits.
+    let mut pair = None;
+    'outer: for a in 0..with_att.len() {
+        for b in (a + 1)..with_att.len() {
+            if with_att[a].modified_at == with_att[b].modified_at {
+                pair = Some((with_att[a], with_att[b]));
+                break 'outer;
+            }
+        }
+    }
+    let (v0, v1) =
+        pair.expect("two with-attachment snapshots must share a second among rapid edits");
+
+    // They share a second but carry different attachment bytes, so a byte-aware
+    // fingerprint must distinguish them — a name-only MAC would collide here.
+    assert_ne!(
+        v0.fingerprint, v1.fingerprint,
+        "fingerprint must disambiguate same-second attachment byte swaps"
+    );
+
+    // And the guard must reject addressing one index with the other's
+    // fingerprint, so a stale index can't shift restore onto the wrong bytes.
+    let crossed = service.restore_entry_history(&db, &entry_id, v0.index, &v1.fingerprint);
+    assert!(
+        matches!(crossed, Err(AppError::HistoryVersionMismatch(_))),
+        "guard must reject a cross-version address differing only in attachment bytes, got {crossed:?}"
+    );
+}
+
 // ============================================================================
 // create_entry command tests
 // ============================================================================

--- a/src-tauri/tests/commands/entries_test.rs
+++ b/src-tauri/tests/commands/entries_test.rs
@@ -1076,6 +1076,60 @@ fn restore_guard_covers_attachment_bytes_for_same_second_versions() {
     );
 }
 
+#[test]
+fn restoring_a_location_only_version_is_rejected_as_unchanged() {
+    let (service, dir, db, entry_id) = create_entry_with_secret("svc", "pw", None);
+    // Move the entry to another Group. The move snapshots a location-only
+    // version whose *content* is identical to the live entry — only its parent
+    // Group differs, and restore deliberately never touches the parent Group.
+    let groups = service.list_groups(&db).expect("groups");
+    let root = &groups[0];
+    let target = root.children.first().expect("a default child group");
+    service
+        .move_entry(&db, &entry_id, &target.id)
+        .expect("move entry");
+
+    // A single move yields exactly one history version: the location-only
+    // snapshot, whose restorable content matches the live entry.
+    let history = service.list_entry_history(&db, &entry_id).expect("history");
+    assert_eq!(
+        history.len(),
+        1,
+        "the move snapshots one location-only version"
+    );
+    let version = history[0].clone();
+    let before_len = history.len();
+
+    // Restoring it would change nothing restorable, so it must be a no-op error
+    // — not a silent success that bumps mtime and appends a junk version.
+    let audit = AuditService::new(dir.path().join("audit"), Arc::new(InMemoryAuditKey::new()));
+    let result = audit_entry_history_restored_on_success(
+        &audit,
+        &db,
+        &entry_id,
+        service.restore_entry_history(&db, &entry_id, version.index, &version.fingerprint),
+    );
+    assert!(
+        matches!(result, Err(AppError::HistoryVersionUnchanged)),
+        "a content-identical restore must be rejected as unchanged, got {result:?}"
+    );
+
+    // No new history version, and nothing recorded — a true no-op.
+    let after = service.list_entry_history(&db, &entry_id).expect("history");
+    assert_eq!(
+        after.len(),
+        before_len,
+        "a no-op restore must not append a history version"
+    );
+    let events = audit
+        .read(Path::new(&db), &AuditFilter::default())
+        .expect("read audit");
+    assert!(
+        events.is_empty(),
+        "a no-op restore must record no audit event"
+    );
+}
+
 // ============================================================================
 // create_entry command tests
 // ============================================================================

--- a/src/components/entries/EntryHistorySection.tsx
+++ b/src/components/entries/EntryHistorySection.tsx
@@ -124,6 +124,12 @@ export function EntryHistorySection({
             query.queryKey[0] === queryKeys.entries.all[0] &&
             query.queryKey[1] === dbId,
         }),
+        // A restore can replace the live password/expiry, so any cached
+        // password-health findings must be recomputed — same as the entry
+        // mutation hook does for the same kind of content change.
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.passwordHealth.report(dbId),
+        }),
       ]);
       toast.success(t("entries.detail.restoreHistorySuccess"));
     },

--- a/src/components/entries/EntryHistorySection.tsx
+++ b/src/components/entries/EntryHistorySection.tsx
@@ -109,6 +109,14 @@ export function EntryHistorySection({
           version.fingerprint
         );
       } catch (error) {
+        // A version whose restorable content matches the current entry (e.g. a
+        // move-only version — restore never touches the parent Group) is a
+        // no-op the backend rejects rather than reporting a phantom success.
+        // Surface it as a neutral info message, not a failure.
+        if (String(error).includes("History version unchanged")) {
+          toast.info(t("entries.detail.restoreHistoryUnchanged"));
+          return;
+        }
         console.error("Failed to restore entry version:", error);
         toast.error(t("entries.detail.restoreHistoryFailed"));
         return;

--- a/src/components/entries/EntryHistorySection.tsx
+++ b/src/components/entries/EntryHistorySection.tsx
@@ -2,8 +2,17 @@
 
 import { useCallback, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, Eye, EyeOff, History, Loader2 } from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ChevronDown,
+  Eye,
+  EyeOff,
+  History,
+  Loader2,
+  RotateCcw,
+} from "lucide-react";
+import { ask } from "@tauri-apps/plugin-dialog";
+import { toast } from "sonner";
 import {
   Collapsible,
   CollapsibleContent,
@@ -12,6 +21,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator.tsx";
 import { entries as entriesApi } from "@/lib/tauri";
+import { saveWithErrorToast } from "@/lib/save-with-error-toast";
 import type { EntryHistoryItem } from "@/lib/types";
 import { queryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
@@ -64,10 +74,61 @@ export function EntryHistorySection({
     location: t("entries.detail.historyField.location"),
   };
 
+  const queryClient = useQueryClient();
+
   const { data: versions = [] } = useQuery({
     queryKey: queryKeys.entries.history(dbId, entryId),
     queryFn: () => entriesApi.listHistory(dbId, entryId),
   });
+
+  // Restores the Entry to a chosen version after an explicit confirmation: the
+  // backend snapshots the current state into history first (so the restore is
+  // undoable), then overwrites the live content (ADR-0008). Secrets are read
+  // backend-side and never round-trip. On success we persist via the shared
+  // helper (which surfaces its own toast on a disk/backup failure) and refresh
+  // the detail, list, and history views so the restored content and the new
+  // pre-restore version both appear.
+  const handleRestore = useCallback(
+    async (version: EntryHistoryItem) => {
+      const confirmed = await ask(
+        t("entries.detail.restoreHistoryConfirm", {
+          date: formatHistoryDate(version.modifiedAt),
+        }),
+        {
+          title: t("entries.detail.restoreHistoryConfirmTitle"),
+          kind: "warning",
+        }
+      );
+      if (!confirmed) return;
+
+      try {
+        await entriesApi.restoreHistory(
+          dbId,
+          entryId,
+          version.index,
+          version.fingerprint
+        );
+      } catch (error) {
+        console.error("Failed to restore entry version:", error);
+        toast.error(t("entries.detail.restoreHistoryFailed"));
+        return;
+      }
+
+      await saveWithErrorToast(dbId, t);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.entries.detail(dbId, entryId),
+        }),
+        queryClient.invalidateQueries({
+          predicate: (query) =>
+            query.queryKey[0] === queryKeys.entries.all[0] &&
+            query.queryKey[1] === dbId,
+        }),
+      ]);
+      toast.success(t("entries.detail.restoreHistorySuccess"));
+    },
+    [dbId, entryId, queryClient, t]
+  );
 
   return (
     <Collapsible
@@ -114,6 +175,7 @@ export function EntryHistorySection({
                 isOldest={index === versions.length - 1}
                 showSeparator={index > 0}
                 fieldLabels={fieldLabels}
+                onRestore={handleRestore}
               />
             ))}
           </ul>
@@ -138,6 +200,7 @@ function HistoryVersionItem({
   isOldest,
   showSeparator,
   fieldLabels,
+  onRestore,
 }: Readonly<{
   dbId: string;
   entryId: string;
@@ -145,6 +208,7 @@ function HistoryVersionItem({
   isOldest: boolean;
   showSeparator: boolean;
   fieldLabels: Record<string, string>;
+  onRestore: (version: EntryHistoryItem) => void;
 }>) {
   const { t } = useTranslation();
   // The changed line is shown even on the oldest "Earliest kept" version:
@@ -162,6 +226,15 @@ function HistoryVersionItem({
         <span className="shrink-0 text-sm text-muted-foreground">
           {formatHistoryDate(version.modifiedAt)}
         </span>
+        <Button
+          variant="outline"
+          size="icon-xs"
+          className="shrink-0"
+          aria-label={t("entries.detail.restoreVersion")}
+          onClick={() => onRestore(version)}
+        >
+          <RotateCcw className="h-3 w-3" />
+        </Button>
       </div>
       {isOldest && (
         <p className="px-4 pb-2 text-xs font-medium text-muted-foreground">

--- a/src/components/entries/__tests__/EntryHistorySection.test.tsx
+++ b/src/components/entries/__tests__/EntryHistorySection.test.tsx
@@ -31,8 +31,15 @@ vi.mock("@/lib/save-with-error-toast", () => ({
   saveWithErrorToast: vi.fn().mockResolvedValue(undefined),
 }));
 
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+const toastInfoMock = vi.fn();
 vi.mock("sonner", () => ({
-  toast: { success: vi.fn(), error: vi.fn() },
+  toast: {
+    success: (...args: unknown[]) => toastSuccessMock(...args),
+    error: (...args: unknown[]) => toastErrorMock(...args),
+    info: (...args: unknown[]) => toastInfoMock(...args),
+  },
 }));
 
 import {
@@ -98,6 +105,9 @@ describe("EntryHistorySection", () => {
     getHistoryProtectedFieldMock.mockReset();
     restoreHistoryMock.mockReset();
     askMock.mockReset();
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    toastInfoMock.mockReset();
   });
 
   it("lists each version with its timestamp once expanded", async () => {
@@ -346,6 +356,34 @@ describe("EntryHistorySection", () => {
       expect(askMock).toHaveBeenCalledTimes(1);
     });
     expect(restoreHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("shows a neutral info message (not a success) when the version is unchanged", async () => {
+    listHistoryMock.mockResolvedValue([
+      makeVersion({ index: 0, fingerprint: "fp-zero", changedFields: [] }),
+    ]);
+    askMock.mockResolvedValue(true);
+    // The backend rejects a no-op (e.g. a move-only version) with this message.
+    restoreHistoryMock.mockRejectedValue(
+      "History version unchanged: this version's content matches the current entry"
+    );
+
+    renderSection();
+    await expand();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "entries.detail.restoreVersion",
+      })
+    );
+
+    await waitFor(() => {
+      expect(toastInfoMock).toHaveBeenCalledWith(
+        "entries.detail.restoreHistoryUnchanged"
+      );
+    });
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 
   it("invalidates the password-health report after a restore", async () => {

--- a/src/components/entries/__tests__/EntryHistorySection.test.tsx
+++ b/src/components/entries/__tests__/EntryHistorySection.test.tsx
@@ -9,6 +9,7 @@ import type { EntryHistoryItem } from "@/lib/types";
 const listHistoryMock = vi.fn();
 const getHistoryPasswordMock = vi.fn();
 const getHistoryProtectedFieldMock = vi.fn();
+const restoreHistoryMock = vi.fn();
 
 vi.mock("@/lib/tauri", () => ({
   entries: {
@@ -16,7 +17,21 @@ vi.mock("@/lib/tauri", () => ({
     getHistoryPassword: (...args: unknown[]) => getHistoryPasswordMock(...args),
     getHistoryProtectedField: (...args: unknown[]) =>
       getHistoryProtectedFieldMock(...args),
+    restoreHistory: (...args: unknown[]) => restoreHistoryMock(...args),
   },
+}));
+
+const askMock = vi.fn();
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  ask: (...args: unknown[]) => askMock(...args),
+}));
+
+vi.mock("@/lib/save-with-error-toast", () => ({
+  saveWithErrorToast: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 import {
@@ -80,6 +95,8 @@ describe("EntryHistorySection", () => {
     listHistoryMock.mockReset();
     getHistoryPasswordMock.mockReset();
     getHistoryProtectedFieldMock.mockReset();
+    restoreHistoryMock.mockReset();
+    askMock.mockReset();
   });
 
   it("lists each version with its timestamp once expanded", async () => {
@@ -269,5 +286,64 @@ describe("EntryHistorySection", () => {
       "fp-zero",
       "PIN"
     );
+  });
+
+  it("restores a version after the user confirms, addressed by index + fingerprint", async () => {
+    listHistoryMock.mockResolvedValue([
+      makeVersion({
+        index: 0,
+        fingerprint: "fp-zero",
+        changedFields: ["password"],
+      }),
+    ]);
+    askMock.mockResolvedValue(true);
+    restoreHistoryMock.mockResolvedValue({ id: TEST_ENTRY_ID });
+
+    renderSection();
+    await expand();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "entries.detail.restoreVersion",
+      })
+    );
+
+    // The destructive action is gated on an explicit confirmation.
+    await waitFor(() => {
+      expect(askMock).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(restoreHistoryMock).toHaveBeenCalledWith(
+        TEST_DB_ID,
+        TEST_ENTRY_ID,
+        0,
+        "fp-zero"
+      );
+    });
+  });
+
+  it("does not restore when the user cancels the confirmation", async () => {
+    listHistoryMock.mockResolvedValue([
+      makeVersion({
+        index: 0,
+        fingerprint: "fp-zero",
+        changedFields: ["password"],
+      }),
+    ]);
+    askMock.mockResolvedValue(false);
+
+    renderSection();
+    await expand();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "entries.detail.restoreVersion",
+      })
+    );
+
+    await waitFor(() => {
+      expect(askMock).toHaveBeenCalledTimes(1);
+    });
+    expect(restoreHistoryMock).not.toHaveBeenCalled();
   });
 });

--- a/src/components/entries/__tests__/EntryHistorySection.test.tsx
+++ b/src/components/entries/__tests__/EntryHistorySection.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { EntryHistoryItem } from "@/lib/types";
+import { queryKeys } from "@/lib/query-keys";
 
 const listHistoryMock = vi.fn();
 const getHistoryPasswordMock = vi.fn();
@@ -345,5 +346,48 @@ describe("EntryHistorySection", () => {
       expect(askMock).toHaveBeenCalledTimes(1);
     });
     expect(restoreHistoryMock).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the password-health report after a restore", async () => {
+    listHistoryMock.mockResolvedValue([
+      makeVersion({
+        index: 0,
+        fingerprint: "fp-zero",
+        changedFields: ["password"],
+      }),
+    ]);
+    askMock.mockResolvedValue(true);
+    restoreHistoryMock.mockResolvedValue({ id: TEST_ENTRY_ID });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    // Seed a cached password-health report so we can prove the restore marks
+    // it stale (a restore can replace the live password/expiry).
+    queryClient.setQueryData(queryKeys.passwordHealth.report(TEST_DB_ID), {
+      entries: [],
+    });
+
+    render(<EntryHistorySection dbId={TEST_DB_ID} entryId={TEST_ENTRY_ID} />, {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          {children}
+        </QueryClientProvider>
+      ),
+    });
+    await expand();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "entries.detail.restoreVersion",
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryState(queryKeys.passwordHealth.report(TEST_DB_ID))
+          ?.isInvalidated
+      ).toBe(true);
+    });
   });
 });

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -358,6 +358,24 @@ describe("tauri wrappers validation", () => {
     });
   });
 
+  it("audit.list accepts an entryHistoryRestored event", async () => {
+    // Regression: a vault with a restore event must not make the whole audit
+    // query reject. The kind has to be in AuditEventKindSchema.
+    const payload = {
+      events: [
+        {
+          kind: "entryHistoryRestored",
+          timestamp: "2026-06-18T12:00:00.000Z",
+          entryId: "uuid-restore",
+        },
+      ],
+      degraded: false,
+    };
+    vi.mocked(invoke).mockResolvedValueOnce(payload);
+
+    await expect(audit.list("/mock/vault.kdbx")).resolves.toEqual(payload);
+  });
+
   it("audit.list surfaces a degraded flag from the backend", async () => {
     vi.mocked(invoke).mockResolvedValueOnce({
       events: [],

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -372,6 +372,34 @@ export const entries = {
   },
 
   /**
+   * Restores an Entry to a past version (ADR-0008). The version is addressed by
+   * its `index` in the newest-first list and guarded by `fingerprint` (taken
+   * from the {@link EntryHistoryItem}); a stale/mismatched fingerprint errors
+   * rather than restoring the wrong version. The backend snapshots the current
+   * state into history first (so the restore is undoable), then overwrites the
+   * live Entry's content from the chosen version — all fields incl. password,
+   * attachments, icon and expiry — leaving its UUID and parent Group untouched.
+   * Secrets are read backend-side and never round-trip. Returns the updated
+   * Entry (no secret fields).
+   */
+  async restoreHistory(
+    dbId: string,
+    id: string,
+    index: number,
+    fingerprint: string
+  ): Promise<Entry> {
+    DbIdSchema.parse({ dbId });
+    IdSchema.parse({ id });
+    const result = await invoke("restore_entry_history", {
+      dbId,
+      id,
+      index,
+      fingerprint,
+    });
+    return EntrySchema.parse(result);
+  },
+
+  /**
    * Phase 1 (picker): opens the multi-select file dialog *in Rust*, buffers the
    * picked paths backend-side, and returns the size-classification plan against
    * the configured thresholds — without reading bytes or mutating the Vault.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -436,6 +436,7 @@ export const AuditEventKindSchema = z.enum([
   "entryPasswordCopied",
   "entryProtectedFieldRevealed",
   "entryAttachmentExported",
+  "entryHistoryRestored",
   "preferencesSecurityChanged",
   "auditCleared",
 ]);

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -374,6 +374,7 @@
       "restoreHistoryConfirm": "Diesen Eintrag auf die Version vom {{date}} zurücksetzen? Der aktuelle Stand wird zuerst im Verlauf gespeichert, sodass Sie dies rückgängig machen können.",
       "restoreHistorySuccess": "Eintrag auf die ausgewählte Version zurückgesetzt",
       "restoreHistoryFailed": "Eintrag konnte nicht wiederhergestellt werden",
+      "restoreHistoryUnchanged": "Diese Version entspricht dem aktuellen Eintrag – nichts wiederherzustellen",
       "historyField": {
         "title": "Titel",
         "username": "Benutzername",

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -35,6 +35,7 @@
       "entryPasswordCopied": "Passwort kopiert",
       "entryProtectedFieldRevealed": "Geschütztes Feld angezeigt",
       "entryAttachmentExported": "Anhang heruntergeladen",
+      "entryHistoryRestored": "Aus Verlauf wiederhergestellt",
       "preferencesSecurityChanged": "Sicherheitseinstellung geändert",
       "auditCleared": "Audit-Protokoll geleert"
     },

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -368,6 +368,11 @@
       "historyChanged": "Geändert: {{fields}}",
       "historyCreated": "Erstellt",
       "historyEarliestKept": "Älteste aufbewahrte Version",
+      "restoreVersion": "Diese Version wiederherstellen",
+      "restoreHistoryConfirmTitle": "Version wiederherstellen",
+      "restoreHistoryConfirm": "Diesen Eintrag auf die Version vom {{date}} zurücksetzen? Der aktuelle Stand wird zuerst im Verlauf gespeichert, sodass Sie dies rückgängig machen können.",
+      "restoreHistorySuccess": "Eintrag auf die ausgewählte Version zurückgesetzt",
+      "restoreHistoryFailed": "Eintrag konnte nicht wiederhergestellt werden",
       "historyField": {
         "title": "Titel",
         "username": "Benutzername",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -391,6 +391,11 @@
       "historyChanged": "Changed: {{fields}}",
       "historyCreated": "Created",
       "historyEarliestKept": "Earliest kept version",
+      "restoreVersion": "Restore this version",
+      "restoreHistoryConfirmTitle": "Restore version",
+      "restoreHistoryConfirm": "Restore this entry to the version from {{date}}? The current state is saved to history first, so you can undo this.",
+      "restoreHistorySuccess": "Entry restored to the selected version",
+      "restoreHistoryFailed": "Failed to restore the entry",
       "historyField": {
         "title": "title",
         "username": "username",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -35,6 +35,7 @@
       "entryPasswordCopied": "Password copied",
       "entryProtectedFieldRevealed": "Protected field revealed",
       "entryAttachmentExported": "Attachment downloaded",
+      "entryHistoryRestored": "Restored from history",
       "preferencesSecurityChanged": "Security preference changed",
       "auditCleared": "Audit log cleared"
     },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -397,6 +397,7 @@
       "restoreHistoryConfirm": "Restore this entry to the version from {{date}}? The current state is saved to history first, so you can undo this.",
       "restoreHistorySuccess": "Entry restored to the selected version",
       "restoreHistoryFailed": "Failed to restore the entry",
+      "restoreHistoryUnchanged": "This version matches the current entry — nothing to restore",
       "historyField": {
         "title": "title",
         "username": "username",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -35,6 +35,7 @@
       "entryPasswordCopied": "Contraseña copiada",
       "entryProtectedFieldRevealed": "Campo protegido revelado",
       "entryAttachmentExported": "Adjunto descargado",
+      "entryHistoryRestored": "Restaurado desde el historial",
       "preferencesSecurityChanged": "Preferencia de seguridad modificada",
       "auditCleared": "Registro de auditoría borrado"
     },

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -368,6 +368,11 @@
       "historyChanged": "Cambiado: {{fields}}",
       "historyCreated": "Creado",
       "historyEarliestKept": "Versión más antigua conservada",
+      "restoreVersion": "Restaurar esta versión",
+      "restoreHistoryConfirmTitle": "Restaurar versión",
+      "restoreHistoryConfirm": "¿Restaurar esta entrada a la versión del {{date}}? El estado actual se guarda primero en el historial, para que puedas deshacerlo.",
+      "restoreHistorySuccess": "Entrada restaurada a la versión seleccionada",
+      "restoreHistoryFailed": "No se pudo restaurar la entrada",
       "historyField": {
         "title": "título",
         "username": "usuario",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -374,6 +374,7 @@
       "restoreHistoryConfirm": "¿Restaurar esta entrada a la versión del {{date}}? El estado actual se guarda primero en el historial, para que puedas deshacerlo.",
       "restoreHistorySuccess": "Entrada restaurada a la versión seleccionada",
       "restoreHistoryFailed": "No se pudo restaurar la entrada",
+      "restoreHistoryUnchanged": "Esta versión coincide con la entrada actual: no hay nada que restaurar",
       "historyField": {
         "title": "título",
         "username": "usuario",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -368,6 +368,11 @@
       "historyChanged": "Modifié : {{fields}}",
       "historyCreated": "Créé",
       "historyEarliestKept": "Version conservée la plus ancienne",
+      "restoreVersion": "Restaurer cette version",
+      "restoreHistoryConfirmTitle": "Restaurer la version",
+      "restoreHistoryConfirm": "Restaurer cette entrée à la version du {{date}} ? L'état actuel est d'abord enregistré dans l'historique, vous pourrez donc annuler.",
+      "restoreHistorySuccess": "Entrée restaurée à la version sélectionnée",
+      "restoreHistoryFailed": "Échec de la restauration de l'entrée",
       "historyField": {
         "title": "titre",
         "username": "nom d’utilisateur",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -35,6 +35,7 @@
       "entryPasswordCopied": "Mot de passe copié",
       "entryProtectedFieldRevealed": "Champ protégé affiché",
       "entryAttachmentExported": "Pièce jointe téléchargée",
+      "entryHistoryRestored": "Restauré depuis l'historique",
       "preferencesSecurityChanged": "Préférence de sécurité modifiée",
       "auditCleared": "Journal d'audit effacé"
     },

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -374,6 +374,7 @@
       "restoreHistoryConfirm": "Restaurer cette entrée à la version du {{date}} ? L'état actuel est d'abord enregistré dans l'historique, vous pourrez donc annuler.",
       "restoreHistorySuccess": "Entrée restaurée à la version sélectionnée",
       "restoreHistoryFailed": "Échec de la restauration de l'entrée",
+      "restoreHistoryUnchanged": "Cette version correspond à l'entrée actuelle — rien à restaurer",
       "historyField": {
         "title": "titre",
         "username": "nom d’utilisateur",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -35,6 +35,7 @@
       "entryPasswordCopied": "Lozinka kopirana",
       "entryProtectedFieldRevealed": "Zaštićeno polje prikazano",
       "entryAttachmentExported": "Prilog preuzet",
+      "entryHistoryRestored": "Vraćeno iz istorije",
       "preferencesSecurityChanged": "Bezbednosno podešavanje promenjeno",
       "auditCleared": "Dnevnik nadzora obrisan"
     },

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -368,6 +368,11 @@
       "historyChanged": "Izmenjeno: {{fields}}",
       "historyCreated": "Kreirano",
       "historyEarliestKept": "Najstarija sačuvana verzija",
+      "restoreVersion": "Vrati ovu verziju",
+      "restoreHistoryConfirmTitle": "Vraćanje verzije",
+      "restoreHistoryConfirm": "Vratiti ovu stavku na verziju od {{date}}? Trenutno stanje se prvo čuva u istoriji, pa možete poništiti ovu radnju.",
+      "restoreHistorySuccess": "Stavka je vraćena na izabranu verziju",
+      "restoreHistoryFailed": "Vraćanje stavke nije uspelo",
       "historyField": {
         "title": "naslov",
         "username": "korisničko ime",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -374,6 +374,7 @@
       "restoreHistoryConfirm": "Vratiti ovu stavku na verziju od {{date}}? Trenutno stanje se prvo čuva u istoriji, pa možete poništiti ovu radnju.",
       "restoreHistorySuccess": "Stavka je vraćena na izabranu verziju",
       "restoreHistoryFailed": "Vraćanje stavke nije uspelo",
+      "restoreHistoryUnchanged": "Ova verzija odgovara trenutnoj stavci — nema šta da se vrati",
       "historyField": {
         "title": "naslov",
         "username": "korisničko ime",


### PR DESCRIPTION
## What

Implements Entry History S5 (#328): the user can restore an Entry to any past version.

`restore_entry_history` snapshots the current state into history **first** (so the restore is itself undoable), then overwrites the live Entry's content — all fields incl. password, attachments, icon and expiry — from the chosen version, bumping `last_modification` to now. The Entry's UUID and parent Group are left untouched (a version carries content, not location). Secrets are read backend-side and never cross IPC.

Version addressing reuses the **index + fingerprint** guard from #325. A restore appends a new `entry.history_restored { entry_id }` audit event through the existing audit-wrapper pattern. The history view gains a per-version Restore action with a confirmation.

## Acceptance criteria

- [x] `restore_history` snapshots the current state before overwriting, so the pre-restore state becomes the newest history version.
- [x] All content (fields incl. password, attachments, icon, expiry) overwritten from the chosen version; UUID and parent Group unchanged; `last_modification` set to now.
- [x] The restored secret is read in Rust and never crosses IPC.
- [x] Restore uses the index + fingerprint guard and errors on mismatch.
- [x] A restore appends an `entry.history_restored` audit event carrying `entry_id`.
- [x] The history view exposes a per-version Restore action with confirmation.
- [x] Service tests cover snapshot-then-overwrite, identity/Group preservation, the guard, and the audit append; a frontend test covers the restore confirmation flow.

Closes #328.

🤖 Generated with [Claude Code](https://claude.com/claude-code)