### PR TITLE
feat(ui): compare current vs historical Entry version (diff view)

### DIFF
--- a/src/components/entries/EntryHistoryCompareDialog.tsx
+++ b/src/components/entries/EntryHistoryCompareDialog.tsx
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: MIT
+
+import { useCallback, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { ArrowRight, Eye, EyeOff, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { entries as entriesApi } from "@/lib/tauri";
+import { queryKeys } from "@/lib/query-keys";
+import type { Entry, EntryHistoryItem } from "@/lib/types";
+
+/**
+ * The built-in field tokens the backend emits in `changedFields` (#324). Any
+ * token outside this set is a user-defined custom field key.
+ */
+const KNOWN_FIELDS = new Set([
+  "title",
+  "username",
+  "password",
+  "url",
+  "notes",
+  "tags",
+  "icon",
+  "attachments",
+  "expiry",
+  "location",
+]);
+
+/**
+ * The set of field tokens that differ between the version at `index` and the
+ * current Entry, derived from the names-only `changedFields` signal (#324)
+ * without any new backend endpoint. Each version's `changedFields` is the diff
+ * against the next-newer version (the newest against the live Entry), so the
+ * union from index 0 through `index` is every field that changed somewhere
+ * between that version and now. It's an upper bound — a field changed and later
+ * reverted still appears — which the dialog's exact value comparison corrects
+ * for the text fields it can compare directly.
+ */
+export function changedSince(
+  versions: EntryHistoryItem[],
+  index: number
+): string[] {
+  const seen = new Set<string>();
+  for (const version of versions.slice(0, index + 1)) {
+    for (const field of version.changedFields) seen.add(field);
+  }
+  return [...seen];
+}
+
+interface EntryHistoryCompareDialogProps {
+  dbId: string;
+  entryId: string;
+  version: EntryHistoryItem;
+  /**
+   * The set of field tokens that differ between this version and the current
+   * Entry — the union of `changedFields` from the newest version through this
+   * one. Drives which rows the comparison shows (changed-only).
+   */
+  changedFields: string[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Compares a historical version against the current Entry, field by field, so
+ * the user can see exactly what differs before deciding to restore (#329).
+ *
+ * This is a pure frontend composition (ADR-0008): no backend diff endpoint
+ * beyond the existing history listing and the per-version secret fetches. Only
+ * the current Entry's values, the version's non-secret listing fields, and
+ * on-demand secret reveals are available — so plain text fields the listing
+ * carries (title/username/url) show a real `historical → current` diff while
+ * fields whose historical value can't be reached show the current value with a
+ * "previous value not available" note.
+ */
+export function EntryHistoryCompareDialog({
+  dbId,
+  entryId,
+  version,
+  changedFields,
+  open,
+  onOpenChange,
+}: Readonly<EntryHistoryCompareDialogProps>) {
+  const { t } = useTranslation();
+
+  const { data: current } = useQuery({
+    queryKey: queryKeys.entries.detail(dbId, entryId),
+    queryFn: () => entriesApi.get(dbId, entryId),
+    enabled: open,
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[80vh] overflow-auto">
+        <DialogHeader>
+          <DialogTitle>{t("entries.detail.compare.title")}</DialogTitle>
+          <DialogDescription>
+            {t("entries.detail.compare.description", {
+              date: formatHistoryDate(version.modifiedAt),
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        {current && (
+          <CompareBody
+            dbId={dbId}
+            entryId={entryId}
+            version={version}
+            current={current}
+            changedFields={changedFields}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * The comparison rows, rendered once the current Entry has loaded. A field is
+ * shown only when it actually differs (changed-only). Direct text fields the
+ * history listing carries (title/username/url) are compared by exact value —
+ * which also corrects the changed-field signal's false positives when a field
+ * was changed and later reverted to its current value.
+ */
+function CompareBody({
+  dbId,
+  entryId,
+  version,
+  current,
+  changedFields,
+}: Readonly<{
+  dbId: string;
+  entryId: string;
+  version: EntryHistoryItem;
+  current: Entry;
+  changedFields: string[];
+}>) {
+  const { t } = useTranslation();
+
+  const rows: ReactNode[] = [];
+
+  // Direct text fields the history listing carries for both sides: compared by
+  // exact value, so a changed-then-reverted field drops out of the diff.
+  for (const field of ["title", "username", "url"] as const) {
+    const before = version[field] ?? "";
+    const after = current[field] ?? "";
+    if (changedFields.includes(field) && before !== after) {
+      rows.push(
+        <CompareRow
+          key={field}
+          label={t(`entries.detail.historyField.${field}`)}
+          before={before}
+          after={after}
+        />
+      );
+    }
+  }
+
+  // Password: a secret on both sides. Revealed only on the explicit toggle,
+  // which fetches the current and historical values together (ADR-0008) — the
+  // historical fetch carries the version's index + fingerprint guard.
+  if (changedFields.includes("password")) {
+    rows.push(
+      <CompareSecretRow
+        key="password"
+        label={t("entries.detail.historyField.password")}
+        revealLabel={t("entries.detail.revealPassword")}
+        hideLabel={t("entries.detail.hidePassword")}
+        fetchBefore={() =>
+          entriesApi.getHistoryPassword(
+            dbId,
+            entryId,
+            version.index,
+            version.fingerprint
+          )
+        }
+        fetchAfter={() => entriesApi.getPassword(dbId, entryId)}
+      />
+    );
+  }
+
+  // Value-less fields: the listing carries no historical value for these, so we
+  // can only show the current value (where it's plain text) and note that the
+  // previous value can't be displayed.
+  for (const field of [
+    "notes",
+    "tags",
+    "icon",
+    "attachments",
+    "expiry",
+    "location",
+  ] as const) {
+    if (changedFields.includes(field)) {
+      rows.push(
+        <PreviousUnavailableRow
+          key={field}
+          label={t(`entries.detail.historyField.${field}`)}
+          current={currentSummary(field, current)}
+        />
+      );
+    }
+  }
+
+  // Custom fields: any changed token that isn't a known built-in is a custom
+  // field key. Protected ones (now or in the version) are secrets revealed on
+  // demand from both sides; plain ones show the current value only, since the
+  // listing carries no historical custom-field value.
+  const protectedNow = new Set(
+    current.customFieldMeta.filter((m) => m.isProtected).map((m) => m.key)
+  );
+  for (const key of changedFields) {
+    if (KNOWN_FIELDS.has(key)) continue;
+    const isProtected =
+      protectedNow.has(key) || version.protectedFields.includes(key);
+    if (isProtected) {
+      rows.push(
+        <CompareSecretRow
+          key={`custom:${key}`}
+          label={key}
+          revealLabel={t("entries.detail.revealField", { field: key })}
+          hideLabel={t("entries.detail.hideField", { field: key })}
+          fetchBefore={async () =>
+            (
+              await entriesApi.getHistoryProtectedField(
+                dbId,
+                entryId,
+                version.index,
+                version.fingerprint,
+                key
+              )
+            ).value
+          }
+          fetchAfter={async () =>
+            (await entriesApi.getProtectedCustomField(dbId, entryId, key)).value
+          }
+        />
+      );
+    } else {
+      rows.push(
+        <PreviousUnavailableRow
+          key={`custom:${key}`}
+          label={key}
+          current={current.customFields[key] ?? null}
+        />
+      );
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t("entries.detail.compare.noChanges")}
+      </p>
+    );
+  }
+
+  return <>{rows}</>;
+}
+
+/**
+ * A secret field compared across both versions (the password or a protected
+ * custom field). Nothing is fetched until the explicit reveal, which loads the
+ * historical and current values together and shows them as `before → after`.
+ * Hiding drops both values from state so neither lingers (ADR-0008).
+ */
+function CompareSecretRow({
+  label,
+  revealLabel,
+  hideLabel,
+  fetchBefore,
+  fetchAfter,
+}: Readonly<{
+  label: string;
+  revealLabel: string;
+  hideLabel: string;
+  fetchBefore: () => Promise<string>;
+  fetchAfter: () => Promise<string>;
+}>) {
+  const [values, setValues] = useState<{
+    before: string;
+    after: string;
+  } | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const isVisible = values !== null;
+
+  const reveal = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const [before, after] = await Promise.all([fetchBefore(), fetchAfter()]);
+      setValues({ before, after });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [fetchBefore, fetchAfter]);
+
+  const hide = useCallback(() => setValues(null), []);
+
+  return (
+    <div className="flex flex-col gap-1 py-1">
+      <small className="text-xs font-medium text-muted-foreground">
+        {label}
+      </small>
+      <div className="flex min-w-0 items-center gap-2 text-sm">
+        {isLoading ? (
+          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+        ) : (
+          <>
+            <span className="min-w-0 flex-1 truncate text-muted-foreground line-through">
+              {isVisible ? values.before : "••••••••"}
+            </span>
+            <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 truncate">
+              {isVisible ? values.after : "••••••••"}
+            </span>
+          </>
+        )}
+        <Button
+          variant="outline"
+          size="icon-xs"
+          className="shrink-0"
+          aria-label={isVisible ? hideLabel : revealLabel}
+          onClick={isVisible ? hide : reveal}
+          disabled={isLoading}
+        >
+          {isVisible ? (
+            <EyeOff className="h-3 w-3" />
+          ) : (
+            <Eye className="h-3 w-3" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A plain-text summary of the current Entry's value for a value-less field, or
+ * `null` when the field has no meaningful one-line representation (icon,
+ * attachments, expiry, location are shown by label alone).
+ */
+function currentSummary(
+  field: "notes" | "tags" | "icon" | "attachments" | "expiry" | "location",
+  current: Entry
+): string | null {
+  if (field === "notes") return current.notes ?? "";
+  if (field === "tags") return current.tags.join(", ");
+  return null;
+}
+
+/**
+ * A field that changed but whose historical value can't be reached over IPC.
+ * Shows the current value (when it's plain text) plus a note that the previous
+ * value isn't available for comparison.
+ */
+function PreviousUnavailableRow({
+  label,
+  current,
+}: Readonly<{ label: string; current: string | null }>) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-1 py-1">
+      <small className="text-xs font-medium text-muted-foreground">
+        {label}
+      </small>
+      {current !== null && current !== "" && (
+        <span className="min-w-0 truncate text-sm">{current}</span>
+      )}
+      <span className="text-xs italic text-muted-foreground">
+        {t("entries.detail.compare.previousNotAvailable")}
+      </span>
+    </div>
+  );
+}
+
+// Format a version's timestamp the same way the history list does, so the
+// compare dialog names the version by a date the user already recognizes.
+function formatHistoryDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date);
+}
+
+/**
+ * One field's `before → after` comparison row.
+ */
+function CompareRow({
+  label,
+  before,
+  after,
+}: Readonly<{ label: string; before: string; after: string }>) {
+  return (
+    <div className="flex flex-col gap-1 py-1">
+      <small className="text-xs font-medium text-muted-foreground">
+        {label}
+      </small>
+      <div className="flex min-w-0 items-center gap-2 text-sm">
+        <span className="min-w-0 flex-1 truncate text-muted-foreground line-through">
+          {before}
+        </span>
+        <ArrowRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1 truncate">{after}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/entries/EntryHistoryCompareDialog.tsx
+++ b/src/components/entries/EntryHistoryCompareDialog.tsx
@@ -145,12 +145,27 @@ function CompareBody({
 
   const rows: ReactNode[] = [];
 
+  // The backend emits built-in tokens (`password`, `tags`, …) and custom field
+  // keys verbatim into the same list, so a custom field named like a built-in
+  // collides. A token is a custom field when it's a known custom key — present
+  // in the current entry's meta or the version's protected set; everything else
+  // matching a built-in token is the built-in field.
+  const customMetaNow = new Map(
+    current.customFieldMeta.map((m) => [m.key, m.isProtected])
+  );
+  const customKeys = new Set([
+    ...customMetaNow.keys(),
+    ...version.protectedFields,
+  ]);
+  const isBuiltin = (token: string) =>
+    KNOWN_FIELDS.has(token) && !customKeys.has(token);
+
   // Direct text fields the history listing carries for both sides: compared by
   // exact value, so a changed-then-reverted field drops out of the diff.
   for (const field of ["title", "username", "url"] as const) {
     const before = version[field] ?? "";
     const after = current[field] ?? "";
-    if (changedFields.includes(field) && before !== after) {
+    if (isBuiltin(field) && changedFields.includes(field) && before !== after) {
       rows.push(
         <CompareRow
           key={field}
@@ -165,7 +180,7 @@ function CompareBody({
   // Password: a secret on both sides. Revealed only on the explicit toggle,
   // which fetches the current and historical values together (ADR-0008) — the
   // historical fetch carries the version's index + fingerprint guard.
-  if (changedFields.includes("password")) {
+  if (isBuiltin("password") && changedFields.includes("password")) {
     rows.push(
       <CompareSecretRow
         key="password"
@@ -196,7 +211,7 @@ function CompareBody({
     "expiry",
     "location",
   ] as const) {
-    if (changedFields.includes(field)) {
+    if (isBuiltin(field) && changedFields.includes(field)) {
       rows.push(
         <PreviousUnavailableRow
           key={field}
@@ -207,18 +222,16 @@ function CompareBody({
     }
   }
 
-  // Custom fields: any changed token that isn't a known built-in is a custom
-  // field key. Protected ones (now or in the version) are secrets revealed on
-  // demand from both sides; plain ones show the current value only, since the
-  // listing carries no historical custom-field value.
-  const protectedNow = new Set(
-    current.customFieldMeta.filter((m) => m.isProtected).map((m) => m.key)
-  );
+  // Custom fields: every changed token that isn't a built-in. A field is a
+  // two-sided secret only when it's protected in *both* versions — then it's
+  // revealed on demand from each side. When protection differs (toggled, or the
+  // field was added/removed), one protected endpoint would error, so we degrade
+  // to showing the current plain value (if any) with "previous not available".
   for (const key of changedFields) {
-    if (KNOWN_FIELDS.has(key)) continue;
-    const isProtected =
-      protectedNow.has(key) || version.protectedFields.includes(key);
-    if (isProtected) {
+    if (isBuiltin(key)) continue;
+    const protectedBoth =
+      customMetaNow.get(key) === true && version.protectedFields.includes(key);
+    if (protectedBoth) {
       rows.push(
         <CompareSecretRow
           key={`custom:${key}`}

--- a/src/components/entries/EntryHistoryCompareDialog.tsx
+++ b/src/components/entries/EntryHistoryCompareDialog.tsx
@@ -145,11 +145,13 @@ function CompareBody({
 
   const rows: ReactNode[] = [];
 
-  // The backend emits built-in tokens (`password`, `tags`, …) and custom field
-  // keys verbatim into the same list, so a custom field named like a built-in
-  // collides. A token is a custom field when it's a known custom key — present
-  // in the current entry's meta or the version's protected set; everything else
-  // matching a built-in token is the built-in field.
+  // The backend flattens built-in tokens (`password`, `tags`, …) and custom
+  // field keys into one list, and a custom field may be named exactly like a
+  // built-in token — the wire can't tell them apart. So on a collision we can't
+  // pick a side without risking hiding a real change; instead the built-in rows
+  // below render on token presence, and any token that is *also* a known custom
+  // key (current meta or the version's protected set) additionally gets its own
+  // custom row. Both possibilities are shown rather than silently dropping one.
   const customMetaNow = new Map(
     current.customFieldMeta.map((m) => [m.key, m.isProtected])
   );
@@ -157,15 +159,13 @@ function CompareBody({
     ...customMetaNow.keys(),
     ...version.protectedFields,
   ]);
-  const isBuiltin = (token: string) =>
-    KNOWN_FIELDS.has(token) && !customKeys.has(token);
 
   // Direct text fields the history listing carries for both sides: compared by
   // exact value, so a changed-then-reverted field drops out of the diff.
   for (const field of ["title", "username", "url"] as const) {
     const before = version[field] ?? "";
     const after = current[field] ?? "";
-    if (isBuiltin(field) && changedFields.includes(field) && before !== after) {
+    if (changedFields.includes(field) && before !== after) {
       rows.push(
         <CompareRow
           key={field}
@@ -180,7 +180,7 @@ function CompareBody({
   // Password: a secret on both sides. Revealed only on the explicit toggle,
   // which fetches the current and historical values together (ADR-0008) — the
   // historical fetch carries the version's index + fingerprint guard.
-  if (isBuiltin("password") && changedFields.includes("password")) {
+  if (changedFields.includes("password")) {
     rows.push(
       <CompareSecretRow
         key="password"
@@ -211,7 +211,7 @@ function CompareBody({
     "expiry",
     "location",
   ] as const) {
-    if (isBuiltin(field) && changedFields.includes(field)) {
+    if (changedFields.includes(field)) {
       rows.push(
         <PreviousUnavailableRow
           key={field}
@@ -222,13 +222,16 @@ function CompareBody({
     }
   }
 
-  // Custom fields: every changed token that isn't a built-in. A field is a
-  // two-sided secret only when it's protected in *both* versions — then it's
-  // revealed on demand from each side. When protection differs (toggled, or the
-  // field was added/removed), one protected endpoint would error, so we degrade
-  // to showing the current plain value (if any) with "previous not available".
+  // Custom fields: a token gets a custom row when it's a known custom key (so a
+  // collision with a built-in token still surfaces the custom field alongside
+  // the built-in row above) or when it isn't a built-in token at all (e.g. a
+  // since-deleted field). A field is a two-sided secret only when it's
+  // protected in *both* versions — then it's revealed on demand from each side.
+  // When protection differs (toggled, or the field was added/removed), one
+  // protected endpoint would error, so we degrade to showing the current plain
+  // value (if any) with "previous not available".
   for (const key of changedFields) {
-    if (isBuiltin(key)) continue;
+    if (!customKeys.has(key) && KNOWN_FIELDS.has(key)) continue;
     const protectedBoth =
       customMetaNow.get(key) === true && version.protectedFields.includes(key);
     if (protectedBoth) {

--- a/src/components/entries/EntryHistoryCompareDialog.tsx
+++ b/src/components/entries/EntryHistoryCompareDialog.tsx
@@ -232,40 +232,17 @@ function CompareBody({
   // value (if any) with "previous not available".
   for (const key of changedFields) {
     if (!customKeys.has(key) && KNOWN_FIELDS.has(key)) continue;
-    const protectedBoth =
-      customMetaNow.get(key) === true && version.protectedFields.includes(key);
-    if (protectedBoth) {
-      rows.push(
-        <CompareSecretRow
-          key={`custom:${key}`}
-          label={key}
-          revealLabel={t("entries.detail.revealField", { field: key })}
-          hideLabel={t("entries.detail.hideField", { field: key })}
-          fetchBefore={async () =>
-            (
-              await entriesApi.getHistoryProtectedField(
-                dbId,
-                entryId,
-                version.index,
-                version.fingerprint,
-                key
-              )
-            ).value
-          }
-          fetchAfter={async () =>
-            (await entriesApi.getProtectedCustomField(dbId, entryId, key)).value
-          }
-        />
-      );
-    } else {
-      rows.push(
-        <PreviousUnavailableRow
-          key={`custom:${key}`}
-          label={key}
-          current={current.customFields[key] ?? null}
-        />
-      );
-    }
+    rows.push(
+      <CustomFieldCompareRow
+        key={`custom:${key}`}
+        dbId={dbId}
+        entryId={entryId}
+        version={version}
+        current={current}
+        fieldKey={key}
+        protectedNow={customMetaNow.get(key) === true}
+      />
+    );
   }
 
   if (rows.length === 0) {
@@ -277,6 +254,65 @@ function CompareBody({
   }
 
   return <>{rows}</>;
+}
+
+/**
+ * One custom field's comparison row. It's a two-sided secret only when the
+ * field is protected in *both* versions — then each side is revealed on demand.
+ * When protection differs (toggled, or the field added/removed), one protected
+ * endpoint would error, so it degrades to the current plain value (if any) with
+ * "previous value not available".
+ */
+function CustomFieldCompareRow({
+  dbId,
+  entryId,
+  version,
+  current,
+  fieldKey,
+  protectedNow,
+}: Readonly<{
+  dbId: string;
+  entryId: string;
+  version: EntryHistoryItem;
+  current: Entry;
+  fieldKey: string;
+  protectedNow: boolean;
+}>) {
+  const { t } = useTranslation();
+  const protectedBoth =
+    protectedNow && version.protectedFields.includes(fieldKey);
+
+  if (protectedBoth) {
+    return (
+      <CompareSecretRow
+        label={fieldKey}
+        revealLabel={t("entries.detail.revealField", { field: fieldKey })}
+        hideLabel={t("entries.detail.hideField", { field: fieldKey })}
+        fetchBefore={async () =>
+          (
+            await entriesApi.getHistoryProtectedField(
+              dbId,
+              entryId,
+              version.index,
+              version.fingerprint,
+              fieldKey
+            )
+          ).value
+        }
+        fetchAfter={async () =>
+          (await entriesApi.getProtectedCustomField(dbId, entryId, fieldKey))
+            .value
+        }
+      />
+    );
+  }
+
+  return (
+    <PreviousUnavailableRow
+      label={fieldKey}
+      current={current.customFields[fieldKey] ?? null}
+    />
+  );
 }
 
 /**

--- a/src/components/entries/EntryHistorySection.tsx
+++ b/src/components/entries/EntryHistorySection.tsx
@@ -7,6 +7,7 @@ import {
   ChevronDown,
   Eye,
   EyeOff,
+  GitCompare,
   History,
   Loader2,
   RotateCcw,
@@ -22,6 +23,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator.tsx";
 import { entries as entriesApi } from "@/lib/tauri";
+import {
+  changedSince,
+  EntryHistoryCompareDialog,
+} from "@/components/entries/EntryHistoryCompareDialog";
 import { saveWithErrorToast } from "@/lib/save-with-error-toast";
 import type { EntryHistoryItem } from "@/lib/types";
 import { queryKeys } from "@/lib/query-keys";
@@ -216,6 +221,10 @@ export function EntryHistorySection({
                 isOldest={index === versions.length - 1}
                 showSeparator={index > 0}
                 fieldLabels={fieldLabels}
+                // What differs between this version and the current Entry: the
+                // union of changedFields from the newest version through this
+                // one (#324), used by the compare dialog (#329).
+                changedSinceFields={changedSince(versions, index)}
                 onRestore={handleRestore}
               />
             ))}
@@ -257,6 +266,7 @@ function HistoryVersionItem({
   isOldest,
   showSeparator,
   fieldLabels,
+  changedSinceFields,
   onRestore,
 }: Readonly<{
   dbId: string;
@@ -265,9 +275,11 @@ function HistoryVersionItem({
   isOldest: boolean;
   showSeparator: boolean;
   fieldLabels: Record<string, string>;
+  changedSinceFields: string[];
   onRestore: (version: EntryHistoryItem) => void;
 }>) {
   const { t } = useTranslation();
+  const [compareOpen, setCompareOpen] = useState(false);
   // The changed line is shown even on the oldest "Earliest kept" version:
   // changedFields is diffed against the next-newer version, so it's accurate
   // even when the original predecessor was pruned.
@@ -287,12 +299,29 @@ function HistoryVersionItem({
           variant="outline"
           size="icon-xs"
           className="shrink-0"
+          aria-label={t("entries.detail.compare.action")}
+          onClick={() => setCompareOpen(true)}
+        >
+          <GitCompare className="h-3 w-3" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon-xs"
+          className="shrink-0"
           aria-label={t("entries.detail.restoreVersion")}
           onClick={() => onRestore(version)}
         >
           <RotateCcw className="h-3 w-3" />
         </Button>
       </div>
+      <EntryHistoryCompareDialog
+        dbId={dbId}
+        entryId={entryId}
+        version={version}
+        changedFields={changedSinceFields}
+        open={compareOpen}
+        onOpenChange={setCompareOpen}
+      />
       {isOldest && (
         <p className="px-4 pb-2 text-xs font-medium text-muted-foreground">
           {version.isCreation

--- a/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
+++ b/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
@@ -312,4 +312,57 @@ describe("EntryHistoryCompareDialog", () => {
     // A plain field is never fetched as a secret.
     expect(getProtectedCustomFieldMock).not.toHaveBeenCalled();
   });
+
+  it("treats a custom field named like a built-in token as a custom field", async () => {
+    // A user-defined custom field whose key collides with a built-in token
+    // (the backend emits both as lowercase) must render as the custom field,
+    // not the entry's built-in password.
+    getMock.mockResolvedValue(
+      makeEntry({
+        customFields: { password: "my-api-token" },
+        customFieldMeta: [{ key: "password", isProtected: false }],
+      })
+    );
+    renderDialog({
+      version: makeVersion({ index: 1 }),
+      changedFields: ["password"],
+    });
+
+    expect(await screen.findByText("my-api-token")).toBeInTheDocument();
+    expect(
+      screen.getByText("entries.detail.compare.previousNotAvailable")
+    ).toBeInTheDocument();
+    // It is the custom field, not the entry password: no password reveal.
+    expect(
+      screen.queryByRole("button", { name: "entries.detail.revealPassword" })
+    ).not.toBeInTheDocument();
+    expect(getPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt a two-sided secret reveal when protection differs across versions", async () => {
+    // "PIN" was protected in the version but is now a plain field. Fetching the
+    // current value via the protected endpoint would error, so the field must
+    // degrade to the 'previous not available' row instead of a broken reveal.
+    getMock.mockResolvedValue(
+      makeEntry({
+        customFields: { PIN: "1234" },
+        customFieldMeta: [{ key: "PIN", isProtected: false }],
+      })
+    );
+    renderDialog({
+      version: makeVersion({ index: 1, protectedFields: ["PIN"] }),
+      changedFields: ["PIN"],
+    });
+
+    expect(await screen.findByText("PIN")).toBeInTheDocument();
+    expect(
+      screen.getByText("entries.detail.compare.previousNotAvailable")
+    ).toBeInTheDocument();
+    // No reveal toggle, and neither protected endpoint is called.
+    expect(
+      screen.queryByRole("button", { name: "entries.detail.revealField" })
+    ).not.toBeInTheDocument();
+    expect(getProtectedCustomFieldMock).not.toHaveBeenCalled();
+    expect(getHistoryProtectedFieldMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
+++ b/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Entry, EntryHistoryItem } from "@/lib/types";
+
+const getMock = vi.fn();
+const getPasswordMock = vi.fn();
+const getProtectedCustomFieldMock = vi.fn();
+const getHistoryPasswordMock = vi.fn();
+const getHistoryProtectedFieldMock = vi.fn();
+
+vi.mock("@/lib/tauri", () => ({
+  entries: {
+    get: (...args: unknown[]) => getMock(...args),
+    getPassword: (...args: unknown[]) => getPasswordMock(...args),
+    getProtectedCustomField: (...args: unknown[]) =>
+      getProtectedCustomFieldMock(...args),
+    getHistoryPassword: (...args: unknown[]) => getHistoryPasswordMock(...args),
+    getHistoryProtectedField: (...args: unknown[]) =>
+      getHistoryProtectedFieldMock(...args),
+  },
+}));
+
+import {
+  changedSince,
+  EntryHistoryCompareDialog,
+} from "@/components/entries/EntryHistoryCompareDialog";
+
+const TEST_DB_ID = "test-vault.kdbx";
+const TEST_ENTRY_ID = "entry-1";
+
+function makeEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    id: TEST_ENTRY_ID,
+    groupId: "group-1",
+    title: "New Name",
+    username: "bob",
+    url: null,
+    notes: null,
+    iconId: 0,
+    customIconUuid: null,
+    tags: [],
+    customFields: {},
+    customFieldMeta: [],
+    createdAt: "2024-01-01T00:00:00Z",
+    modifiedAt: "2024-02-17T15:58:43Z",
+    accessedAt: "2024-02-17T15:58:43Z",
+    expires: false,
+    expiryTime: null,
+    attachments: [],
+    ...overrides,
+  };
+}
+
+function makeVersion(
+  overrides: Partial<EntryHistoryItem> & Pick<EntryHistoryItem, "index">
+): EntryHistoryItem {
+  return {
+    modifiedAt: "2024-02-10T10:00:00Z",
+    title: "New Name",
+    username: "bob",
+    url: null,
+    changedFields: [],
+    isCreation: false,
+    fingerprint: `fp-${overrides.index}`,
+    protectedFields: [],
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function renderDialog(props: {
+  version: EntryHistoryItem;
+  changedFields: string[];
+}) {
+  return render(
+    <EntryHistoryCompareDialog
+      dbId={TEST_DB_ID}
+      entryId={TEST_ENTRY_ID}
+      version={props.version}
+      changedFields={props.changedFields}
+      open
+      onOpenChange={vi.fn()}
+    />,
+    { wrapper: createWrapper() }
+  );
+}
+
+describe("changedSince", () => {
+  // Versions are newest-first; each version's changedFields is the diff against
+  // the next-newer version (the newest against the live Entry). The union from
+  // index 0 through the selected index is "what changed since this version".
+  const versions = [
+    makeVersion({ index: 0, changedFields: ["title"] }),
+    makeVersion({ index: 1, changedFields: ["username"] }),
+    makeVersion({ index: 2, changedFields: ["url", "title"] }),
+  ];
+
+  it("returns the newest version's own changed fields at index 0", () => {
+    expect(changedSince(versions, 0)).toEqual(["title"]);
+  });
+
+  it("unions changed fields from the newest version through the selected one", () => {
+    expect(new Set(changedSince(versions, 2))).toEqual(
+      new Set(["title", "username", "url"])
+    );
+  });
+
+  it("de-duplicates a field changed in more than one version", () => {
+    // "title" appears in versions 0 and 2 but should be listed once.
+    expect(changedSince(versions, 2).filter((f) => f === "title")).toHaveLength(
+      1
+    );
+  });
+});
+
+describe("EntryHistoryCompareDialog", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    getPasswordMock.mockReset();
+    getProtectedCustomFieldMock.mockReset();
+    getHistoryPasswordMock.mockReset();
+    getHistoryProtectedFieldMock.mockReset();
+  });
+
+  it("shows a changed text field as historical → current", async () => {
+    getMock.mockResolvedValue(makeEntry({ title: "New Name" }));
+    renderDialog({
+      version: makeVersion({ index: 1, title: "Old Name", changedFields: [] }),
+      changedFields: ["title"],
+    });
+
+    expect(await screen.findByText("Old Name")).toBeInTheDocument();
+    expect(screen.getByText("New Name")).toBeInTheDocument();
+  });
+
+  it("describes which version is being compared", async () => {
+    getMock.mockResolvedValue(makeEntry());
+    renderDialog({
+      version: makeVersion({ index: 1 }),
+      changedFields: [],
+    });
+
+    // A dialog description (which version, by date) gives the comparison
+    // context and satisfies the dialog's accessibility contract.
+    expect(
+      await screen.findByText("entries.detail.compare.description")
+    ).toBeInTheDocument();
+  });
+
+  it("shows an empty state when nothing differs", async () => {
+    getMock.mockResolvedValue(makeEntry({ title: "Same" }));
+    renderDialog({
+      version: makeVersion({ index: 1, title: "Same" }),
+      changedFields: ["title"],
+    });
+
+    expect(
+      await screen.findByText("entries.detail.compare.noChanges")
+    ).toBeInTheDocument();
+  });
+
+  it("compares username and url as historical → current", async () => {
+    getMock.mockResolvedValue(
+      makeEntry({ username: "bob@example.com", url: "https://new.example" })
+    );
+    renderDialog({
+      version: makeVersion({
+        index: 1,
+        username: "bob",
+        url: "https://old.example",
+      }),
+      changedFields: ["username", "url"],
+    });
+
+    expect(await screen.findByText("bob")).toBeInTheDocument();
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+    expect(screen.getByText("https://old.example")).toBeInTheDocument();
+    expect(screen.getByText("https://new.example")).toBeInTheDocument();
+  });
+
+  it("shows the current value and a 'previous not available' note for value-less fields", async () => {
+    getMock.mockResolvedValue(makeEntry({ notes: "Current notes text" }));
+    renderDialog({
+      version: makeVersion({ index: 1 }),
+      changedFields: ["notes"],
+    });
+
+    expect(await screen.findByText("Current notes text")).toBeInTheDocument();
+    expect(
+      screen.getByText("entries.detail.compare.previousNotAvailable")
+    ).toBeInTheDocument();
+  });
+
+  it("reveals both passwords only on demand and hides them again", async () => {
+    getMock.mockResolvedValue(makeEntry());
+    getPasswordMock.mockResolvedValue("newpass");
+    getHistoryPasswordMock.mockResolvedValue("oldpass");
+    renderDialog({
+      version: makeVersion({ index: 1, fingerprint: "fp-1" }),
+      changedFields: ["password"],
+    });
+
+    const revealButton = await screen.findByRole("button", {
+      name: "entries.detail.revealPassword",
+    });
+    // Nothing is fetched until the explicit reveal.
+    expect(getPasswordMock).not.toHaveBeenCalled();
+    expect(getHistoryPasswordMock).not.toHaveBeenCalled();
+    expect(screen.queryByText("oldpass")).not.toBeInTheDocument();
+
+    fireEvent.click(revealButton);
+
+    expect(await screen.findByText("oldpass")).toBeInTheDocument();
+    expect(screen.getByText("newpass")).toBeInTheDocument();
+    expect(getPasswordMock).toHaveBeenCalledWith(TEST_DB_ID, TEST_ENTRY_ID);
+    expect(getHistoryPasswordMock).toHaveBeenCalledWith(
+      TEST_DB_ID,
+      TEST_ENTRY_ID,
+      1,
+      "fp-1"
+    );
+
+    const hideButton = screen.getByRole("button", {
+      name: "entries.detail.hidePassword",
+    });
+    fireEvent.click(hideButton);
+
+    await waitFor(() => {
+      expect(screen.queryByText("oldpass")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("newpass")).not.toBeInTheDocument();
+  });
+
+  it("reveals a protected custom field's values on demand", async () => {
+    getMock.mockResolvedValue(
+      makeEntry({
+        customFields: { "API Key": "" },
+        customFieldMeta: [{ key: "API Key", isProtected: true }],
+      })
+    );
+    getHistoryProtectedFieldMock.mockResolvedValue({
+      key: "API Key",
+      value: "old-secret",
+    });
+    getProtectedCustomFieldMock.mockResolvedValue({
+      key: "API Key",
+      value: "new-secret",
+    });
+    renderDialog({
+      version: makeVersion({
+        index: 2,
+        fingerprint: "fp-2",
+        protectedFields: ["API Key"],
+      }),
+      changedFields: ["API Key"],
+    });
+
+    const revealButton = await screen.findByRole("button", {
+      name: "entries.detail.revealField",
+    });
+    expect(getHistoryProtectedFieldMock).not.toHaveBeenCalled();
+
+    fireEvent.click(revealButton);
+
+    expect(await screen.findByText("old-secret")).toBeInTheDocument();
+    expect(screen.getByText("new-secret")).toBeInTheDocument();
+    expect(getHistoryProtectedFieldMock).toHaveBeenCalledWith(
+      TEST_DB_ID,
+      TEST_ENTRY_ID,
+      2,
+      "fp-2",
+      "API Key"
+    );
+    expect(getProtectedCustomFieldMock).toHaveBeenCalledWith(
+      TEST_DB_ID,
+      TEST_ENTRY_ID,
+      "API Key"
+    );
+  });
+
+  it("shows a plain custom field's current value with a 'previous not available' note", async () => {
+    getMock.mockResolvedValue(
+      makeEntry({
+        customFields: { Department: "Engineering" },
+        customFieldMeta: [{ key: "Department", isProtected: false }],
+      })
+    );
+    renderDialog({
+      version: makeVersion({ index: 1 }),
+      changedFields: ["Department"],
+    });
+
+    expect(await screen.findByText("Department")).toBeInTheDocument();
+    expect(screen.getByText("Engineering")).toBeInTheDocument();
+    expect(
+      screen.getByText("entries.detail.compare.previousNotAvailable")
+    ).toBeInTheDocument();
+    // A plain field is never fetched as a secret.
+    expect(getProtectedCustomFieldMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
+++ b/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
@@ -313,10 +313,11 @@ describe("EntryHistoryCompareDialog", () => {
     expect(getProtectedCustomFieldMock).not.toHaveBeenCalled();
   });
 
-  it("treats a custom field named like a built-in token as a custom field", async () => {
-    // A user-defined custom field whose key collides with a built-in token
-    // (the backend emits both as lowercase) must render as the custom field,
-    // not the entry's built-in password.
+  it("renders both rows when a custom field key collides with a built-in token", async () => {
+    // The backend emits both the built-in Password and a custom field named
+    // `password` as the same lowercase token, so neither side can be hidden:
+    // render the built-in password compare AND the custom field row, so a real
+    // built-in rotation is never silently dropped.
     getMock.mockResolvedValue(
       makeEntry({
         customFields: { password: "my-api-token" },
@@ -328,14 +329,16 @@ describe("EntryHistoryCompareDialog", () => {
       changedFields: ["password"],
     });
 
+    // The custom field row (its current plain value + previous-unavailable).
     expect(await screen.findByText("my-api-token")).toBeInTheDocument();
     expect(
       screen.getByText("entries.detail.compare.previousNotAvailable")
     ).toBeInTheDocument();
-    // It is the custom field, not the entry password: no password reveal.
+    // The built-in password compare row is still present (reveal on demand).
     expect(
-      screen.queryByRole("button", { name: "entries.detail.revealPassword" })
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: "entries.detail.revealPassword" })
+    ).toBeInTheDocument();
+    // Nothing fetched until an explicit reveal.
     expect(getPasswordMock).not.toHaveBeenCalled();
   });
 

--- a/src/components/entries/__tests__/EntryHistorySection.test.tsx
+++ b/src/components/entries/__tests__/EntryHistorySection.test.tsx
@@ -12,6 +12,9 @@ const getHistoryPasswordMock = vi.fn();
 const getHistoryProtectedFieldMock = vi.fn();
 const restoreHistoryMock = vi.fn();
 const clearHistoryMock = vi.fn();
+const getMock = vi.fn();
+const getPasswordMock = vi.fn();
+const getProtectedCustomFieldMock = vi.fn();
 
 vi.mock("@/lib/tauri", () => ({
   entries: {
@@ -21,6 +24,10 @@ vi.mock("@/lib/tauri", () => ({
       getHistoryProtectedFieldMock(...args),
     restoreHistory: (...args: unknown[]) => restoreHistoryMock(...args),
     clearHistory: (...args: unknown[]) => clearHistoryMock(...args),
+    get: (...args: unknown[]) => getMock(...args),
+    getPassword: (...args: unknown[]) => getPasswordMock(...args),
+    getProtectedCustomField: (...args: unknown[]) =>
+      getProtectedCustomFieldMock(...args),
   },
 }));
 
@@ -107,6 +114,9 @@ describe("EntryHistorySection", () => {
     getHistoryProtectedFieldMock.mockReset();
     restoreHistoryMock.mockReset();
     clearHistoryMock.mockReset();
+    getMock.mockReset();
+    getPasswordMock.mockReset();
+    getProtectedCustomFieldMock.mockReset();
     askMock.mockReset();
     toastSuccessMock.mockReset();
     toastErrorMock.mockReset();
@@ -476,5 +486,45 @@ describe("EntryHistorySection", () => {
           ?.isInvalidated
       ).toBe(true);
     });
+  });
+
+  it("opens the compare dialog for a version, diffing it against the current entry", async () => {
+    listHistoryMock.mockResolvedValue([
+      makeVersion({ index: 0, title: "Old Title", changedFields: ["title"] }),
+    ]);
+    getMock.mockResolvedValue({
+      id: TEST_ENTRY_ID,
+      groupId: "group-1",
+      title: "New Title",
+      username: "bob",
+      url: null,
+      notes: null,
+      iconId: 0,
+      customIconUuid: null,
+      tags: [],
+      customFields: {},
+      customFieldMeta: [],
+      createdAt: "2024-01-01T00:00:00Z",
+      modifiedAt: "2024-02-17T15:58:43Z",
+      accessedAt: "2024-02-17T15:58:43Z",
+      expires: false,
+      expiryTime: null,
+      attachments: [],
+    });
+
+    renderSection();
+    await expand();
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "entries.detail.compare.action",
+      })
+    );
+
+    // The current title (only rendered inside the dialog) confirms the compare
+    // view opened and diffed against the current entry.
+    expect(await screen.findByText("New Title")).toBeInTheDocument();
+    // "Old Title" appears twice now: the history row and the dialog's before.
+    expect(screen.getAllByText("Old Title").length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -383,6 +383,13 @@
       "historyCreated": "Erstellt",
       "historyEarliestKept": "Älteste aufbewahrte Version",
       "restoreVersion": "Diese Version wiederherstellen",
+      "compare": {
+        "action": "Mit aktueller Version vergleichen",
+        "title": "Mit aktueller Version vergleichen",
+        "description": "Vergleich der Version vom {{date}} mit dem aktuellen Eintrag",
+        "noChanges": "Keine Unterschiede zwischen dieser Version und dem aktuellen Eintrag",
+        "previousNotAvailable": "Vorheriger Wert nicht verfügbar"
+      },
       "restoreHistoryConfirmTitle": "Version wiederherstellen",
       "restoreHistoryConfirm": "Diesen Eintrag auf die Version vom {{date}} zurücksetzen? Der aktuelle Stand wird zuerst im Verlauf gespeichert, sodass Sie dies rückgängig machen können.",
       "restoreHistorySuccess": "Eintrag auf die ausgewählte Version zurückgesetzt",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -406,6 +406,13 @@
       "historyCreated": "Created",
       "historyEarliestKept": "Earliest kept version",
       "restoreVersion": "Restore this version",
+      "compare": {
+        "action": "Compare with current version",
+        "title": "Compare with current version",
+        "description": "Comparing the version from {{date}} with the current entry",
+        "noChanges": "No differences between this version and the current entry",
+        "previousNotAvailable": "Previous value not available"
+      },
       "restoreHistoryConfirmTitle": "Restore version",
       "restoreHistoryConfirm": "Restore this entry to the version from {{date}}? The current state is saved to history first, so you can undo this.",
       "restoreHistorySuccess": "Entry restored to the selected version",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -383,6 +383,13 @@
       "historyCreated": "Creado",
       "historyEarliestKept": "Versión más antigua conservada",
       "restoreVersion": "Restaurar esta versión",
+      "compare": {
+        "action": "Comparar con la versión actual",
+        "title": "Comparar con la versión actual",
+        "description": "Comparando la versión del {{date}} con la entrada actual",
+        "noChanges": "No hay diferencias entre esta versión y la entrada actual",
+        "previousNotAvailable": "Valor anterior no disponible"
+      },
       "restoreHistoryConfirmTitle": "Restaurar versión",
       "restoreHistoryConfirm": "¿Restaurar esta entrada a la versión del {{date}}? El estado actual se guarda primero en el historial, para que puedas deshacerlo.",
       "restoreHistorySuccess": "Entrada restaurada a la versión seleccionada",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -383,6 +383,13 @@
       "historyCreated": "Créé",
       "historyEarliestKept": "Version conservée la plus ancienne",
       "restoreVersion": "Restaurer cette version",
+      "compare": {
+        "action": "Comparer avec la version actuelle",
+        "title": "Comparer avec la version actuelle",
+        "description": "Comparaison de la version du {{date}} avec l'entrée actuelle",
+        "noChanges": "Aucune différence entre cette version et l'entrée actuelle",
+        "previousNotAvailable": "Valeur précédente non disponible"
+      },
       "restoreHistoryConfirmTitle": "Restaurer la version",
       "restoreHistoryConfirm": "Restaurer cette entrée à la version du {{date}} ? L'état actuel est d'abord enregistré dans l'historique, vous pourrez donc annuler.",
       "restoreHistorySuccess": "Entrée restaurée à la version sélectionnée",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -383,6 +383,13 @@
       "historyCreated": "Kreirano",
       "historyEarliestKept": "Najstarija sačuvana verzija",
       "restoreVersion": "Vrati ovu verziju",
+      "compare": {
+        "action": "Uporedi sa trenutnom verzijom",
+        "title": "Uporedi sa trenutnom verzijom",
+        "description": "Poređenje verzije od {{date}} sa trenutnim unosom",
+        "noChanges": "Nema razlika između ove verzije i trenutnog unosa",
+        "previousNotAvailable": "Prethodna vrednost nije dostupna"
+      },
       "restoreHistoryConfirmTitle": "Vraćanje verzije",
       "restoreHistoryConfirm": "Vratiti ovu stavku na verziju od {{date}}? Trenutno stanje se prvo čuva u istoriji, pa možete poništiti ovu radnju.",
       "restoreHistorySuccess": "Stavka je vraćena na izabranu verziju",


### PR DESCRIPTION
Closes #329.

## What

A compare/diff view that shows exactly what differs between a chosen historical version and the current Entry, so the user can decide before restoring. Pure **frontend composition** — no new backend endpoint beyond the existing history listing, `changed_fields` (#324), and the per-version secret fetches (#325), per ADR-0008.

## Design (HITL resolved up front)

The diff-view UX wasn't pinned by the PRD, so the layout was agreed before implementation:

- **Presentation** — a modal `Dialog` launched from a new `compare` action on each history row.
- **Layout** — stacked `historical → current` rows, **changed fields only**.
- **Secret reveal** — values revealed only on demand; one toggle fetches both sides and clears on hide.

### The data constraint that shaped it

A frontend-only diff can reach real before→after values for **title / username / url** (carried in the listing) and **password / protected custom fields** (on-demand secret fetch). The remaining fields (notes, tags, icon, attachments, expiry, location, plain custom fields) have no reachable historical value, so they show the current value with a *"previous value not available"* note.

`changedFields` for a version is the diff against the *next-newer* version, so `changedSince(versions, index)` unions `changedFields[0..=index]` to derive "what changed between this version and now" — an upper bound the exact value comparison corrects for the text fields it can compare directly.

## Changes

- **`EntryHistoryCompareDialog.tsx`** — the dialog + exported `changedSince` helper.
- **`EntryHistorySection.tsx`** — wired a compare button + dialog into each version row.
- **i18n** — `entries.detail.compare.*` keys across all 5 locales.

## Acceptance criteria

- [x] Design agreed (layout, changed-field emphasis, secret-reveal behavior).
- [x] Shows current vs a selected historical version, highlighting differing fields.
- [x] Secret values revealed only on demand, reusing the per-version secret fetch (nothing pre-loaded).
- [x] No new backend diff endpoint beyond `changed_fields` and the per-version secret fetch.
- [x] Frontend tests cover the diff rendering and on-demand secret reveal.

## Testing

Built test-first across 10 RED→GREEN slices.

- `bunx tsc --noEmit` — clean
- `bun run check` — lint 0 errors, format clean
- `bun run test` — **631 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)