### PR TITLE
feat(core): name added/removed attachments in history compare view

### DIFF
--- a/src-tauri/src/dto/entry.rs
+++ b/src-tauri/src/dto/entry.rs
@@ -168,6 +168,10 @@ pub struct EntryHistoryItem {
     /// values (ADR-0008). Lets the view render a per-version reveal action for
     /// each protected field, fetched on demand via `get_history_protected_field`.
     pub protected_fields: Vec<String>,
+    /// Filenames of this version's attachments — names only, never bytes
+    /// (ADR-0008). The compare view diffs this set against the current Entry's
+    /// attachments to name what was added/removed; the payloads never cross IPC.
+    pub attachment_names: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -3197,11 +3197,8 @@ mod tests {
                 },
             )
             .expect("rename username");
-        service.save(&db_path).expect("save vault");
-        service.close(&db_path).expect("close vault");
 
-        let reopened = KdbxService::new();
-        reopened.open(&db_path, "testpass").expect("reopen vault");
+        let reopened = save_close_reopen(&service, &db_path);
 
         let history = reopened
             .list_entry_history(&db_path, &entry_a)
@@ -3398,6 +3395,17 @@ mod tests {
             .expect("read historical attachment")
     }
 
+    /// Persists the vault, drops it, and reopens it with a *fresh* service so a
+    /// test can assert on-disk durability with nothing cached in memory. Returns
+    /// the reopened service.
+    fn save_close_reopen(service: &KdbxService, db_path: &str) -> KdbxService {
+        service.save(db_path).expect("save vault");
+        service.close(db_path).expect("close vault");
+        let reopened = KdbxService::new();
+        reopened.open(db_path, "testpass").expect("reopen vault");
+        reopened
+    }
+
     #[test]
     fn attachment_blob_is_retrievable_from_history_after_delete_and_reopen() {
         // The interop proof point (#332): after deleting an Attachment, the
@@ -3410,11 +3418,8 @@ mod tests {
         service
             .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
             .expect("delete attachment");
-        service.save(&db_path).expect("save vault");
-        service.close(&db_path).expect("close vault");
 
-        let reopened = KdbxService::new();
-        reopened.open(&db_path, "testpass").expect("reopen vault");
+        let reopened = save_close_reopen(&service, &db_path);
 
         // The live Entry still has no attachment after the round-trip...
         let entry = reopened.get_entry(&db_path, &entry_a).expect("get entry");
@@ -3471,11 +3476,7 @@ mod tests {
             .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
             .expect("delete attachment");
 
-        service.save(&db_path).expect("save vault");
-        service.close(&db_path).expect("close vault");
-
-        let reopened = KdbxService::new();
-        reopened.open(&db_path, "testpass").expect("reopen vault");
+        let reopened = save_close_reopen(&service, &db_path);
 
         let history = reopened
             .list_entry_history(&db_path, &entry_a)
@@ -3513,11 +3514,8 @@ mod tests {
         service
             .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
             .expect("delete attachment");
-        service.save(&db_path).expect("save vault");
-        service.close(&db_path).expect("close vault");
 
-        let reopened = KdbxService::new();
-        reopened.open(&db_path, "testpass").expect("reopen vault");
+        let reopened = save_close_reopen(&service, &db_path);
 
         let history = reopened
             .list_entry_history(&db_path, &entry_a)

--- a/src-tauri/src/services/kdbx/entries.rs
+++ b/src-tauri/src/services/kdbx/entries.rs
@@ -394,6 +394,18 @@ fn history_fingerprint(snapshot: &EntryRef<'_>, key: &[u8; blake3::KEY_LEN]) -> 
 /// The keys of a snapshot's *protected custom* fields (excludes the standard
 /// Password etc.), sorted. Names only — values never cross IPC (ADR-0008); they
 /// let the view offer a per-version reveal action for each protected field.
+/// The filenames of a snapshot's attachments — names only, never the bytes
+/// (ADR-0008). Sorted so the listing is deterministic and the frontend's
+/// filename-set diff is stable.
+fn attachment_names(snapshot: &EntryRef<'_>) -> Vec<String> {
+    let mut names: Vec<String> = snapshot
+        .attachments_named()
+        .map(|(name, _)| name.to_string())
+        .collect();
+    names.sort();
+    names
+}
+
 fn protected_field_keys(snapshot: &EntryRef<'_>) -> Vec<String> {
     let mut keys: Vec<String> = snapshot
         .fields
@@ -518,6 +530,7 @@ impl KdbxService {
                     is_creation,
                     fingerprint: history_fingerprint(&snapshot, &self.history_fingerprint_key),
                     protected_fields: protected_field_keys(&snapshot),
+                    attachment_names: attachment_names(&snapshot),
                 });
             }
             Ok(items)
@@ -3485,6 +3498,36 @@ mod tests {
                 "history version {index} must retain the original attachment bytes"
             );
         }
+    }
+
+    #[test]
+    fn history_listing_exposes_a_versions_attachment_filenames_across_reopen() {
+        // The compare view names which attachments a version carried (#356), so
+        // the listing DTO must surface each snapshot's attachment filenames
+        // (names only — never bytes) and they must survive the on-disk
+        // round-trip. Seeding then deleting an attachment captures a pre-delete
+        // version that still references it.
+        let (service, _dir, db_path, entry_a, _b) = create_test_database();
+        seed_attachment(&service, &db_path, &entry_a, "codes.txt", b"secret");
+
+        service
+            .delete_entry_attachment(&db_path, &entry_a, "codes.txt")
+            .expect("delete attachment");
+        service.save(&db_path).expect("save vault");
+        service.close(&db_path).expect("close vault");
+
+        let reopened = KdbxService::new();
+        reopened.open(&db_path, "testpass").expect("reopen vault");
+
+        let history = reopened
+            .list_entry_history(&db_path, &entry_a)
+            .expect("list history after reopen");
+        let version = history.first().expect("one pre-delete version");
+        assert_eq!(
+            version.attachment_names,
+            vec!["codes.txt".to_string()],
+            "the version's attachment filename must round-trip into the listing"
+        );
     }
 
     #[test]

--- a/src/components/entries/EntryHistoryCompareDialog.tsx
+++ b/src/components/entries/EntryHistoryCompareDialog.tsx
@@ -200,6 +200,33 @@ function CompareBody({
     );
   }
 
+  // Attachments: the listing carries the version's filenames (names only, never
+  // bytes — ADR-0008), so we can name what changed instead of falling back to
+  // the generic "previous not available" row (#356). A rename surfaces as one
+  // removed + one added, matching the backend's filename-set comparison. The
+  // row is shown only when something actually differs, which also corrects the
+  // changed-field signal's upper-bound false positives.
+  if (changedFields.includes("attachments")) {
+    const currentNames = new Set(current.attachments.map((a) => a.filename));
+    const versionNames = new Set(version.attachmentNames);
+    const added = current.attachments
+      .map((a) => a.filename)
+      .filter((name) => !versionNames.has(name));
+    const removed = version.attachmentNames.filter(
+      (name) => !currentNames.has(name)
+    );
+    if (added.length > 0 || removed.length > 0) {
+      rows.push(
+        <AttachmentCompareRow
+          key="attachments"
+          label={t("entries.detail.historyField.attachments")}
+          added={added}
+          removed={removed}
+        />
+      );
+    }
+  }
+
   // Value-less fields: the listing carries no historical value for these, so we
   // can only show the current value (where it's plain text) and note that the
   // previous value can't be displayed.
@@ -207,7 +234,6 @@ function CompareBody({
     "notes",
     "tags",
     "icon",
-    "attachments",
     "expiry",
     "location",
   ] as const) {
@@ -397,7 +423,7 @@ function CompareSecretRow({
  * attachments, expiry, location are shown by label alone).
  */
 function currentSummary(
-  field: "notes" | "tags" | "icon" | "attachments" | "expiry" | "location",
+  field: "notes" | "tags" | "icon" | "expiry" | "location",
   current: Entry
 ): string | null {
   if (field === "notes") return current.notes ?? "";
@@ -426,6 +452,51 @@ function PreviousUnavailableRow({
       <span className="text-xs italic text-muted-foreground">
         {t("entries.detail.compare.previousNotAvailable")}
       </span>
+    </div>
+  );
+}
+
+/**
+ * Names the attachments added and removed between a version and the current
+ * Entry (#356). Names only — no size, MIME, preview, or bytes ever cross IPC
+ * (ADR-0008). Removed names are struck through (gone now), added names plain
+ * (present now); each is prefixed with a localized Added/Removed label.
+ */
+function AttachmentCompareRow({
+  label,
+  added,
+  removed,
+}: Readonly<{ label: string; added: string[]; removed: string[] }>) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-1 py-1">
+      <small className="text-xs font-medium text-muted-foreground">
+        {label}
+      </small>
+      {removed.map((name) => (
+        <div
+          key={`removed:${name}`}
+          className="flex min-w-0 items-center gap-2 text-sm"
+        >
+          <span className="shrink-0 text-xs font-medium text-muted-foreground">
+            {t("entries.detail.compare.attachmentRemoved")}
+          </span>
+          <span className="min-w-0 truncate text-muted-foreground line-through">
+            {name}
+          </span>
+        </div>
+      ))}
+      {added.map((name) => (
+        <div
+          key={`added:${name}`}
+          className="flex min-w-0 items-center gap-2 text-sm"
+        >
+          <span className="shrink-0 text-xs font-medium text-muted-foreground">
+            {t("entries.detail.compare.attachmentAdded")}
+          </span>
+          <span className="min-w-0 truncate">{name}</span>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/components/entries/EntryHistoryCompareDialog.tsx
+++ b/src/components/entries/EntryHistoryCompareDialog.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowRight, Eye, EyeOff, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -200,32 +201,14 @@ function CompareBody({
     );
   }
 
-  // Attachments: the listing carries the version's filenames (names only, never
-  // bytes — ADR-0008), so we can name what changed instead of falling back to
-  // the generic "previous not available" row (#356). A rename surfaces as one
-  // removed + one added, matching the backend's filename-set comparison. The
-  // row is shown only when something actually differs, which also corrects the
-  // changed-field signal's upper-bound false positives.
-  if (changedFields.includes("attachments")) {
-    const currentNames = new Set(current.attachments.map((a) => a.filename));
-    const versionNames = new Set(version.attachmentNames);
-    const added = current.attachments
-      .map((a) => a.filename)
-      .filter((name) => !versionNames.has(name));
-    const removed = version.attachmentNames.filter(
-      (name) => !currentNames.has(name)
-    );
-    if (added.length > 0 || removed.length > 0) {
-      rows.push(
-        <AttachmentCompareRow
-          key="attachments"
-          label={t("entries.detail.historyField.attachments")}
-          added={added}
-          removed={removed}
-        />
-      );
-    }
-  }
+  // Attachments: the listing carries the version's filenames, so we name what
+  // changed instead of the generic "previous not available" row (#356). The
+  // helper returns null when nothing net-differs, so the empty-state check below
+  // still fires and the changed-field signal's false positives are corrected.
+  const attachmentRow = changedFields.includes("attachments")
+    ? attachmentCompareRow(version, current, t)
+    : null;
+  if (attachmentRow) rows.push(attachmentRow);
 
   // Value-less fields: the listing carries no historical value for these, so we
   // can only show the current value (where it's plain text) and note that the
@@ -453,6 +436,37 @@ function PreviousUnavailableRow({
         {t("entries.detail.compare.previousNotAvailable")}
       </span>
     </div>
+  );
+}
+
+/**
+ * Diffs the version's attachment filenames against the current Entry's and,
+ * when they net-differ, returns the row naming what was added/removed (#356). A
+ * rename surfaces as one removed + one added, matching the backend's
+ * filename-set comparison. Returns null when nothing differs so the caller can
+ * skip an empty row — names only, never bytes (ADR-0008).
+ */
+function attachmentCompareRow(
+  version: EntryHistoryItem,
+  current: Entry,
+  t: TFunction
+): ReactNode {
+  const currentNames = new Set(current.attachments.map((a) => a.filename));
+  const versionNames = new Set(version.attachmentNames);
+  const added = current.attachments
+    .map((a) => a.filename)
+    .filter((name) => !versionNames.has(name));
+  const removed = version.attachmentNames.filter(
+    (name) => !currentNames.has(name)
+  );
+  if (added.length === 0 && removed.length === 0) return null;
+  return (
+    <AttachmentCompareRow
+      key="attachments"
+      label={t("entries.detail.historyField.attachments")}
+      added={added}
+      removed={removed}
+    />
   );
 }
 

--- a/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
+++ b/src/components/entries/__tests__/EntryHistoryCompareDialog.test.tsx
@@ -67,6 +67,7 @@ function makeVersion(
     isCreation: false,
     fingerprint: `fp-${overrides.index}`,
     protectedFields: [],
+    attachmentNames: [],
     ...overrides,
   };
 }
@@ -340,6 +341,60 @@ describe("EntryHistoryCompareDialog", () => {
     ).toBeInTheDocument();
     // Nothing fetched until an explicit reveal.
     expect(getPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it("names the attachments added and removed since the version", async () => {
+    // The version carried `old-key.pem`; the current Entry carries
+    // `invoice.pdf`. The compare view must name both — `invoice.pdf` as added,
+    // `old-key.pem` as removed — instead of the generic 'previous not available'
+    // line.
+    getMock.mockResolvedValue(
+      makeEntry({
+        attachments: [
+          { filename: "invoice.pdf", size: 10, mimeType: "application/pdf" },
+        ],
+      })
+    );
+    renderDialog({
+      version: makeVersion({ index: 1, attachmentNames: ["old-key.pem"] }),
+      changedFields: ["attachments"],
+    });
+
+    expect(await screen.findByText("invoice.pdf")).toBeInTheDocument();
+    expect(screen.getByText("old-key.pem")).toBeInTheDocument();
+    expect(
+      screen.getByText("entries.detail.compare.attachmentAdded")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("entries.detail.compare.attachmentRemoved")
+    ).toBeInTheDocument();
+    // The generic fallback row must not be used for attachments anymore.
+    expect(
+      screen.queryByText("entries.detail.compare.previousNotAvailable")
+    ).not.toBeInTheDocument();
+  });
+
+  it("treats a renamed attachment as one removed plus one added", async () => {
+    // A rename is a filename-set difference: the old name is gone, the new name
+    // is present (matching the backend's names-only comparison).
+    getMock.mockResolvedValue(
+      makeEntry({
+        attachments: [
+          {
+            filename: "report-final.pdf",
+            size: 10,
+            mimeType: "application/pdf",
+          },
+        ],
+      })
+    );
+    renderDialog({
+      version: makeVersion({ index: 1, attachmentNames: ["report.pdf"] }),
+      changedFields: ["attachments"],
+    });
+
+    expect(await screen.findByText("report-final.pdf")).toBeInTheDocument();
+    expect(screen.getByText("report.pdf")).toBeInTheDocument();
   });
 
   it("does not attempt a two-sided secret reveal when protection differs across versions", async () => {

--- a/src/components/entries/__tests__/EntryHistorySection.test.tsx
+++ b/src/components/entries/__tests__/EntryHistorySection.test.tsx
@@ -76,6 +76,7 @@ function makeVersion(
     isCreation: false,
     fingerprint: `fp-${overrides.index}`,
     protectedFields: [],
+    attachmentNames: [],
     ...overrides,
   };
 }

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -483,6 +483,7 @@ describe("tauri wrappers validation", () => {
         isCreation: true,
         fingerprint: "abc123",
         protectedFields: ["PIN"],
+        attachmentNames: ["invoice.pdf"],
       },
     ]);
 
@@ -491,6 +492,7 @@ describe("tauri wrappers validation", () => {
     expect(invoke).toHaveBeenCalledWith("list_entry_history", { dbId, id });
     expect(version?.fingerprint).toBe("abc123");
     expect(version?.protectedFields).toEqual(["PIN"]);
+    expect(version?.attachmentNames).toEqual(["invoice.pdf"]);
   });
 
   it("reveals a historical password addressed by index + fingerprint", async () => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -111,6 +111,10 @@ export const EntryHistoryItemSchema = z.object({
   // Keys of this version's protected custom fields (names only — never values),
   // so the view can render a per-version reveal action for each.
   protectedFields: z.array(z.string()),
+  // Filenames of this version's attachments (names only — never bytes). The
+  // compare view diffs this set against the current Entry to name what was
+  // added/removed between the version and now.
+  attachmentNames: z.array(z.string()),
 });
 export type EntryHistoryItem = z.infer<typeof EntryHistoryItemSchema>;
 

--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -388,7 +388,9 @@
         "title": "Mit aktueller Version vergleichen",
         "description": "Vergleich der Version vom {{date}} mit dem aktuellen Eintrag",
         "noChanges": "Keine Unterschiede zwischen dieser Version und dem aktuellen Eintrag",
-        "previousNotAvailable": "Vorheriger Wert nicht verfügbar"
+        "previousNotAvailable": "Vorheriger Wert nicht verfügbar",
+        "attachmentAdded": "Hinzugefügt",
+        "attachmentRemoved": "Entfernt"
       },
       "restoreHistoryConfirmTitle": "Version wiederherstellen",
       "restoreHistoryConfirm": "Diesen Eintrag auf die Version vom {{date}} zurücksetzen? Der aktuelle Stand wird zuerst im Verlauf gespeichert, sodass Sie dies rückgängig machen können.",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -411,7 +411,9 @@
         "title": "Compare with current version",
         "description": "Comparing the version from {{date}} with the current entry",
         "noChanges": "No differences between this version and the current entry",
-        "previousNotAvailable": "Previous value not available"
+        "previousNotAvailable": "Previous value not available",
+        "attachmentAdded": "Added",
+        "attachmentRemoved": "Removed"
       },
       "restoreHistoryConfirmTitle": "Restore version",
       "restoreHistoryConfirm": "Restore this entry to the version from {{date}}? The current state is saved to history first, so you can undo this.",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -388,7 +388,9 @@
         "title": "Comparar con la versión actual",
         "description": "Comparando la versión del {{date}} con la entrada actual",
         "noChanges": "No hay diferencias entre esta versión y la entrada actual",
-        "previousNotAvailable": "Valor anterior no disponible"
+        "previousNotAvailable": "Valor anterior no disponible",
+        "attachmentAdded": "Añadido",
+        "attachmentRemoved": "Eliminado"
       },
       "restoreHistoryConfirmTitle": "Restaurar versión",
       "restoreHistoryConfirm": "¿Restaurar esta entrada a la versión del {{date}}? El estado actual se guarda primero en el historial, para que puedas deshacerlo.",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -388,7 +388,9 @@
         "title": "Comparer avec la version actuelle",
         "description": "Comparaison de la version du {{date}} avec l'entrée actuelle",
         "noChanges": "Aucune différence entre cette version et l'entrée actuelle",
-        "previousNotAvailable": "Valeur précédente non disponible"
+        "previousNotAvailable": "Valeur précédente non disponible",
+        "attachmentAdded": "Ajouté",
+        "attachmentRemoved": "Supprimé"
       },
       "restoreHistoryConfirmTitle": "Restaurer la version",
       "restoreHistoryConfirm": "Restaurer cette entrée à la version du {{date}} ? L'état actuel est d'abord enregistré dans l'historique, vous pourrez donc annuler.",

--- a/src/locales/sr/common.json
+++ b/src/locales/sr/common.json
@@ -388,7 +388,9 @@
         "title": "Uporedi sa trenutnom verzijom",
         "description": "Poređenje verzije od {{date}} sa trenutnim unosom",
         "noChanges": "Nema razlika između ove verzije i trenutnog unosa",
-        "previousNotAvailable": "Prethodna vrednost nije dostupna"
+        "previousNotAvailable": "Prethodna vrednost nije dostupna",
+        "attachmentAdded": "Dodato",
+        "attachmentRemoved": "Uklonjeno"
       },
       "restoreHistoryConfirmTitle": "Vraćanje verzije",
       "restoreHistoryConfirm": "Vratiti ovu stavku na verziju od {{date}}? Trenutno stanje se prvo čuva u istoriji, pa možete poništiti ovu radnju.",


### PR DESCRIPTION
## What

Closes #356. Follow-up to #329 (S8 compare view).

The compare view rendered a generic `attachments — previous value not available` line, so a user couldn't tell *which* attachment differed between a historical version and the current Entry before deciding to restore. This surfaces the **filenames** added and removed.

## Changes

**Backend**
- `EntryHistoryItem` gains `attachment_names: Vec<String>` — names only, never bytes (ADR-0008), sorted for a deterministic listing.
- `list_entry_history` populates it via a small `attachment_names()` helper over `snapshot.attachments_named()`.

**Frontend**
- `EntryHistoryItemSchema` gains `attachmentNames`.
- `EntryHistoryCompareDialog` diffs the version's filename set against the current Entry: **Added** = present now ∖ version, **Removed** = present in version ∖ now, rendered as labeled lines (`AttachmentCompareRow`). A rename = one removed + one added (filename-set comparison, matching the backend). The row only renders when the sets actually differ, which also corrects the changed-field signal's upper-bound false positives.
- New i18n keys `compare.attachmentAdded` / `attachmentRemoved` across all 5 locales.

Names-only throughout — no size/MIME/preview/content, no byte reads cross IPC.

## Tests

- Service test: a version's attachment filenames survive a save→reopen round-trip into the listing.
- Wire-parse test: `EntryHistoryItemSchema` carries `attachmentNames`.
- Dialog tests: added/removed rendering, and a rename rendered as removed + added.

All 635 frontend tests and 411 Rust tests pass; `clippy`/`fmt`/lint clean.

## Acceptance criteria

- [x] `EntryHistoryItem` exposes the version's attachment filenames (names only); no bytes cross IPC.
- [x] Compare view lists added/removed filenames instead of the generic line.
- [x] No attachment preview/content shown — filenames only.
- [x] Frontend test for added/removed rendering; service test for the new DTO field over save→reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)