### PR TITLE
security(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4123,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Bumps the transitive dependency `quinn-proto` `0.11.14` → `0.11.15` via a one-line `Cargo.lock` change. No `Cargo.toml`, source, or feature changes.

## Why

This is the **only** vulnerability flagged by the failing `Rust Security Audit` job:

> **RUSTSEC-2026-0185** — *Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly* — CVSS **7.5 (high)** — Solution: upgrade to `>=0.11.15`.

`quinn-proto` enters the tree transitively through the favicon HTTPS client:

```
quinn-proto 0.11.14 → quinn 0.11.9 → reqwest 0.12.28 → mithril-vault
```

It's an **optional, `http3`-gated** dependency of `reqwest`. Because the favicon client uses `default-features = false, features = ["rustls-tls"]`, `http3`/`quinn` is **never compiled into the shipped binary** (`cargo tree -e features -i quinn` prints nothing) — so real-world exposure is minimal. But `cargo-audit` scans `Cargo.lock` regardless of feature activation, so the job legitimately fails on the lockfile entry until the version is bumped.

## Why this, not the `reqwest` 0.13 bump (#352)

`0.11.15` satisfies `quinn 0.11.9`'s `^0.11.12` requirement, so the fix is a clean, semver-compatible, surgical lockfile pin — the lowest-risk remediation. PR #352 (`reqwest` 0.12 → 0.13, `ring` → `aws-lc-rs` C build dep) is **orthogonal**: by its own description it does **not** fix `quinn-proto`, and it carries a much larger, separately-justifiable build-system change. Keeping these decoupled means the high-severity advisory is resolved now without blocking on the riskier migration.

## Verification

- ✅ `cargo audit` — `RUSTSEC-2026-0185` gone, **0 vulnerabilities** (the remaining `unmaintained`/`yanked`/`unsound` items are non-failing warnings, unchanged by this PR)
- ✅ `cargo clippy --all-targets --all-features -- -D warnings` (pre-push hook) clean
- ✅ One-line lockfile diff: `quinn-proto` version + checksum only
- ✅ Durable: a future routine `cargo update` reaches `0.11.15` on its own (cargo never downgrades), so the fix won't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
